### PR TITLE
Bumpalo-default

### DIFF
--- a/puroro-plugin/templates/bumpalo/body.rs.txt
+++ b/puroro-plugin/templates/bumpalo/body.rs.txt
@@ -118,7 +118,7 @@ impl<'bump> ::puroro::internal::de::DeserMessageFromBytesIter for {{ m.bumpalo_i
                 {%- endif %}
                 DeserFieldFromBytesIter::<
                     {{ field.bumpalo_label_and_type_tags }}
-                >::deser_field(&mut self.{{ field.ident }}, data, &self._bump)
+                >::deser_field(&mut self.{{ field.ident }}, data, &self._bump, ChildsBumpStrategy::new_child_bump)
             }
             {%- endif %}
             {%- endfor %}
@@ -145,7 +145,7 @@ impl<'bump> ::puroro::internal::de::DeserMessageFromBytesIter for {{ m.bumpalo_i
                 };
                 DeserFieldFromBytesIter::<
                     ::puroro::tags::OneofField, {{ field.bumpalo_field_type_tag }}
-                >::deser_field(field_value_mut_ref, data, &self._bump)
+                >::deser_field(field_value_mut_ref, data, &self._bump, ChildsBumpStrategy::new_child_bump)
             }
             {%- endfor %}
             {%- endfor %}

--- a/puroro-plugin/templates/bumpalo/body.rs.txt
+++ b/puroro-plugin/templates/bumpalo/body.rs.txt
@@ -57,6 +57,12 @@ impl<'bump> {{ m.bumpalo_ident }}<'bump> {
 
 impl<'bump> ::puroro::Message<super::_puroro_simple_impl::{{ m.simple_ident }}> for {{ m.bumpalo_ident }}<'bump> {}
 
+impl<'bump> ::puroro::BumpaloMessage<'bump> for {{ m.bumpalo_ident }}<'bump> {
+    fn new_in(bump: &'bump ::puroro::bumpalo::Bump) -> Self {
+        Self::new_in(bump)
+    }
+}
+
 impl<'bump> ::puroro::internal::impls::bumpalo::BumpaloDefault<'bump> for {{ m.bumpalo_ident }}<'bump> {
     fn default_in(bump: &'bump ::puroro::bumpalo::Bump) -> Self {
         Self::new_in(bump)
@@ -118,7 +124,7 @@ impl<'bump> ::puroro::internal::de::DeserMessageFromBytesIter for {{ m.bumpalo_i
                 {%- endif %}
                 DeserFieldFromBytesIter::<
                     {{ field.bumpalo_label_and_type_tags }}
-                >::deser_field(&mut self.{{ field.ident }}, data, &self._bump, ChildsBumpStrategy::new_child_bump)
+                >::deser_field(&mut self.{{ field.ident }}, data, &self._bump)
             }
             {%- endif %}
             {%- endfor %}
@@ -132,11 +138,11 @@ impl<'bump> ::puroro::internal::de::DeserMessageFromBytesIter for {{ m.bumpalo_i
                     E::{{ field.ident }}(_))
                 {
                     self.{{ oneof.field_ident }} = E::{{ field.ident }}(
-                        {%- if field.is_length_delimited %}
+                        {%- if field.is_message %}
+                        ::puroro::BumpaloMessage::new_in(&self._bump)
+                        {%- else %} {#- if field.is_message #}
                         ::puroro::internal::impls::bumpalo::BumpaloDefault::default_in(&self._bump)
-                        {%- else %}
-                        ::std::default::Default::default()
-                        {%- endif %}
+                        {%- endif %} {#- if field.is_message #}
                     );
                 }
                 let field_value_mut_ref = match &mut self.{{ oneof.field_ident }} {
@@ -145,7 +151,7 @@ impl<'bump> ::puroro::internal::de::DeserMessageFromBytesIter for {{ m.bumpalo_i
                 };
                 DeserFieldFromBytesIter::<
                     ::puroro::tags::OneofField, {{ field.bumpalo_field_type_tag }}
-                >::deser_field(field_value_mut_ref, data, &self._bump, ChildsBumpStrategy::new_child_bump)
+                >::deser_field(field_value_mut_ref, data, &self._bump)
             }
             {%- endfor %}
             {%- endfor %}

--- a/puroro/src/common_traits.rs
+++ b/puroro/src/common_traits.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::bumpalo::Bump;
 use crate::internal::de::from_iter::deser_from_iter;
 use crate::internal::de::DeserMessageFromBytesIter;
 use crate::internal::se::SerMessageToIoWrite;
@@ -122,3 +123,16 @@ pub trait Enum3: 'static + PartialEq + Clone + Default + From<i32> + Into<i32> {
 /// Currently this trait is just an analogous of [`std::iter::IntoIterator`].
 pub trait RepeatedField<'msg>: IntoIterator {}
 impl<'msg, T> RepeatedField<'msg> for T where T: IntoIterator {}
+
+/// Bumpalo message, initialized from bump ptr instance.
+pub trait BumpaloMessage<'bump> {
+    fn new_in(bump: &'bump Bump) -> Self;
+}
+impl<'bump, T> BumpaloMessage<'bump> for crate::bumpalo::boxed::Box<'bump, T>
+where
+    T: BumpaloMessage<'bump>,
+{
+    fn new_in(bump: &'bump Bump) -> Self {
+        crate::bumpalo::boxed::Box::new_in(BumpaloMessage::new_in(bump), bump)
+    }
+}

--- a/puroro/src/internal/impls/bumpalo.rs
+++ b/puroro/src/internal/impls/bumpalo.rs
@@ -126,14 +126,6 @@ impl<'bump, T> BumpaloDefault<'bump> for Vec<'bump, T> {
         Vec::new_in(bump)
     }
 }
-impl<'bump, T> BumpaloDefault<'bump> for Box<'bump, T>
-where
-    T: BumpaloDefault<'bump>,
-{
-    fn default_in(bump: &'bump Bump) -> Self {
-        Box::new_in(BumpaloDefault::default_in(bump), bump)
-    }
-}
 impl<'bump, T> BumpaloDefault<'bump> for Option<T> {
     fn default_in(_: &'bump Bump) -> Self {
         ::std::default::Default::default()

--- a/puroro/src/internal/impls/bumpalo/de.rs
+++ b/puroro/src/internal/impls/bumpalo/de.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::{BumpaloDefault, VecOrOptionOrBare};
+use super::VecOrOptionOrBare;
 use crate::bumpalo::collections::{String, Vec};
 use crate::bumpalo::Bump;
 use crate::internal::de::from_iter::{deser_from_scoped_iter, ScopedIter, Variants};
@@ -20,6 +20,7 @@ use crate::internal::de::DeserMessageFromBytesIter;
 use crate::internal::fixed_bits::{Bits32TypeTag, Bits64TypeTag};
 use crate::internal::types::FieldData;
 use crate::internal::variant::VariantTypeTag;
+use crate::BumpaloMessage;
 use crate::ErrorKind;
 use crate::{tags, Result};
 use ::std::marker::PhantomData;
@@ -193,10 +194,10 @@ where
     where
         FieldType: VecOrOptionOrBare<M>,
         I: Iterator<Item = ::std::io::Result<u8>>,
-        M: BumpaloDefault<'bump>,
+        M: BumpaloMessage<'bump>,
     {
         if let FieldData::LengthDelimited(mut iter) = input {
-            let msg = field.get_or_insert_with(|| BumpaloDefault::default_in(bump));
+            let msg = field.get_or_insert_with(|| BumpaloMessage::new_in(bump));
             deser_from_scoped_iter(msg, &mut iter)?;
         } else {
             Err(ErrorKind::UnexpectedWireType)?;

--- a/tests-pb/src/full_coverage2.rs
+++ b/tests-pb/src/full_coverage2.rs
@@ -10738,6 +10738,12 @@ pub mod _puroro_impls {
 
     impl<'bump> ::puroro::Message<super::_puroro_simple_impl::Msg> for MsgBumpalo<'bump> {}
 
+    impl<'bump> ::puroro::BumpaloMessage<'bump> for MsgBumpalo<'bump> {
+        fn new_in(bump: &'bump ::puroro::bumpalo::Bump) -> Self {
+            Self::new_in(bump)
+        }
+    }
+
     impl<'bump> ::puroro::internal::impls::bumpalo::BumpaloDefault<'bump> for MsgBumpalo<'bump> {
         fn default_in(bump: &'bump ::puroro::bumpalo::Bump) -> Self {
             Self::new_in(bump)
@@ -15344,6 +15350,12 @@ pub mod _puroro_nested {
             }
 
             impl<'bump> ::puroro::Message<super::_puroro_simple_impl::Submsg> for SubmsgBumpalo<'bump> {}
+
+            impl<'bump> ::puroro::BumpaloMessage<'bump> for SubmsgBumpalo<'bump> {
+                fn new_in(bump: &'bump ::puroro::bumpalo::Bump) -> Self {
+                    Self::new_in(bump)
+                }
+            }
 
             impl<'bump> ::puroro::internal::impls::bumpalo::BumpaloDefault<'bump> for SubmsgBumpalo<'bump> {
                 fn default_in(bump: &'bump ::puroro::bumpalo::Bump) -> Self {

--- a/tests-pb/src/full_coverage3.rs
+++ b/tests-pb/src/full_coverage3.rs
@@ -10798,6 +10798,12 @@ pub mod _puroro_impls {
 
     impl<'bump> ::puroro::Message<super::_puroro_simple_impl::Msg> for MsgBumpalo<'bump> {}
 
+    impl<'bump> ::puroro::BumpaloMessage<'bump> for MsgBumpalo<'bump> {
+        fn new_in(bump: &'bump ::puroro::bumpalo::Bump) -> Self {
+            Self::new_in(bump)
+        }
+    }
+
     impl<'bump> ::puroro::internal::impls::bumpalo::BumpaloDefault<'bump> for MsgBumpalo<'bump> {
         fn default_in(bump: &'bump ::puroro::bumpalo::Bump) -> Self {
             Self::new_in(bump)
@@ -15338,6 +15344,12 @@ pub mod _puroro_nested {
             }
 
             impl<'bump> ::puroro::Message<super::_puroro_simple_impl::Submsg> for SubmsgBumpalo<'bump> {}
+
+            impl<'bump> ::puroro::BumpaloMessage<'bump> for SubmsgBumpalo<'bump> {
+                fn new_in(bump: &'bump ::puroro::bumpalo::Bump) -> Self {
+                    Self::new_in(bump)
+                }
+            }
 
             impl<'bump> ::puroro::internal::impls::bumpalo::BumpaloDefault<'bump> for SubmsgBumpalo<'bump> {
                 fn default_in(bump: &'bump ::puroro::bumpalo::Bump) -> Self {

--- a/tests-pb/src/keywords.rs
+++ b/tests-pb/src/keywords.rs
@@ -212,7 +212,7 @@ pub mod _puroro_impls {
                     self._bitfield.set(0, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Int32
-                >::deser_field(&mut self.r#type, data, &self._bump)
+                >::deser_field(&mut self.r#type, data, &self._bump, ChildsBumpStrategy::new_child_bump)
                 }
 
                 _ => unimplemented!("TODO: This case should be handled properly..."),

--- a/tests-pb/src/keywords.rs
+++ b/tests-pb/src/keywords.rs
@@ -179,6 +179,12 @@ pub mod _puroro_impls {
 
     impl<'bump> ::puroro::Message<super::_puroro_simple_impl::Msg> for MsgBumpalo<'bump> {}
 
+    impl<'bump> ::puroro::BumpaloMessage<'bump> for MsgBumpalo<'bump> {
+        fn new_in(bump: &'bump ::puroro::bumpalo::Bump) -> Self {
+            Self::new_in(bump)
+        }
+    }
+
     impl<'bump> ::puroro::internal::impls::bumpalo::BumpaloDefault<'bump> for MsgBumpalo<'bump> {
         fn default_in(bump: &'bump ::puroro::bumpalo::Bump) -> Self {
             Self::new_in(bump)
@@ -212,7 +218,7 @@ pub mod _puroro_impls {
                     self._bitfield.set(0, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Int32
-                >::deser_field(&mut self.r#type, data, &self._bump, ChildsBumpStrategy::new_child_bump)
+                >::deser_field(&mut self.r#type, data, &self._bump)
                 }
 
                 _ => unimplemented!("TODO: This case should be handled properly..."),

--- a/tests-pb/src/official_samples2.rs
+++ b/tests-pb/src/official_samples2.rs
@@ -400,6 +400,12 @@ pub mod _puroro_impls {
 
     impl<'bump> ::puroro::Message<super::_puroro_simple_impl::Test1> for Test1Bumpalo<'bump> {}
 
+    impl<'bump> ::puroro::BumpaloMessage<'bump> for Test1Bumpalo<'bump> {
+        fn new_in(bump: &'bump ::puroro::bumpalo::Bump) -> Self {
+            Self::new_in(bump)
+        }
+    }
+
     impl<'bump> ::puroro::internal::impls::bumpalo::BumpaloDefault<'bump> for Test1Bumpalo<'bump> {
         fn default_in(bump: &'bump ::puroro::bumpalo::Bump) -> Self {
             Self::new_in(bump)
@@ -433,7 +439,7 @@ pub mod _puroro_impls {
                     self._bitfield.set(0, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Int32
-                >::deser_field(&mut self.a, data, &self._bump, ChildsBumpStrategy::new_child_bump)
+                >::deser_field(&mut self.a, data, &self._bump)
                 }
 
                 _ => unimplemented!("TODO: This case should be handled properly..."),
@@ -595,6 +601,12 @@ pub mod _puroro_impls {
 
     impl<'bump> ::puroro::Message<super::_puroro_simple_impl::Test2> for Test2Bumpalo<'bump> {}
 
+    impl<'bump> ::puroro::BumpaloMessage<'bump> for Test2Bumpalo<'bump> {
+        fn new_in(bump: &'bump ::puroro::bumpalo::Bump) -> Self {
+            Self::new_in(bump)
+        }
+    }
+
     impl<'bump> ::puroro::internal::impls::bumpalo::BumpaloDefault<'bump> for Test2Bumpalo<'bump> {
         fn default_in(bump: &'bump ::puroro::bumpalo::Bump) -> Self {
             Self::new_in(bump)
@@ -628,7 +640,7 @@ pub mod _puroro_impls {
                     self._bitfield.set(0, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::String
-                >::deser_field(&mut self.b, data, &self._bump, ChildsBumpStrategy::new_child_bump)
+                >::deser_field(&mut self.b, data, &self._bump)
                 }
 
                 _ => unimplemented!("TODO: This case should be handled properly..."),
@@ -804,6 +816,12 @@ pub mod _puroro_impls {
 
     impl<'bump> ::puroro::Message<super::_puroro_simple_impl::Test3> for Test3Bumpalo<'bump> {}
 
+    impl<'bump> ::puroro::BumpaloMessage<'bump> for Test3Bumpalo<'bump> {
+        fn new_in(bump: &'bump ::puroro::bumpalo::Bump) -> Self {
+            Self::new_in(bump)
+        }
+    }
+
     impl<'bump> ::puroro::internal::impls::bumpalo::BumpaloDefault<'bump> for Test3Bumpalo<'bump> {
         fn default_in(bump: &'bump ::puroro::bumpalo::Bump) -> Self {
             Self::new_in(bump)
@@ -843,12 +861,7 @@ pub mod _puroro_impls {
                             >,
                         >,
                     >,
-                >::deser_field(
-                    &mut self.c,
-                    data,
-                    &self._bump,
-                    ChildsBumpStrategy::new_child_bump,
-                ),
+                >::deser_field(&mut self.c, data, &self._bump),
 
                 _ => unimplemented!("TODO: This case should be handled properly..."),
             }
@@ -1029,6 +1042,12 @@ pub mod _puroro_impls {
 
     impl<'bump> ::puroro::Message<super::_puroro_simple_impl::Test4> for Test4Bumpalo<'bump> {}
 
+    impl<'bump> ::puroro::BumpaloMessage<'bump> for Test4Bumpalo<'bump> {
+        fn new_in(bump: &'bump ::puroro::bumpalo::Bump) -> Self {
+            Self::new_in(bump)
+        }
+    }
+
     impl<'bump> ::puroro::internal::impls::bumpalo::BumpaloDefault<'bump> for Test4Bumpalo<'bump> {
         fn default_in(bump: &'bump ::puroro::bumpalo::Bump) -> Self {
             Self::new_in(bump)
@@ -1062,7 +1081,7 @@ pub mod _puroro_impls {
             4 => {
                 DeserFieldFromBytesIter::<
                     ::puroro::tags::Repeated, ::puroro::tags::Int32
-                >::deser_field(&mut self.d, data, &self._bump, ChildsBumpStrategy::new_child_bump)
+                >::deser_field(&mut self.d, data, &self._bump)
             }
 
             _ => unimplemented!("TODO: This case should be handled properly..."),

--- a/tests-pb/src/official_samples2.rs
+++ b/tests-pb/src/official_samples2.rs
@@ -433,7 +433,7 @@ pub mod _puroro_impls {
                     self._bitfield.set(0, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Int32
-                >::deser_field(&mut self.a, data, &self._bump)
+                >::deser_field(&mut self.a, data, &self._bump, ChildsBumpStrategy::new_child_bump)
                 }
 
                 _ => unimplemented!("TODO: This case should be handled properly..."),
@@ -628,7 +628,7 @@ pub mod _puroro_impls {
                     self._bitfield.set(0, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::String
-                >::deser_field(&mut self.b, data, &self._bump)
+                >::deser_field(&mut self.b, data, &self._bump, ChildsBumpStrategy::new_child_bump)
                 }
 
                 _ => unimplemented!("TODO: This case should be handled properly..."),
@@ -843,7 +843,12 @@ pub mod _puroro_impls {
                             >,
                         >,
                     >,
-                >::deser_field(&mut self.c, data, &self._bump),
+                >::deser_field(
+                    &mut self.c,
+                    data,
+                    &self._bump,
+                    ChildsBumpStrategy::new_child_bump,
+                ),
 
                 _ => unimplemented!("TODO: This case should be handled properly..."),
             }
@@ -1057,7 +1062,7 @@ pub mod _puroro_impls {
             4 => {
                 DeserFieldFromBytesIter::<
                     ::puroro::tags::Repeated, ::puroro::tags::Int32
-                >::deser_field(&mut self.d, data, &self._bump)
+                >::deser_field(&mut self.d, data, &self._bump, ChildsBumpStrategy::new_child_bump)
             }
 
             _ => unimplemented!("TODO: This case should be handled properly..."),

--- a/tests-pb/src/official_samples3.rs
+++ b/tests-pb/src/official_samples3.rs
@@ -436,7 +436,7 @@ pub mod _puroro_impls {
             1 => {
                 DeserFieldFromBytesIter::<
                     ::puroro::tags::Unlabeled, ::puroro::tags::Int32
-                >::deser_field(&mut self.a, data, &self._bump)
+                >::deser_field(&mut self.a, data, &self._bump, ChildsBumpStrategy::new_child_bump)
             }
 
             _ => unimplemented!("TODO: This case should be handled properly..."),
@@ -626,7 +626,7 @@ pub mod _puroro_impls {
             2 => {
                 DeserFieldFromBytesIter::<
                     ::puroro::tags::Unlabeled, ::puroro::tags::String
-                >::deser_field(&mut self.b, data, &self._bump)
+                >::deser_field(&mut self.b, data, &self._bump, ChildsBumpStrategy::new_child_bump)
             }
 
             _ => unimplemented!("TODO: This case should be handled properly..."),
@@ -841,7 +841,12 @@ pub mod _puroro_impls {
                             >,
                         >,
                     >,
-                >::deser_field(&mut self.c, data, &self._bump),
+                >::deser_field(
+                    &mut self.c,
+                    data,
+                    &self._bump,
+                    ChildsBumpStrategy::new_child_bump,
+                ),
 
                 _ => unimplemented!("TODO: This case should be handled properly..."),
             }
@@ -1055,7 +1060,7 @@ pub mod _puroro_impls {
             4 => {
                 DeserFieldFromBytesIter::<
                     ::puroro::tags::Repeated, ::puroro::tags::Int32
-                >::deser_field(&mut self.d, data, &self._bump)
+                >::deser_field(&mut self.d, data, &self._bump, ChildsBumpStrategy::new_child_bump)
             }
 
             _ => unimplemented!("TODO: This case should be handled properly..."),

--- a/tests-pb/src/official_samples3.rs
+++ b/tests-pb/src/official_samples3.rs
@@ -408,6 +408,12 @@ pub mod _puroro_impls {
 
     impl<'bump> ::puroro::Message<super::_puroro_simple_impl::Test1> for Test1Bumpalo<'bump> {}
 
+    impl<'bump> ::puroro::BumpaloMessage<'bump> for Test1Bumpalo<'bump> {
+        fn new_in(bump: &'bump ::puroro::bumpalo::Bump) -> Self {
+            Self::new_in(bump)
+        }
+    }
+
     impl<'bump> ::puroro::internal::impls::bumpalo::BumpaloDefault<'bump> for Test1Bumpalo<'bump> {
         fn default_in(bump: &'bump ::puroro::bumpalo::Bump) -> Self {
             Self::new_in(bump)
@@ -436,7 +442,7 @@ pub mod _puroro_impls {
             1 => {
                 DeserFieldFromBytesIter::<
                     ::puroro::tags::Unlabeled, ::puroro::tags::Int32
-                >::deser_field(&mut self.a, data, &self._bump, ChildsBumpStrategy::new_child_bump)
+                >::deser_field(&mut self.a, data, &self._bump)
             }
 
             _ => unimplemented!("TODO: This case should be handled properly..."),
@@ -598,6 +604,12 @@ pub mod _puroro_impls {
 
     impl<'bump> ::puroro::Message<super::_puroro_simple_impl::Test2> for Test2Bumpalo<'bump> {}
 
+    impl<'bump> ::puroro::BumpaloMessage<'bump> for Test2Bumpalo<'bump> {
+        fn new_in(bump: &'bump ::puroro::bumpalo::Bump) -> Self {
+            Self::new_in(bump)
+        }
+    }
+
     impl<'bump> ::puroro::internal::impls::bumpalo::BumpaloDefault<'bump> for Test2Bumpalo<'bump> {
         fn default_in(bump: &'bump ::puroro::bumpalo::Bump) -> Self {
             Self::new_in(bump)
@@ -626,7 +638,7 @@ pub mod _puroro_impls {
             2 => {
                 DeserFieldFromBytesIter::<
                     ::puroro::tags::Unlabeled, ::puroro::tags::String
-                >::deser_field(&mut self.b, data, &self._bump, ChildsBumpStrategy::new_child_bump)
+                >::deser_field(&mut self.b, data, &self._bump)
             }
 
             _ => unimplemented!("TODO: This case should be handled properly..."),
@@ -802,6 +814,12 @@ pub mod _puroro_impls {
 
     impl<'bump> ::puroro::Message<super::_puroro_simple_impl::Test3> for Test3Bumpalo<'bump> {}
 
+    impl<'bump> ::puroro::BumpaloMessage<'bump> for Test3Bumpalo<'bump> {
+        fn new_in(bump: &'bump ::puroro::bumpalo::Bump) -> Self {
+            Self::new_in(bump)
+        }
+    }
+
     impl<'bump> ::puroro::internal::impls::bumpalo::BumpaloDefault<'bump> for Test3Bumpalo<'bump> {
         fn default_in(bump: &'bump ::puroro::bumpalo::Bump) -> Self {
             Self::new_in(bump)
@@ -841,12 +859,7 @@ pub mod _puroro_impls {
                             >,
                         >,
                     >,
-                >::deser_field(
-                    &mut self.c,
-                    data,
-                    &self._bump,
-                    ChildsBumpStrategy::new_child_bump,
-                ),
+                >::deser_field(&mut self.c, data, &self._bump),
 
                 _ => unimplemented!("TODO: This case should be handled properly..."),
             }
@@ -1027,6 +1040,12 @@ pub mod _puroro_impls {
 
     impl<'bump> ::puroro::Message<super::_puroro_simple_impl::Test4> for Test4Bumpalo<'bump> {}
 
+    impl<'bump> ::puroro::BumpaloMessage<'bump> for Test4Bumpalo<'bump> {
+        fn new_in(bump: &'bump ::puroro::bumpalo::Bump) -> Self {
+            Self::new_in(bump)
+        }
+    }
+
     impl<'bump> ::puroro::internal::impls::bumpalo::BumpaloDefault<'bump> for Test4Bumpalo<'bump> {
         fn default_in(bump: &'bump ::puroro::bumpalo::Bump) -> Self {
             Self::new_in(bump)
@@ -1060,7 +1079,7 @@ pub mod _puroro_impls {
             4 => {
                 DeserFieldFromBytesIter::<
                     ::puroro::tags::Repeated, ::puroro::tags::Int32
-                >::deser_field(&mut self.d, data, &self._bump, ChildsBumpStrategy::new_child_bump)
+                >::deser_field(&mut self.d, data, &self._bump)
             }
 
             _ => unimplemented!("TODO: This case should be handled properly..."),

--- a/tests-pb/src/oneofs2.rs
+++ b/tests-pb/src/oneofs2.rs
@@ -949,6 +949,12 @@ pub mod _puroro_impls {
 
     impl<'bump> ::puroro::Message<super::_puroro_simple_impl::Msg> for MsgBumpalo<'bump> {}
 
+    impl<'bump> ::puroro::BumpaloMessage<'bump> for MsgBumpalo<'bump> {
+        fn new_in(bump: &'bump ::puroro::bumpalo::Bump) -> Self {
+            Self::new_in(bump)
+        }
+    }
+
     impl<'bump> ::puroro::internal::impls::bumpalo::BumpaloDefault<'bump> for MsgBumpalo<'bump> {
         fn default_in(bump: &'bump ::puroro::bumpalo::Bump) -> Self {
             Self::new_in(bump)
@@ -1022,7 +1028,11 @@ pub mod _puroro_impls {
                 1 => {
                     use super::_puroro_nested::msg::_puroro_bumpalo_oneofs::GroupOne as E;
                     if !matches!(&self.group_one, E::G1Int32(_)) {
-                        self.group_one = E::G1Int32(::std::default::Default::default());
+                        self.group_one = E::G1Int32(
+                            ::puroro::internal::impls::bumpalo::BumpaloDefault::default_in(
+                                &self._bump,
+                            ),
+                        );
                     }
                     let field_value_mut_ref = match &mut self.group_one {
                         E::G1Int32(v) => v,
@@ -1030,7 +1040,7 @@ pub mod _puroro_impls {
                     };
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::OneofField, ::puroro::tags::Int32
-                >::deser_field(field_value_mut_ref, data, &self._bump, ChildsBumpStrategy::new_child_bump)
+                >::deser_field(field_value_mut_ref, data, &self._bump)
                 }
                 2 => {
                     use super::_puroro_nested::msg::_puroro_bumpalo_oneofs::GroupOne as E;
@@ -1047,12 +1057,16 @@ pub mod _puroro_impls {
                     };
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::OneofField, ::puroro::tags::String
-                >::deser_field(field_value_mut_ref, data, &self._bump, ChildsBumpStrategy::new_child_bump)
+                >::deser_field(field_value_mut_ref, data, &self._bump)
                 }
                 3 => {
                     use super::_puroro_nested::msg::_puroro_bumpalo_oneofs::GroupTwo as E;
                     if !matches!(&self.group_two, E::G2F32(_)) {
-                        self.group_two = E::G2F32(::std::default::Default::default());
+                        self.group_two = E::G2F32(
+                            ::puroro::internal::impls::bumpalo::BumpaloDefault::default_in(
+                                &self._bump,
+                            ),
+                        );
                     }
                     let field_value_mut_ref = match &mut self.group_two {
                         E::G2F32(v) => v,
@@ -1060,7 +1074,7 @@ pub mod _puroro_impls {
                     };
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::OneofField, ::puroro::tags::Float
-                >::deser_field(field_value_mut_ref, data, &self._bump, ChildsBumpStrategy::new_child_bump)
+                >::deser_field(field_value_mut_ref, data, &self._bump)
                 }
                 4 => {
                     use super::_puroro_nested::msg::_puroro_bumpalo_oneofs::GroupTwo as E;
@@ -1077,16 +1091,12 @@ pub mod _puroro_impls {
                     };
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::OneofField, ::puroro::tags::String
-                >::deser_field(field_value_mut_ref, data, &self._bump, ChildsBumpStrategy::new_child_bump)
+                >::deser_field(field_value_mut_ref, data, &self._bump)
                 }
                 5 => {
                     use super::_puroro_nested::msg::_puroro_bumpalo_oneofs::GroupTwo as E;
                     if !matches!(&self.group_two, E::G2Submsg(_)) {
-                        self.group_two = E::G2Submsg(
-                            ::puroro::internal::impls::bumpalo::BumpaloDefault::default_in(
-                                &self._bump,
-                            ),
-                        );
+                        self.group_two = E::G2Submsg(::puroro::BumpaloMessage::new_in(&self._bump));
                     }
                     let field_value_mut_ref = match &mut self.group_two {
                         E::G2Submsg(v) => v,
@@ -1100,17 +1110,16 @@ pub mod _puroro_impls {
                                 self::_puroro_root::oneofs2::_puroro_impls::SubmsgBumpalo<'bump>,
                             >,
                         >,
-                    >::deser_field(
-                        field_value_mut_ref,
-                        data,
-                        &self._bump,
-                        ChildsBumpStrategy::new_child_bump,
-                    )
+                    >::deser_field(field_value_mut_ref, data, &self._bump)
                 }
                 6 => {
                     use super::_puroro_nested::msg::_puroro_bumpalo_oneofs::GroupThree as E;
                     if !matches!(&self.group_three, E::G3Int32(_)) {
-                        self.group_three = E::G3Int32(::std::default::Default::default());
+                        self.group_three = E::G3Int32(
+                            ::puroro::internal::impls::bumpalo::BumpaloDefault::default_in(
+                                &self._bump,
+                            ),
+                        );
                     }
                     let field_value_mut_ref = match &mut self.group_three {
                         E::G3Int32(v) => v,
@@ -1118,7 +1127,7 @@ pub mod _puroro_impls {
                     };
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::OneofField, ::puroro::tags::Int32
-                >::deser_field(field_value_mut_ref, data, &self._bump, ChildsBumpStrategy::new_child_bump)
+                >::deser_field(field_value_mut_ref, data, &self._bump)
                 }
 
                 _ => unimplemented!("TODO: This case should be handled properly..."),
@@ -1408,6 +1417,12 @@ pub mod _puroro_impls {
 
     impl<'bump> ::puroro::Message<super::_puroro_simple_impl::Submsg> for SubmsgBumpalo<'bump> {}
 
+    impl<'bump> ::puroro::BumpaloMessage<'bump> for SubmsgBumpalo<'bump> {
+        fn new_in(bump: &'bump ::puroro::bumpalo::Bump) -> Self {
+            Self::new_in(bump)
+        }
+    }
+
     impl<'bump> ::puroro::internal::impls::bumpalo::BumpaloDefault<'bump> for SubmsgBumpalo<'bump> {
         fn default_in(bump: &'bump ::puroro::bumpalo::Bump) -> Self {
             Self::new_in(bump)
@@ -1441,7 +1456,7 @@ pub mod _puroro_impls {
                     self._bitfield.set(0, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Int32
-                >::deser_field(&mut self.i32_optional, data, &self._bump, ChildsBumpStrategy::new_child_bump)
+                >::deser_field(&mut self.i32_optional, data, &self._bump)
                 }
 
                 _ => unimplemented!("TODO: This case should be handled properly..."),

--- a/tests-pb/src/oneofs2.rs
+++ b/tests-pb/src/oneofs2.rs
@@ -1030,7 +1030,7 @@ pub mod _puroro_impls {
                     };
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::OneofField, ::puroro::tags::Int32
-                >::deser_field(field_value_mut_ref, data, &self._bump)
+                >::deser_field(field_value_mut_ref, data, &self._bump, ChildsBumpStrategy::new_child_bump)
                 }
                 2 => {
                     use super::_puroro_nested::msg::_puroro_bumpalo_oneofs::GroupOne as E;
@@ -1047,7 +1047,7 @@ pub mod _puroro_impls {
                     };
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::OneofField, ::puroro::tags::String
-                >::deser_field(field_value_mut_ref, data, &self._bump)
+                >::deser_field(field_value_mut_ref, data, &self._bump, ChildsBumpStrategy::new_child_bump)
                 }
                 3 => {
                     use super::_puroro_nested::msg::_puroro_bumpalo_oneofs::GroupTwo as E;
@@ -1060,7 +1060,7 @@ pub mod _puroro_impls {
                     };
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::OneofField, ::puroro::tags::Float
-                >::deser_field(field_value_mut_ref, data, &self._bump)
+                >::deser_field(field_value_mut_ref, data, &self._bump, ChildsBumpStrategy::new_child_bump)
                 }
                 4 => {
                     use super::_puroro_nested::msg::_puroro_bumpalo_oneofs::GroupTwo as E;
@@ -1077,7 +1077,7 @@ pub mod _puroro_impls {
                     };
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::OneofField, ::puroro::tags::String
-                >::deser_field(field_value_mut_ref, data, &self._bump)
+                >::deser_field(field_value_mut_ref, data, &self._bump, ChildsBumpStrategy::new_child_bump)
                 }
                 5 => {
                     use super::_puroro_nested::msg::_puroro_bumpalo_oneofs::GroupTwo as E;
@@ -1100,7 +1100,12 @@ pub mod _puroro_impls {
                                 self::_puroro_root::oneofs2::_puroro_impls::SubmsgBumpalo<'bump>,
                             >,
                         >,
-                    >::deser_field(field_value_mut_ref, data, &self._bump)
+                    >::deser_field(
+                        field_value_mut_ref,
+                        data,
+                        &self._bump,
+                        ChildsBumpStrategy::new_child_bump,
+                    )
                 }
                 6 => {
                     use super::_puroro_nested::msg::_puroro_bumpalo_oneofs::GroupThree as E;
@@ -1113,7 +1118,7 @@ pub mod _puroro_impls {
                     };
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::OneofField, ::puroro::tags::Int32
-                >::deser_field(field_value_mut_ref, data, &self._bump)
+                >::deser_field(field_value_mut_ref, data, &self._bump, ChildsBumpStrategy::new_child_bump)
                 }
 
                 _ => unimplemented!("TODO: This case should be handled properly..."),
@@ -1436,7 +1441,7 @@ pub mod _puroro_impls {
                     self._bitfield.set(0, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Int32
-                >::deser_field(&mut self.i32_optional, data, &self._bump)
+                >::deser_field(&mut self.i32_optional, data, &self._bump, ChildsBumpStrategy::new_child_bump)
                 }
 
                 _ => unimplemented!("TODO: This case should be handled properly..."),

--- a/tests-pb/src/oneofs3.rs
+++ b/tests-pb/src/oneofs3.rs
@@ -1034,7 +1034,7 @@ pub mod _puroro_impls {
                     };
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::OneofField, ::puroro::tags::Int32
-                >::deser_field(field_value_mut_ref, data, &self._bump)
+                >::deser_field(field_value_mut_ref, data, &self._bump, ChildsBumpStrategy::new_child_bump)
                 }
                 2 => {
                     use super::_puroro_nested::msg::_puroro_bumpalo_oneofs::GroupOne as E;
@@ -1051,7 +1051,7 @@ pub mod _puroro_impls {
                     };
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::OneofField, ::puroro::tags::String
-                >::deser_field(field_value_mut_ref, data, &self._bump)
+                >::deser_field(field_value_mut_ref, data, &self._bump, ChildsBumpStrategy::new_child_bump)
                 }
                 3 => {
                     use super::_puroro_nested::msg::_puroro_bumpalo_oneofs::GroupTwo as E;
@@ -1064,7 +1064,7 @@ pub mod _puroro_impls {
                     };
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::OneofField, ::puroro::tags::Float
-                >::deser_field(field_value_mut_ref, data, &self._bump)
+                >::deser_field(field_value_mut_ref, data, &self._bump, ChildsBumpStrategy::new_child_bump)
                 }
                 4 => {
                     use super::_puroro_nested::msg::_puroro_bumpalo_oneofs::GroupTwo as E;
@@ -1081,7 +1081,7 @@ pub mod _puroro_impls {
                     };
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::OneofField, ::puroro::tags::String
-                >::deser_field(field_value_mut_ref, data, &self._bump)
+                >::deser_field(field_value_mut_ref, data, &self._bump, ChildsBumpStrategy::new_child_bump)
                 }
                 5 => {
                     use super::_puroro_nested::msg::_puroro_bumpalo_oneofs::GroupTwo as E;
@@ -1104,7 +1104,12 @@ pub mod _puroro_impls {
                                 self::_puroro_root::oneofs3::_puroro_impls::SubmsgBumpalo<'bump>,
                             >,
                         >,
-                    >::deser_field(field_value_mut_ref, data, &self._bump)
+                    >::deser_field(
+                        field_value_mut_ref,
+                        data,
+                        &self._bump,
+                        ChildsBumpStrategy::new_child_bump,
+                    )
                 }
                 6 => {
                     use super::_puroro_nested::msg::_puroro_bumpalo_oneofs::GroupThree as E;
@@ -1117,7 +1122,7 @@ pub mod _puroro_impls {
                     };
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::OneofField, ::puroro::tags::Int32
-                >::deser_field(field_value_mut_ref, data, &self._bump)
+                >::deser_field(field_value_mut_ref, data, &self._bump, ChildsBumpStrategy::new_child_bump)
                 }
 
                 _ => unimplemented!("TODO: This case should be handled properly..."),
@@ -1435,7 +1440,7 @@ pub mod _puroro_impls {
             1 => {
                 DeserFieldFromBytesIter::<
                     ::puroro::tags::Unlabeled, ::puroro::tags::Int32
-                >::deser_field(&mut self.i32_unlabeled, data, &self._bump)
+                >::deser_field(&mut self.i32_unlabeled, data, &self._bump, ChildsBumpStrategy::new_child_bump)
             }
 
             _ => unimplemented!("TODO: This case should be handled properly..."),

--- a/tests-pb/src/oneofs3.rs
+++ b/tests-pb/src/oneofs3.rs
@@ -953,6 +953,12 @@ pub mod _puroro_impls {
 
     impl<'bump> ::puroro::Message<super::_puroro_simple_impl::Msg> for MsgBumpalo<'bump> {}
 
+    impl<'bump> ::puroro::BumpaloMessage<'bump> for MsgBumpalo<'bump> {
+        fn new_in(bump: &'bump ::puroro::bumpalo::Bump) -> Self {
+            Self::new_in(bump)
+        }
+    }
+
     impl<'bump> ::puroro::internal::impls::bumpalo::BumpaloDefault<'bump> for MsgBumpalo<'bump> {
         fn default_in(bump: &'bump ::puroro::bumpalo::Bump) -> Self {
             Self::new_in(bump)
@@ -1026,7 +1032,11 @@ pub mod _puroro_impls {
                 1 => {
                     use super::_puroro_nested::msg::_puroro_bumpalo_oneofs::GroupOne as E;
                     if !matches!(&self.group_one, E::G1Int32(_)) {
-                        self.group_one = E::G1Int32(::std::default::Default::default());
+                        self.group_one = E::G1Int32(
+                            ::puroro::internal::impls::bumpalo::BumpaloDefault::default_in(
+                                &self._bump,
+                            ),
+                        );
                     }
                     let field_value_mut_ref = match &mut self.group_one {
                         E::G1Int32(v) => v,
@@ -1034,7 +1044,7 @@ pub mod _puroro_impls {
                     };
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::OneofField, ::puroro::tags::Int32
-                >::deser_field(field_value_mut_ref, data, &self._bump, ChildsBumpStrategy::new_child_bump)
+                >::deser_field(field_value_mut_ref, data, &self._bump)
                 }
                 2 => {
                     use super::_puroro_nested::msg::_puroro_bumpalo_oneofs::GroupOne as E;
@@ -1051,12 +1061,16 @@ pub mod _puroro_impls {
                     };
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::OneofField, ::puroro::tags::String
-                >::deser_field(field_value_mut_ref, data, &self._bump, ChildsBumpStrategy::new_child_bump)
+                >::deser_field(field_value_mut_ref, data, &self._bump)
                 }
                 3 => {
                     use super::_puroro_nested::msg::_puroro_bumpalo_oneofs::GroupTwo as E;
                     if !matches!(&self.group_two, E::G2F32(_)) {
-                        self.group_two = E::G2F32(::std::default::Default::default());
+                        self.group_two = E::G2F32(
+                            ::puroro::internal::impls::bumpalo::BumpaloDefault::default_in(
+                                &self._bump,
+                            ),
+                        );
                     }
                     let field_value_mut_ref = match &mut self.group_two {
                         E::G2F32(v) => v,
@@ -1064,7 +1078,7 @@ pub mod _puroro_impls {
                     };
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::OneofField, ::puroro::tags::Float
-                >::deser_field(field_value_mut_ref, data, &self._bump, ChildsBumpStrategy::new_child_bump)
+                >::deser_field(field_value_mut_ref, data, &self._bump)
                 }
                 4 => {
                     use super::_puroro_nested::msg::_puroro_bumpalo_oneofs::GroupTwo as E;
@@ -1081,16 +1095,12 @@ pub mod _puroro_impls {
                     };
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::OneofField, ::puroro::tags::String
-                >::deser_field(field_value_mut_ref, data, &self._bump, ChildsBumpStrategy::new_child_bump)
+                >::deser_field(field_value_mut_ref, data, &self._bump)
                 }
                 5 => {
                     use super::_puroro_nested::msg::_puroro_bumpalo_oneofs::GroupTwo as E;
                     if !matches!(&self.group_two, E::G2Submsg(_)) {
-                        self.group_two = E::G2Submsg(
-                            ::puroro::internal::impls::bumpalo::BumpaloDefault::default_in(
-                                &self._bump,
-                            ),
-                        );
+                        self.group_two = E::G2Submsg(::puroro::BumpaloMessage::new_in(&self._bump));
                     }
                     let field_value_mut_ref = match &mut self.group_two {
                         E::G2Submsg(v) => v,
@@ -1104,17 +1114,16 @@ pub mod _puroro_impls {
                                 self::_puroro_root::oneofs3::_puroro_impls::SubmsgBumpalo<'bump>,
                             >,
                         >,
-                    >::deser_field(
-                        field_value_mut_ref,
-                        data,
-                        &self._bump,
-                        ChildsBumpStrategy::new_child_bump,
-                    )
+                    >::deser_field(field_value_mut_ref, data, &self._bump)
                 }
                 6 => {
                     use super::_puroro_nested::msg::_puroro_bumpalo_oneofs::GroupThree as E;
                     if !matches!(&self.group_three, E::G3Int32(_)) {
-                        self.group_three = E::G3Int32(::std::default::Default::default());
+                        self.group_three = E::G3Int32(
+                            ::puroro::internal::impls::bumpalo::BumpaloDefault::default_in(
+                                &self._bump,
+                            ),
+                        );
                     }
                     let field_value_mut_ref = match &mut self.group_three {
                         E::G3Int32(v) => v,
@@ -1122,7 +1131,7 @@ pub mod _puroro_impls {
                     };
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::OneofField, ::puroro::tags::Int32
-                >::deser_field(field_value_mut_ref, data, &self._bump, ChildsBumpStrategy::new_child_bump)
+                >::deser_field(field_value_mut_ref, data, &self._bump)
                 }
 
                 _ => unimplemented!("TODO: This case should be handled properly..."),
@@ -1412,6 +1421,12 @@ pub mod _puroro_impls {
 
     impl<'bump> ::puroro::Message<super::_puroro_simple_impl::Submsg> for SubmsgBumpalo<'bump> {}
 
+    impl<'bump> ::puroro::BumpaloMessage<'bump> for SubmsgBumpalo<'bump> {
+        fn new_in(bump: &'bump ::puroro::bumpalo::Bump) -> Self {
+            Self::new_in(bump)
+        }
+    }
+
     impl<'bump> ::puroro::internal::impls::bumpalo::BumpaloDefault<'bump> for SubmsgBumpalo<'bump> {
         fn default_in(bump: &'bump ::puroro::bumpalo::Bump) -> Self {
             Self::new_in(bump)
@@ -1440,7 +1455,7 @@ pub mod _puroro_impls {
             1 => {
                 DeserFieldFromBytesIter::<
                     ::puroro::tags::Unlabeled, ::puroro::tags::Int32
-                >::deser_field(&mut self.i32_unlabeled, data, &self._bump, ChildsBumpStrategy::new_child_bump)
+                >::deser_field(&mut self.i32_unlabeled, data, &self._bump)
             }
 
             _ => unimplemented!("TODO: This case should be handled properly..."),

--- a/tests-pb/src/proto2_defaults.rs
+++ b/tests-pb/src/proto2_defaults.rs
@@ -6033,376 +6033,391 @@ pub mod _puroro_impls {
                     self._bitfield.set(0, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Int32
-                >::deser_field(&mut self.i32_default, data, &self._bump)
+                >::deser_field(&mut self.i32_default, data, &self._bump, ChildsBumpStrategy::new_child_bump)
                 }
                 2 => {
                     self._bitfield.set(1, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Int32
-                >::deser_field(&mut self.i32_0, data, &self._bump)
+                >::deser_field(&mut self.i32_0, data, &self._bump, ChildsBumpStrategy::new_child_bump)
                 }
                 3 => {
                     self._bitfield.set(2, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Int32
-                >::deser_field(&mut self.i32_42, data, &self._bump)
+                >::deser_field(&mut self.i32_42, data, &self._bump, ChildsBumpStrategy::new_child_bump)
                 }
                 4 => {
                     self._bitfield.set(3, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Int32
-                >::deser_field(&mut self.i32_m42, data, &self._bump)
+                >::deser_field(&mut self.i32_m42, data, &self._bump, ChildsBumpStrategy::new_child_bump)
                 }
                 5 => {
                     self._bitfield.set(4, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Int32
-                >::deser_field(&mut self.i32_2147483647, data, &self._bump)
+                >::deser_field(&mut self.i32_2147483647, data, &self._bump, ChildsBumpStrategy::new_child_bump)
                 }
                 6 => {
                     self._bitfield.set(5, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Int32
-                >::deser_field(&mut self.i32_m2147483648, data, &self._bump)
+                >::deser_field(&mut self.i32_m2147483648, data, &self._bump, ChildsBumpStrategy::new_child_bump)
                 }
                 7 => {
                     self._bitfield.set(6, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Int32
-                >::deser_field(&mut self.i32_0123, data, &self._bump)
+                >::deser_field(&mut self.i32_0123, data, &self._bump, ChildsBumpStrategy::new_child_bump)
                 }
                 8 => {
                     self._bitfield.set(7, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Int32
-                >::deser_field(&mut self.i32_0x123, data, &self._bump)
+                >::deser_field(&mut self.i32_0x123, data, &self._bump, ChildsBumpStrategy::new_child_bump)
                 }
                 11 => {
                     self._bitfield.set(8, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::UInt32
-                >::deser_field(&mut self.u32_default, data, &self._bump)
+                >::deser_field(&mut self.u32_default, data, &self._bump, ChildsBumpStrategy::new_child_bump)
                 }
                 12 => {
                     self._bitfield.set(9, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::UInt32
-                >::deser_field(&mut self.u32_0, data, &self._bump)
+                >::deser_field(&mut self.u32_0, data, &self._bump, ChildsBumpStrategy::new_child_bump)
                 }
                 13 => {
                     self._bitfield.set(10, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::UInt32
-                >::deser_field(&mut self.u32_42, data, &self._bump)
+                >::deser_field(&mut self.u32_42, data, &self._bump, ChildsBumpStrategy::new_child_bump)
                 }
                 15 => {
                     self._bitfield.set(11, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::UInt32
-                >::deser_field(&mut self.u32_4294967295, data, &self._bump)
+                >::deser_field(&mut self.u32_4294967295, data, &self._bump, ChildsBumpStrategy::new_child_bump)
                 }
                 17 => {
                     self._bitfield.set(12, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::UInt32
-                >::deser_field(&mut self.u32_0123, data, &self._bump)
+                >::deser_field(&mut self.u32_0123, data, &self._bump, ChildsBumpStrategy::new_child_bump)
                 }
                 18 => {
                     self._bitfield.set(13, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::UInt32
-                >::deser_field(&mut self.u32_0x123, data, &self._bump)
+                >::deser_field(&mut self.u32_0x123, data, &self._bump, ChildsBumpStrategy::new_child_bump)
                 }
                 21 => {
                     self._bitfield.set(14, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Int64
-                >::deser_field(&mut self.i64_default, data, &self._bump)
+                >::deser_field(&mut self.i64_default, data, &self._bump, ChildsBumpStrategy::new_child_bump)
                 }
                 22 => {
                     self._bitfield.set(15, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Int64
-                >::deser_field(&mut self.i64_0, data, &self._bump)
+                >::deser_field(&mut self.i64_0, data, &self._bump, ChildsBumpStrategy::new_child_bump)
                 }
                 23 => {
                     self._bitfield.set(16, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Int64
-                >::deser_field(&mut self.i64_42, data, &self._bump)
+                >::deser_field(&mut self.i64_42, data, &self._bump, ChildsBumpStrategy::new_child_bump)
                 }
                 24 => {
                     self._bitfield.set(17, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Int64
-                >::deser_field(&mut self.i64_m42, data, &self._bump)
+                >::deser_field(&mut self.i64_m42, data, &self._bump, ChildsBumpStrategy::new_child_bump)
                 }
                 25 => {
                     self._bitfield.set(18, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Int64
-                >::deser_field(&mut self.i64_9223372036854775807, data, &self._bump)
+                >::deser_field(&mut self.i64_9223372036854775807, data, &self._bump, ChildsBumpStrategy::new_child_bump)
                 }
                 26 => {
                     self._bitfield.set(19, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Int64
-                >::deser_field(&mut self.i64_m9223372036854775808, data, &self._bump)
+                >::deser_field(&mut self.i64_m9223372036854775808, data, &self._bump, ChildsBumpStrategy::new_child_bump)
                 }
                 27 => {
                     self._bitfield.set(20, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Int64
-                >::deser_field(&mut self.i64_0123, data, &self._bump)
+                >::deser_field(&mut self.i64_0123, data, &self._bump, ChildsBumpStrategy::new_child_bump)
                 }
                 28 => {
                     self._bitfield.set(21, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Int64
-                >::deser_field(&mut self.i64_0x123, data, &self._bump)
+                >::deser_field(&mut self.i64_0x123, data, &self._bump, ChildsBumpStrategy::new_child_bump)
                 }
                 31 => {
                     self._bitfield.set(22, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::UInt64
-                >::deser_field(&mut self.u64_default, data, &self._bump)
+                >::deser_field(&mut self.u64_default, data, &self._bump, ChildsBumpStrategy::new_child_bump)
                 }
                 32 => {
                     self._bitfield.set(23, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::UInt64
-                >::deser_field(&mut self.u64_0, data, &self._bump)
+                >::deser_field(&mut self.u64_0, data, &self._bump, ChildsBumpStrategy::new_child_bump)
                 }
                 33 => {
                     self._bitfield.set(24, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::UInt64
-                >::deser_field(&mut self.u64_42, data, &self._bump)
+                >::deser_field(&mut self.u64_42, data, &self._bump, ChildsBumpStrategy::new_child_bump)
                 }
                 35 => {
                     self._bitfield.set(25, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::UInt64
-                >::deser_field(&mut self.u64_18446744073709551615, data, &self._bump)
+                >::deser_field(&mut self.u64_18446744073709551615, data, &self._bump, ChildsBumpStrategy::new_child_bump)
                 }
                 37 => {
                     self._bitfield.set(26, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::UInt64
-                >::deser_field(&mut self.u64_0123, data, &self._bump)
+                >::deser_field(&mut self.u64_0123, data, &self._bump, ChildsBumpStrategy::new_child_bump)
                 }
                 38 => {
                     self._bitfield.set(27, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::UInt64
-                >::deser_field(&mut self.u64_0x123, data, &self._bump)
+                >::deser_field(&mut self.u64_0x123, data, &self._bump, ChildsBumpStrategy::new_child_bump)
                 }
                 41 => {
                     self._bitfield.set(28, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Float
-                >::deser_field(&mut self.f32_default, data, &self._bump)
+                >::deser_field(&mut self.f32_default, data, &self._bump, ChildsBumpStrategy::new_child_bump)
                 }
                 42 => {
                     self._bitfield.set(29, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Float
-                >::deser_field(&mut self.f32_0, data, &self._bump)
+                >::deser_field(&mut self.f32_0, data, &self._bump, ChildsBumpStrategy::new_child_bump)
                 }
                 43 => {
                     self._bitfield.set(30, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Float
-                >::deser_field(&mut self.f32_m0, data, &self._bump)
+                >::deser_field(&mut self.f32_m0, data, &self._bump, ChildsBumpStrategy::new_child_bump)
                 }
                 44 => {
                     self._bitfield.set(31, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Float
-                >::deser_field(&mut self.f32_0p, data, &self._bump)
+                >::deser_field(&mut self.f32_0p, data, &self._bump, ChildsBumpStrategy::new_child_bump)
                 }
                 45 => {
                     self._bitfield.set(32, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Float
-                >::deser_field(&mut self.f32_p0, data, &self._bump)
+                >::deser_field(&mut self.f32_p0, data, &self._bump, ChildsBumpStrategy::new_child_bump)
                 }
                 46 => {
                     self._bitfield.set(33, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Float
-                >::deser_field(&mut self.f32_0p0, data, &self._bump)
+                >::deser_field(&mut self.f32_0p0, data, &self._bump, ChildsBumpStrategy::new_child_bump)
                 }
                 47 => {
                     self._bitfield.set(34, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Float
-                >::deser_field(&mut self.f32_42, data, &self._bump)
+                >::deser_field(&mut self.f32_42, data, &self._bump, ChildsBumpStrategy::new_child_bump)
                 }
                 48 => {
                     self._bitfield.set(35, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Float
-                >::deser_field(&mut self.f32_m42, data, &self._bump)
+                >::deser_field(&mut self.f32_m42, data, &self._bump, ChildsBumpStrategy::new_child_bump)
                 }
                 49 => {
                     self._bitfield.set(36, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Float
-                >::deser_field(&mut self.f32_0p25, data, &self._bump)
+                >::deser_field(&mut self.f32_0p25, data, &self._bump, ChildsBumpStrategy::new_child_bump)
                 }
                 50 => {
                     self._bitfield.set(37, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Float
-                >::deser_field(&mut self.f32_1p5e2, data, &self._bump)
+                >::deser_field(&mut self.f32_1p5e2, data, &self._bump, ChildsBumpStrategy::new_child_bump)
                 }
                 51 => {
                     self._bitfield.set(38, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Float
-                >::deser_field(&mut self.f32_inf, data, &self._bump)
+                >::deser_field(&mut self.f32_inf, data, &self._bump, ChildsBumpStrategy::new_child_bump)
                 }
                 52 => {
                     self._bitfield.set(39, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Float
-                >::deser_field(&mut self.f32_minf, data, &self._bump)
+                >::deser_field(&mut self.f32_minf, data, &self._bump, ChildsBumpStrategy::new_child_bump)
                 }
                 53 => {
                     self._bitfield.set(40, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Float
-                >::deser_field(&mut self.f32_nan, data, &self._bump)
+                >::deser_field(&mut self.f32_nan, data, &self._bump, ChildsBumpStrategy::new_child_bump)
                 }
                 54 => {
                     self._bitfield.set(41, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Float
-                >::deser_field(&mut self.f32_mnan, data, &self._bump)
+                >::deser_field(&mut self.f32_mnan, data, &self._bump, ChildsBumpStrategy::new_child_bump)
                 }
                 61 => {
                     self._bitfield.set(42, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Bool
-                >::deser_field(&mut self.bool_default, data, &self._bump)
+                >::deser_field(&mut self.bool_default, data, &self._bump, ChildsBumpStrategy::new_child_bump)
                 }
                 62 => {
                     self._bitfield.set(43, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Bool
-                >::deser_field(&mut self.bool_true, data, &self._bump)
+                >::deser_field(&mut self.bool_true, data, &self._bump, ChildsBumpStrategy::new_child_bump)
                 }
                 63 => {
                     self._bitfield.set(44, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Bool
-                >::deser_field(&mut self.bool_false, data, &self._bump)
+                >::deser_field(&mut self.bool_false, data, &self._bump, ChildsBumpStrategy::new_child_bump)
                 }
                 71 => {
                     self._bitfield.set(45, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::String
-                >::deser_field(&mut self.string_default, data, &self._bump)
+                >::deser_field(&mut self.string_default, data, &self._bump, ChildsBumpStrategy::new_child_bump)
                 }
                 72 => {
                     self._bitfield.set(46, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::String
-                >::deser_field(&mut self.string_empty, data, &self._bump)
+                >::deser_field(&mut self.string_empty, data, &self._bump, ChildsBumpStrategy::new_child_bump)
                 }
                 73 => {
                     self._bitfield.set(47, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::String
-                >::deser_field(&mut self.string_abc, data, &self._bump)
+                >::deser_field(&mut self.string_abc, data, &self._bump, ChildsBumpStrategy::new_child_bump)
                 }
                 74 => {
                     self._bitfield.set(48, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::String
-                >::deser_field(&mut self.string_aiu, data, &self._bump)
+                >::deser_field(&mut self.string_aiu, data, &self._bump, ChildsBumpStrategy::new_child_bump)
                 }
                 75 => {
                     self._bitfield.set(49, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::String
-                >::deser_field(&mut self.string_backslash, data, &self._bump)
+                >::deser_field(&mut self.string_backslash, data, &self._bump, ChildsBumpStrategy::new_child_bump)
                 }
                 76 => {
                     self._bitfield.set(50, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::String
-                >::deser_field(&mut self.string_tab, data, &self._bump)
+                >::deser_field(&mut self.string_tab, data, &self._bump, ChildsBumpStrategy::new_child_bump)
                 }
                 77 => {
                     self._bitfield.set(51, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::String
-                >::deser_field(&mut self.string_crlf, data, &self._bump)
+                >::deser_field(&mut self.string_crlf, data, &self._bump, ChildsBumpStrategy::new_child_bump)
                 }
                 81 => {
                     self._bitfield.set(52, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Bytes
-                >::deser_field(&mut self.bytes_default, data, &self._bump)
+                >::deser_field(&mut self.bytes_default, data, &self._bump, ChildsBumpStrategy::new_child_bump)
                 }
                 82 => {
                     self._bitfield.set(53, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Bytes
-                >::deser_field(&mut self.bytes_empty, data, &self._bump)
+                >::deser_field(&mut self.bytes_empty, data, &self._bump, ChildsBumpStrategy::new_child_bump)
                 }
                 83 => {
                     self._bitfield.set(54, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Bytes
-                >::deser_field(&mut self.bytes_abc, data, &self._bump)
+                >::deser_field(&mut self.bytes_abc, data, &self._bump, ChildsBumpStrategy::new_child_bump)
                 }
                 84 => {
                     self._bitfield.set(55, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Bytes
-                >::deser_field(&mut self.bytes_aiu, data, &self._bump)
+                >::deser_field(&mut self.bytes_aiu, data, &self._bump, ChildsBumpStrategy::new_child_bump)
                 }
                 85 => {
                     self._bitfield.set(56, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Bytes
-                >::deser_field(&mut self.bytes_backslash, data, &self._bump)
+                >::deser_field(&mut self.bytes_backslash, data, &self._bump, ChildsBumpStrategy::new_child_bump)
                 }
                 86 => {
                     self._bitfield.set(57, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Bytes
-                >::deser_field(&mut self.bytes_tab, data, &self._bump)
+                >::deser_field(&mut self.bytes_tab, data, &self._bump, ChildsBumpStrategy::new_child_bump)
                 }
                 87 => {
                     self._bitfield.set(58, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Bytes
-                >::deser_field(&mut self.bytes_crlf, data, &self._bump)
+                >::deser_field(&mut self.bytes_crlf, data, &self._bump, ChildsBumpStrategy::new_child_bump)
                 }
                 91 => {
                     self._bitfield.set(59, true);
                     DeserFieldFromBytesIter::<
                         ::puroro::tags::Optional,
                         ::puroro::tags::Enum2<self::_puroro_root::proto2_defaults::MyEnum>,
-                    >::deser_field(&mut self.enum_default, data, &self._bump)
+                    >::deser_field(
+                        &mut self.enum_default,
+                        data,
+                        &self._bump,
+                        ChildsBumpStrategy::new_child_bump,
+                    )
                 }
                 92 => {
                     self._bitfield.set(60, true);
                     DeserFieldFromBytesIter::<
                         ::puroro::tags::Optional,
                         ::puroro::tags::Enum2<self::_puroro_root::proto2_defaults::MyEnum>,
-                    >::deser_field(&mut self.enum_one, data, &self._bump)
+                    >::deser_field(
+                        &mut self.enum_one,
+                        data,
+                        &self._bump,
+                        ChildsBumpStrategy::new_child_bump,
+                    )
                 }
                 93 => {
                     self._bitfield.set(61, true);
                     DeserFieldFromBytesIter::<
                         ::puroro::tags::Optional,
                         ::puroro::tags::Enum2<self::_puroro_root::proto2_defaults::MyEnum>,
-                    >::deser_field(&mut self.enum_fourty_two, data, &self._bump)
+                    >::deser_field(
+                        &mut self.enum_fourty_two,
+                        data,
+                        &self._bump,
+                        ChildsBumpStrategy::new_child_bump,
+                    )
                 }
 
                 _ => unimplemented!("TODO: This case should be handled properly..."),

--- a/tests-pb/src/proto2_defaults.rs
+++ b/tests-pb/src/proto2_defaults.rs
@@ -5563,6 +5563,12 @@ pub mod _puroro_impls {
 
     impl<'bump> ::puroro::Message<super::_puroro_simple_impl::Msg> for MsgBumpalo<'bump> {}
 
+    impl<'bump> ::puroro::BumpaloMessage<'bump> for MsgBumpalo<'bump> {
+        fn new_in(bump: &'bump ::puroro::bumpalo::Bump) -> Self {
+            Self::new_in(bump)
+        }
+    }
+
     impl<'bump> ::puroro::internal::impls::bumpalo::BumpaloDefault<'bump> for MsgBumpalo<'bump> {
         fn default_in(bump: &'bump ::puroro::bumpalo::Bump) -> Self {
             Self::new_in(bump)
@@ -6033,391 +6039,376 @@ pub mod _puroro_impls {
                     self._bitfield.set(0, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Int32
-                >::deser_field(&mut self.i32_default, data, &self._bump, ChildsBumpStrategy::new_child_bump)
+                >::deser_field(&mut self.i32_default, data, &self._bump)
                 }
                 2 => {
                     self._bitfield.set(1, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Int32
-                >::deser_field(&mut self.i32_0, data, &self._bump, ChildsBumpStrategy::new_child_bump)
+                >::deser_field(&mut self.i32_0, data, &self._bump)
                 }
                 3 => {
                     self._bitfield.set(2, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Int32
-                >::deser_field(&mut self.i32_42, data, &self._bump, ChildsBumpStrategy::new_child_bump)
+                >::deser_field(&mut self.i32_42, data, &self._bump)
                 }
                 4 => {
                     self._bitfield.set(3, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Int32
-                >::deser_field(&mut self.i32_m42, data, &self._bump, ChildsBumpStrategy::new_child_bump)
+                >::deser_field(&mut self.i32_m42, data, &self._bump)
                 }
                 5 => {
                     self._bitfield.set(4, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Int32
-                >::deser_field(&mut self.i32_2147483647, data, &self._bump, ChildsBumpStrategy::new_child_bump)
+                >::deser_field(&mut self.i32_2147483647, data, &self._bump)
                 }
                 6 => {
                     self._bitfield.set(5, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Int32
-                >::deser_field(&mut self.i32_m2147483648, data, &self._bump, ChildsBumpStrategy::new_child_bump)
+                >::deser_field(&mut self.i32_m2147483648, data, &self._bump)
                 }
                 7 => {
                     self._bitfield.set(6, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Int32
-                >::deser_field(&mut self.i32_0123, data, &self._bump, ChildsBumpStrategy::new_child_bump)
+                >::deser_field(&mut self.i32_0123, data, &self._bump)
                 }
                 8 => {
                     self._bitfield.set(7, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Int32
-                >::deser_field(&mut self.i32_0x123, data, &self._bump, ChildsBumpStrategy::new_child_bump)
+                >::deser_field(&mut self.i32_0x123, data, &self._bump)
                 }
                 11 => {
                     self._bitfield.set(8, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::UInt32
-                >::deser_field(&mut self.u32_default, data, &self._bump, ChildsBumpStrategy::new_child_bump)
+                >::deser_field(&mut self.u32_default, data, &self._bump)
                 }
                 12 => {
                     self._bitfield.set(9, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::UInt32
-                >::deser_field(&mut self.u32_0, data, &self._bump, ChildsBumpStrategy::new_child_bump)
+                >::deser_field(&mut self.u32_0, data, &self._bump)
                 }
                 13 => {
                     self._bitfield.set(10, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::UInt32
-                >::deser_field(&mut self.u32_42, data, &self._bump, ChildsBumpStrategy::new_child_bump)
+                >::deser_field(&mut self.u32_42, data, &self._bump)
                 }
                 15 => {
                     self._bitfield.set(11, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::UInt32
-                >::deser_field(&mut self.u32_4294967295, data, &self._bump, ChildsBumpStrategy::new_child_bump)
+                >::deser_field(&mut self.u32_4294967295, data, &self._bump)
                 }
                 17 => {
                     self._bitfield.set(12, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::UInt32
-                >::deser_field(&mut self.u32_0123, data, &self._bump, ChildsBumpStrategy::new_child_bump)
+                >::deser_field(&mut self.u32_0123, data, &self._bump)
                 }
                 18 => {
                     self._bitfield.set(13, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::UInt32
-                >::deser_field(&mut self.u32_0x123, data, &self._bump, ChildsBumpStrategy::new_child_bump)
+                >::deser_field(&mut self.u32_0x123, data, &self._bump)
                 }
                 21 => {
                     self._bitfield.set(14, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Int64
-                >::deser_field(&mut self.i64_default, data, &self._bump, ChildsBumpStrategy::new_child_bump)
+                >::deser_field(&mut self.i64_default, data, &self._bump)
                 }
                 22 => {
                     self._bitfield.set(15, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Int64
-                >::deser_field(&mut self.i64_0, data, &self._bump, ChildsBumpStrategy::new_child_bump)
+                >::deser_field(&mut self.i64_0, data, &self._bump)
                 }
                 23 => {
                     self._bitfield.set(16, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Int64
-                >::deser_field(&mut self.i64_42, data, &self._bump, ChildsBumpStrategy::new_child_bump)
+                >::deser_field(&mut self.i64_42, data, &self._bump)
                 }
                 24 => {
                     self._bitfield.set(17, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Int64
-                >::deser_field(&mut self.i64_m42, data, &self._bump, ChildsBumpStrategy::new_child_bump)
+                >::deser_field(&mut self.i64_m42, data, &self._bump)
                 }
                 25 => {
                     self._bitfield.set(18, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Int64
-                >::deser_field(&mut self.i64_9223372036854775807, data, &self._bump, ChildsBumpStrategy::new_child_bump)
+                >::deser_field(&mut self.i64_9223372036854775807, data, &self._bump)
                 }
                 26 => {
                     self._bitfield.set(19, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Int64
-                >::deser_field(&mut self.i64_m9223372036854775808, data, &self._bump, ChildsBumpStrategy::new_child_bump)
+                >::deser_field(&mut self.i64_m9223372036854775808, data, &self._bump)
                 }
                 27 => {
                     self._bitfield.set(20, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Int64
-                >::deser_field(&mut self.i64_0123, data, &self._bump, ChildsBumpStrategy::new_child_bump)
+                >::deser_field(&mut self.i64_0123, data, &self._bump)
                 }
                 28 => {
                     self._bitfield.set(21, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Int64
-                >::deser_field(&mut self.i64_0x123, data, &self._bump, ChildsBumpStrategy::new_child_bump)
+                >::deser_field(&mut self.i64_0x123, data, &self._bump)
                 }
                 31 => {
                     self._bitfield.set(22, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::UInt64
-                >::deser_field(&mut self.u64_default, data, &self._bump, ChildsBumpStrategy::new_child_bump)
+                >::deser_field(&mut self.u64_default, data, &self._bump)
                 }
                 32 => {
                     self._bitfield.set(23, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::UInt64
-                >::deser_field(&mut self.u64_0, data, &self._bump, ChildsBumpStrategy::new_child_bump)
+                >::deser_field(&mut self.u64_0, data, &self._bump)
                 }
                 33 => {
                     self._bitfield.set(24, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::UInt64
-                >::deser_field(&mut self.u64_42, data, &self._bump, ChildsBumpStrategy::new_child_bump)
+                >::deser_field(&mut self.u64_42, data, &self._bump)
                 }
                 35 => {
                     self._bitfield.set(25, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::UInt64
-                >::deser_field(&mut self.u64_18446744073709551615, data, &self._bump, ChildsBumpStrategy::new_child_bump)
+                >::deser_field(&mut self.u64_18446744073709551615, data, &self._bump)
                 }
                 37 => {
                     self._bitfield.set(26, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::UInt64
-                >::deser_field(&mut self.u64_0123, data, &self._bump, ChildsBumpStrategy::new_child_bump)
+                >::deser_field(&mut self.u64_0123, data, &self._bump)
                 }
                 38 => {
                     self._bitfield.set(27, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::UInt64
-                >::deser_field(&mut self.u64_0x123, data, &self._bump, ChildsBumpStrategy::new_child_bump)
+                >::deser_field(&mut self.u64_0x123, data, &self._bump)
                 }
                 41 => {
                     self._bitfield.set(28, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Float
-                >::deser_field(&mut self.f32_default, data, &self._bump, ChildsBumpStrategy::new_child_bump)
+                >::deser_field(&mut self.f32_default, data, &self._bump)
                 }
                 42 => {
                     self._bitfield.set(29, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Float
-                >::deser_field(&mut self.f32_0, data, &self._bump, ChildsBumpStrategy::new_child_bump)
+                >::deser_field(&mut self.f32_0, data, &self._bump)
                 }
                 43 => {
                     self._bitfield.set(30, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Float
-                >::deser_field(&mut self.f32_m0, data, &self._bump, ChildsBumpStrategy::new_child_bump)
+                >::deser_field(&mut self.f32_m0, data, &self._bump)
                 }
                 44 => {
                     self._bitfield.set(31, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Float
-                >::deser_field(&mut self.f32_0p, data, &self._bump, ChildsBumpStrategy::new_child_bump)
+                >::deser_field(&mut self.f32_0p, data, &self._bump)
                 }
                 45 => {
                     self._bitfield.set(32, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Float
-                >::deser_field(&mut self.f32_p0, data, &self._bump, ChildsBumpStrategy::new_child_bump)
+                >::deser_field(&mut self.f32_p0, data, &self._bump)
                 }
                 46 => {
                     self._bitfield.set(33, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Float
-                >::deser_field(&mut self.f32_0p0, data, &self._bump, ChildsBumpStrategy::new_child_bump)
+                >::deser_field(&mut self.f32_0p0, data, &self._bump)
                 }
                 47 => {
                     self._bitfield.set(34, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Float
-                >::deser_field(&mut self.f32_42, data, &self._bump, ChildsBumpStrategy::new_child_bump)
+                >::deser_field(&mut self.f32_42, data, &self._bump)
                 }
                 48 => {
                     self._bitfield.set(35, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Float
-                >::deser_field(&mut self.f32_m42, data, &self._bump, ChildsBumpStrategy::new_child_bump)
+                >::deser_field(&mut self.f32_m42, data, &self._bump)
                 }
                 49 => {
                     self._bitfield.set(36, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Float
-                >::deser_field(&mut self.f32_0p25, data, &self._bump, ChildsBumpStrategy::new_child_bump)
+                >::deser_field(&mut self.f32_0p25, data, &self._bump)
                 }
                 50 => {
                     self._bitfield.set(37, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Float
-                >::deser_field(&mut self.f32_1p5e2, data, &self._bump, ChildsBumpStrategy::new_child_bump)
+                >::deser_field(&mut self.f32_1p5e2, data, &self._bump)
                 }
                 51 => {
                     self._bitfield.set(38, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Float
-                >::deser_field(&mut self.f32_inf, data, &self._bump, ChildsBumpStrategy::new_child_bump)
+                >::deser_field(&mut self.f32_inf, data, &self._bump)
                 }
                 52 => {
                     self._bitfield.set(39, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Float
-                >::deser_field(&mut self.f32_minf, data, &self._bump, ChildsBumpStrategy::new_child_bump)
+                >::deser_field(&mut self.f32_minf, data, &self._bump)
                 }
                 53 => {
                     self._bitfield.set(40, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Float
-                >::deser_field(&mut self.f32_nan, data, &self._bump, ChildsBumpStrategy::new_child_bump)
+                >::deser_field(&mut self.f32_nan, data, &self._bump)
                 }
                 54 => {
                     self._bitfield.set(41, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Float
-                >::deser_field(&mut self.f32_mnan, data, &self._bump, ChildsBumpStrategy::new_child_bump)
+                >::deser_field(&mut self.f32_mnan, data, &self._bump)
                 }
                 61 => {
                     self._bitfield.set(42, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Bool
-                >::deser_field(&mut self.bool_default, data, &self._bump, ChildsBumpStrategy::new_child_bump)
+                >::deser_field(&mut self.bool_default, data, &self._bump)
                 }
                 62 => {
                     self._bitfield.set(43, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Bool
-                >::deser_field(&mut self.bool_true, data, &self._bump, ChildsBumpStrategy::new_child_bump)
+                >::deser_field(&mut self.bool_true, data, &self._bump)
                 }
                 63 => {
                     self._bitfield.set(44, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Bool
-                >::deser_field(&mut self.bool_false, data, &self._bump, ChildsBumpStrategy::new_child_bump)
+                >::deser_field(&mut self.bool_false, data, &self._bump)
                 }
                 71 => {
                     self._bitfield.set(45, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::String
-                >::deser_field(&mut self.string_default, data, &self._bump, ChildsBumpStrategy::new_child_bump)
+                >::deser_field(&mut self.string_default, data, &self._bump)
                 }
                 72 => {
                     self._bitfield.set(46, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::String
-                >::deser_field(&mut self.string_empty, data, &self._bump, ChildsBumpStrategy::new_child_bump)
+                >::deser_field(&mut self.string_empty, data, &self._bump)
                 }
                 73 => {
                     self._bitfield.set(47, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::String
-                >::deser_field(&mut self.string_abc, data, &self._bump, ChildsBumpStrategy::new_child_bump)
+                >::deser_field(&mut self.string_abc, data, &self._bump)
                 }
                 74 => {
                     self._bitfield.set(48, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::String
-                >::deser_field(&mut self.string_aiu, data, &self._bump, ChildsBumpStrategy::new_child_bump)
+                >::deser_field(&mut self.string_aiu, data, &self._bump)
                 }
                 75 => {
                     self._bitfield.set(49, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::String
-                >::deser_field(&mut self.string_backslash, data, &self._bump, ChildsBumpStrategy::new_child_bump)
+                >::deser_field(&mut self.string_backslash, data, &self._bump)
                 }
                 76 => {
                     self._bitfield.set(50, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::String
-                >::deser_field(&mut self.string_tab, data, &self._bump, ChildsBumpStrategy::new_child_bump)
+                >::deser_field(&mut self.string_tab, data, &self._bump)
                 }
                 77 => {
                     self._bitfield.set(51, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::String
-                >::deser_field(&mut self.string_crlf, data, &self._bump, ChildsBumpStrategy::new_child_bump)
+                >::deser_field(&mut self.string_crlf, data, &self._bump)
                 }
                 81 => {
                     self._bitfield.set(52, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Bytes
-                >::deser_field(&mut self.bytes_default, data, &self._bump, ChildsBumpStrategy::new_child_bump)
+                >::deser_field(&mut self.bytes_default, data, &self._bump)
                 }
                 82 => {
                     self._bitfield.set(53, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Bytes
-                >::deser_field(&mut self.bytes_empty, data, &self._bump, ChildsBumpStrategy::new_child_bump)
+                >::deser_field(&mut self.bytes_empty, data, &self._bump)
                 }
                 83 => {
                     self._bitfield.set(54, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Bytes
-                >::deser_field(&mut self.bytes_abc, data, &self._bump, ChildsBumpStrategy::new_child_bump)
+                >::deser_field(&mut self.bytes_abc, data, &self._bump)
                 }
                 84 => {
                     self._bitfield.set(55, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Bytes
-                >::deser_field(&mut self.bytes_aiu, data, &self._bump, ChildsBumpStrategy::new_child_bump)
+                >::deser_field(&mut self.bytes_aiu, data, &self._bump)
                 }
                 85 => {
                     self._bitfield.set(56, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Bytes
-                >::deser_field(&mut self.bytes_backslash, data, &self._bump, ChildsBumpStrategy::new_child_bump)
+                >::deser_field(&mut self.bytes_backslash, data, &self._bump)
                 }
                 86 => {
                     self._bitfield.set(57, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Bytes
-                >::deser_field(&mut self.bytes_tab, data, &self._bump, ChildsBumpStrategy::new_child_bump)
+                >::deser_field(&mut self.bytes_tab, data, &self._bump)
                 }
                 87 => {
                     self._bitfield.set(58, true);
                     DeserFieldFromBytesIter::<
                     ::puroro::tags::Optional, ::puroro::tags::Bytes
-                >::deser_field(&mut self.bytes_crlf, data, &self._bump, ChildsBumpStrategy::new_child_bump)
+                >::deser_field(&mut self.bytes_crlf, data, &self._bump)
                 }
                 91 => {
                     self._bitfield.set(59, true);
                     DeserFieldFromBytesIter::<
                         ::puroro::tags::Optional,
                         ::puroro::tags::Enum2<self::_puroro_root::proto2_defaults::MyEnum>,
-                    >::deser_field(
-                        &mut self.enum_default,
-                        data,
-                        &self._bump,
-                        ChildsBumpStrategy::new_child_bump,
-                    )
+                    >::deser_field(&mut self.enum_default, data, &self._bump)
                 }
                 92 => {
                     self._bitfield.set(60, true);
                     DeserFieldFromBytesIter::<
                         ::puroro::tags::Optional,
                         ::puroro::tags::Enum2<self::_puroro_root::proto2_defaults::MyEnum>,
-                    >::deser_field(
-                        &mut self.enum_one,
-                        data,
-                        &self._bump,
-                        ChildsBumpStrategy::new_child_bump,
-                    )
+                    >::deser_field(&mut self.enum_one, data, &self._bump)
                 }
                 93 => {
                     self._bitfield.set(61, true);
                     DeserFieldFromBytesIter::<
                         ::puroro::tags::Optional,
                         ::puroro::tags::Enum2<self::_puroro_root::proto2_defaults::MyEnum>,
-                    >::deser_field(
-                        &mut self.enum_fourty_two,
-                        data,
-                        &self._bump,
-                        ChildsBumpStrategy::new_child_bump,
-                    )
+                    >::deser_field(&mut self.enum_fourty_two, data, &self._bump)
                 }
 
                 _ => unimplemented!("TODO: This case should be handled properly..."),

--- a/tests-pb/src/proto3_defaults.rs
+++ b/tests-pb/src/proto3_defaults.rs
@@ -814,6 +814,12 @@ pub mod _puroro_impls {
 
     impl<'bump> ::puroro::Message<super::_puroro_simple_impl::Msg> for MsgBumpalo<'bump> {}
 
+    impl<'bump> ::puroro::BumpaloMessage<'bump> for MsgBumpalo<'bump> {
+        fn new_in(bump: &'bump ::puroro::bumpalo::Bump) -> Self {
+            Self::new_in(bump)
+        }
+    }
+
     impl<'bump> ::puroro::internal::impls::bumpalo::BumpaloDefault<'bump> for MsgBumpalo<'bump> {
         fn default_in(bump: &'bump ::puroro::bumpalo::Bump) -> Self {
             Self::new_in(bump)
@@ -1231,6 +1237,12 @@ pub mod _puroro_impls {
     }
 
     impl<'bump> ::puroro::Message<super::_puroro_simple_impl::Submsg> for SubmsgBumpalo<'bump> {}
+
+    impl<'bump> ::puroro::BumpaloMessage<'bump> for SubmsgBumpalo<'bump> {
+        fn new_in(bump: &'bump ::puroro::bumpalo::Bump) -> Self {
+            Self::new_in(bump)
+        }
+    }
 
     impl<'bump> ::puroro::internal::impls::bumpalo::BumpaloDefault<'bump> for SubmsgBumpalo<'bump> {
         fn default_in(bump: &'bump ::puroro::bumpalo::Bump) -> Self {

--- a/tests-pb/src/self_recursive.rs
+++ b/tests-pb/src/self_recursive.rs
@@ -246,7 +246,10 @@ pub mod _puroro_impls {
                         >,
                     >,
                 >::deser_field(
-                    &mut self.recursive_unlabeled, data, &self._bump
+                    &mut self.recursive_unlabeled,
+                    data,
+                    &self._bump,
+                    ChildsBumpStrategy::new_child_bump,
                 ),
 
                 _ => unimplemented!("TODO: This case should be handled properly..."),

--- a/tests-pb/src/self_recursive.rs
+++ b/tests-pb/src/self_recursive.rs
@@ -208,6 +208,12 @@ pub mod _puroro_impls {
 
     impl<'bump> ::puroro::Message<super::_puroro_simple_impl::Msg> for MsgBumpalo<'bump> {}
 
+    impl<'bump> ::puroro::BumpaloMessage<'bump> for MsgBumpalo<'bump> {
+        fn new_in(bump: &'bump ::puroro::bumpalo::Bump) -> Self {
+            Self::new_in(bump)
+        }
+    }
+
     impl<'bump> ::puroro::internal::impls::bumpalo::BumpaloDefault<'bump> for MsgBumpalo<'bump> {
         fn default_in(bump: &'bump ::puroro::bumpalo::Bump) -> Self {
             Self::new_in(bump)
@@ -246,10 +252,7 @@ pub mod _puroro_impls {
                         >,
                     >,
                 >::deser_field(
-                    &mut self.recursive_unlabeled,
-                    data,
-                    &self._bump,
-                    ChildsBumpStrategy::new_child_bump,
+                    &mut self.recursive_unlabeled, data, &self._bump
                 ),
 
                 _ => unimplemented!("TODO: This case should be handled properly..."),

--- a/tests-pb/src/ser_tests2.rs
+++ b/tests-pb/src/ser_tests2.rs
@@ -1701,6 +1701,12 @@ pub mod _puroro_impls {
 
     impl<'bump> ::puroro::Message<super::_puroro_simple_impl::Msg> for MsgBumpalo<'bump> {}
 
+    impl<'bump> ::puroro::BumpaloMessage<'bump> for MsgBumpalo<'bump> {
+        fn new_in(bump: &'bump ::puroro::bumpalo::Bump) -> Self {
+            Self::new_in(bump)
+        }
+    }
+
     impl<'bump> ::puroro::internal::impls::bumpalo::BumpaloDefault<'bump> for MsgBumpalo<'bump> {
         fn default_in(bump: &'bump ::puroro::bumpalo::Bump) -> Self {
             Self::new_in(bump)
@@ -3160,6 +3166,12 @@ pub mod _puroro_nested {
             }
 
             impl<'bump> ::puroro::Message<super::_puroro_simple_impl::Submsg> for SubmsgBumpalo<'bump> {}
+
+            impl<'bump> ::puroro::BumpaloMessage<'bump> for SubmsgBumpalo<'bump> {
+                fn new_in(bump: &'bump ::puroro::bumpalo::Bump) -> Self {
+                    Self::new_in(bump)
+                }
+            }
 
             impl<'bump> ::puroro::internal::impls::bumpalo::BumpaloDefault<'bump> for SubmsgBumpalo<'bump> {
                 fn default_in(bump: &'bump ::puroro::bumpalo::Bump) -> Self {

--- a/tests-pb/src/ser_tests3.rs
+++ b/tests-pb/src/ser_tests3.rs
@@ -1721,6 +1721,12 @@ pub mod _puroro_impls {
 
     impl<'bump> ::puroro::Message<super::_puroro_simple_impl::Msg> for MsgBumpalo<'bump> {}
 
+    impl<'bump> ::puroro::BumpaloMessage<'bump> for MsgBumpalo<'bump> {
+        fn new_in(bump: &'bump ::puroro::bumpalo::Bump) -> Self {
+            Self::new_in(bump)
+        }
+    }
+
     impl<'bump> ::puroro::internal::impls::bumpalo::BumpaloDefault<'bump> for MsgBumpalo<'bump> {
         fn default_in(bump: &'bump ::puroro::bumpalo::Bump) -> Self {
             Self::new_in(bump)
@@ -3158,6 +3164,12 @@ pub mod _puroro_nested {
             }
 
             impl<'bump> ::puroro::Message<super::_puroro_simple_impl::Submsg> for SubmsgBumpalo<'bump> {}
+
+            impl<'bump> ::puroro::BumpaloMessage<'bump> for SubmsgBumpalo<'bump> {
+                fn new_in(bump: &'bump ::puroro::bumpalo::Bump) -> Self {
+                    Self::new_in(bump)
+                }
+            }
 
             impl<'bump> ::puroro::internal::impls::bumpalo::BumpaloDefault<'bump> for SubmsgBumpalo<'bump> {
                 fn default_in(bump: &'bump ::puroro::bumpalo::Bump) -> Self {


### PR DESCRIPTION
Change BumpaloDefault to just take &Bump instance, instead of <B> generic type.
Create BumpaloMessage trait for Message field and implement that instead of BumpaloDefault.
This PR is for future change.