### PR TITLE
Rename-modules

### DIFF
--- a/codegen/src/codegen.rs
+++ b/codegen/src/codegen.rs
@@ -16,10 +16,10 @@ mod data;
 mod gen;
 mod util;
 
-use self::data::*;
-use self::gen::*;
+use self::data::{PackageOrMessage, RootPackage};
+use self::gen::PackageOrMessageExt as _;
 
-use crate::{ErrorKind, GeneratorError, Result};
+use crate::Result;
 use ::itertools::Itertools;
 use ::proc_macro2::TokenStream;
 use ::puroro_protobuf_compiled::google::protobuf::compiler::code_generator_response::File;
@@ -28,30 +28,6 @@ use ::puroro_protobuf_compiled::google::protobuf::FileDescriptorProto;
 use ::quote::quote;
 use ::std::iter;
 use ::std::rc::Rc;
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Syntax {
-    Proto2,
-    Proto3,
-}
-impl TryFrom<&str> for Syntax {
-    type Error = GeneratorError;
-    fn try_from(value: &str) -> Result<Self> {
-        Ok(match value {
-            "" | "proto2" => Syntax::Proto2,
-            "proto3" => Syntax::Proto3,
-            _ => Err(ErrorKind::UnknownProtoSyntax {
-                name: value.to_string(),
-            })?,
-        })
-    }
-}
-
-#[derive(Debug, Clone, Copy)]
-pub enum MessageOrEnum<M, E> {
-    Message(M),
-    Enum(E),
-}
 
 pub fn generate_file_names_and_tokens<'a>(
     files: impl Iterator<Item = &'a FileDescriptorProto>,

--- a/codegen/src/codegen/data.rs
+++ b/codegen/src/codegen/data.rs
@@ -33,3 +33,29 @@ pub use self::oneof::*;
 pub use self::oneof_field::*;
 pub use self::package::*;
 pub use self::package_or_message::*;
+
+use crate::{ErrorKind, GeneratorError, Result};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Syntax {
+    Proto2,
+    Proto3,
+}
+impl TryFrom<&str> for Syntax {
+    type Error = GeneratorError;
+    fn try_from(value: &str) -> Result<Self> {
+        Ok(match value {
+            "" | "proto2" => Syntax::Proto2,
+            "proto3" => Syntax::Proto3,
+            _ => Err(ErrorKind::UnknownProtoSyntax {
+                name: value.to_string(),
+            })?,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum MessageOrEnum<M, E> {
+    Message(M),
+    Enum(E),
+}

--- a/codegen/src/codegen/data/enum.rs
+++ b/codegen/src/codegen/data/enum.rs
@@ -18,7 +18,7 @@
 //!  - [c++ generated code](https://developers.google.com/protocol-buffers/docs/reference/cpp-generated#enum)
 
 use super::super::util::*;
-use super::super::{InputFile, PackageOrMessage, Syntax};
+use super::{InputFile, PackageOrMessage, Syntax};
 use crate::Result;
 use ::puroro_protobuf_compiled::google::protobuf::EnumDescriptorProto;
 use ::std::fmt::Debug;

--- a/codegen/src/codegen/data/field.rs
+++ b/codegen/src/codegen/data/field.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use super::super::util::{AnonymousCache, WeakExt};
-use super::super::{FieldRule, FieldType, Message};
+use super::{FieldRule, FieldType, Message};
 use crate::Result;
 use ::once_cell::unsync::OnceCell;
 use ::puroro_protobuf_compiled::google::protobuf::{field_descriptor_proto, FieldDescriptorProto};

--- a/codegen/src/codegen/data/field_rule.rs
+++ b/codegen/src/codegen/data/field_rule.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::super::Syntax;
+use super::Syntax;
 use crate::{ErrorKind, Result};
 use ::puroro_protobuf_compiled::google::protobuf::field_descriptor_proto;
 

--- a/codegen/src/codegen/data/field_type.rs
+++ b/codegen/src/codegen/data/field_type.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::super::{Enum, Message, MessageOrEnum, Syntax};
+use super::{Enum, Message, MessageOrEnum, Syntax};
 use crate::{ErrorKind, Result};
 use ::puroro_protobuf_compiled::google::protobuf::field_descriptor_proto;
 use ::std::rc::{Rc, Weak};

--- a/codegen/src/codegen/data/input_file.rs
+++ b/codegen/src/codegen/data/input_file.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use super::super::util::*;
-use super::super::{Enum, EnumImpl, Message, MessageImpl, Package, PackageOrMessage, Syntax};
+use super::{Enum, EnumImpl, Message, MessageImpl, Package, PackageOrMessage, Syntax};
 use crate::Result;
 use ::once_cell::unsync::OnceCell;
 use ::puroro_protobuf_compiled::google::protobuf::{

--- a/codegen/src/codegen/data/message.rs
+++ b/codegen/src/codegen/data/message.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use super::super::util::*;
-use super::super::{
+use super::{
     Enum, EnumImpl, Field, FieldImpl, InputFile, Oneof, OneofImpl, Package, PackageOrMessage,
     RootPackage,
 };

--- a/codegen/src/codegen/data/oneof.rs
+++ b/codegen/src/codegen/data/oneof.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use super::super::util::*;
-use super::super::{Message, OneofField, OneofFieldImpl};
+use super::{Message, OneofField, OneofFieldImpl};
 use crate::Result;
 use ::puroro_protobuf_compiled::google::protobuf::{DescriptorProto, OneofDescriptorProto};
 use ::std::fmt::Debug;

--- a/codegen/src/codegen/data/oneof_field.rs
+++ b/codegen/src/codegen/data/oneof_field.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use super::super::util::*;
-use super::super::{FieldBase, FieldType, Message, Oneof};
+use super::{FieldBase, FieldType, Message, Oneof};
 use crate::Result;
 use ::once_cell::unsync::OnceCell;
 use ::puroro_protobuf_compiled::google::protobuf::{field_descriptor_proto, FieldDescriptorProto};

--- a/codegen/src/codegen/data/package.rs
+++ b/codegen/src/codegen/data/package.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use super::super::util::*;
-use super::super::{Enum, InputFile, InputFileImpl, Message, PackageOrMessage};
+use super::{Enum, InputFile, InputFileImpl, Message, PackageOrMessage};
 use crate::Result;
 use ::itertools::Itertools;
 use ::once_cell::unsync::OnceCell;

--- a/codegen/src/codegen/data/package_or_message.rs
+++ b/codegen/src/codegen/data/package_or_message.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use super::super::util::*;
-use super::super::{Enum, Message, MessageOrEnum, Oneof, Package, RootPackage};
+use super::{Enum, Message, MessageOrEnum, Oneof, Package, RootPackage};
 use crate::{ErrorKind, Result};
 use ::std::fmt::Debug;
 use ::std::rc::Rc;

--- a/codegen/src/codegen/gen.rs
+++ b/codegen/src/codegen/gen.rs
@@ -20,12 +20,11 @@ mod oneof;
 mod oneof_field;
 mod package_or_message;
 
-pub use self::r#enum::*;
-pub use self::field::*;
-pub use self::field_type::*;
-pub use self::message::*;
-pub use self::oneof::*;
-pub use self::oneof_field::*;
+use self::r#enum::*;
+use self::field::*;
+use self::message::*;
+use self::oneof::*;
+use self::oneof_field::*;
 pub use self::package_or_message::*;
 
 use super::data::*;

--- a/codegen/src/codegen/gen.rs
+++ b/codegen/src/codegen/gen.rs
@@ -28,3 +28,39 @@ use self::oneof_field::*;
 pub use self::package_or_message::*;
 
 use super::data::*;
+
+// Global generator constants
+// Q: Is there any good way to implement this using something like `Lazy` generic type?
+// I couldn't find a good way for this case, where the target type
+// like `Ident` or `Path` are `!Sync`...
+//
+// e.g. This does not compile:
+// ```
+// use once_cell::sync::Lazy;
+// static FOO: Lazy<Ident> = Lazy::new(|| format_ident!("foo"));
+// ```
+
+use ::quote::{format_ident, quote, ToTokens};
+
+macro_rules! gen_global_constants {
+    () => {};
+    (const $id:ident: $ty:ident = $expr:expr ; $($rest:tt)*) => {
+        const $id: $ty = $ty;
+        struct $ty;
+        impl ToTokens for $ty {
+            fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+                ($expr).to_tokens(tokens)
+            }
+        }
+        gen_global_constants!($($rest)*);
+    };
+}
+
+gen_global_constants! {
+    const PURORO_INTERNAL_IDENT: PuroroInternalIdent = format_ident!("_pinternal");
+    const PURORO_INTERNAL: PuroroInternal = quote! { self :: #PURORO_INTERNAL_IDENT };
+    const PURORO_ROOT_IDENT: PuroroRootIdent = format_ident!("_root");
+    const PURORO_ROOT: PuroroRoot = quote! { self :: #PURORO_ROOT_IDENT };
+    const PURORO_LIB_IDENT: PuroroLibIdent = format_ident!("_puroro");
+    const PURORO_LIB: PuroroLib = quote! { self :: #PURORO_LIB_IDENT };
+}

--- a/codegen/src/codegen/gen.rs
+++ b/codegen/src/codegen/gen.rs
@@ -27,3 +27,5 @@ pub use self::message::*;
 pub use self::oneof::*;
 pub use self::oneof_field::*;
 pub use self::package_or_message::*;
+
+use super::data::*;

--- a/codegen/src/codegen/gen/enum.rs
+++ b/codegen/src/codegen/gen/enum.rs
@@ -18,7 +18,7 @@
 //!  - [c++ generated code](https://developers.google.com/protocol-buffers/docs/reference/cpp-generated#enum)
 
 use super::super::util::*;
-use super::super::{Enum, PackageOrMessageExt, Syntax};
+use super::{Enum, PackageOrMessageExt, Syntax};
 use crate::syn;
 use crate::syn::{parse2, Item, ItemEnum, Path, Type};
 use crate::{ErrorKind, Result};

--- a/codegen/src/codegen/gen/enum.rs
+++ b/codegen/src/codegen/gen/enum.rs
@@ -18,7 +18,7 @@
 //!  - [c++ generated code](https://developers.google.com/protocol-buffers/docs/reference/cpp-generated#enum)
 
 use super::super::util::*;
-use super::{Enum, PackageOrMessageExt, Syntax};
+use super::{Enum, PackageOrMessageExt, Syntax, PURORO_LIB};
 use crate::syn;
 use crate::syn::{parse2, Item, ItemEnum, Path, Type};
 use crate::{ErrorKind, Result};
@@ -171,11 +171,11 @@ fn gen_enum_try_from_i32(this: &(impl ?Sized + Enum)) -> Result<ItemImpl> {
     let value_numbers = this.values()?.map(|(_, number)| number).collect::<Vec<_>>();
     Ok(parse2(quote! {
         impl ::std::convert::TryFrom::<i32> for #ident {
-            type Error = self::_puroro::PuroroError;
+            type Error = #PURORO_LIB::PuroroError;
             fn try_from(val: i32) -> ::std::result::Result<Self, Self::Error> {
                 match val {
                     #(#value_numbers => ::std::result::Result::Ok(self::#ident::#value_idents),)*
-                    _ => ::std::result::Result::Err(self::_puroro::ErrorKind::UnknownEnumVariant(val))?,
+                    _ => ::std::result::Result::Err(#PURORO_LIB::ErrorKind::UnknownEnumVariant(val))?,
                 }
             }
         }

--- a/codegen/src/codegen/gen/field.rs
+++ b/codegen/src/codegen/gen/field.rs
@@ -15,7 +15,7 @@
 use super::super::util::*;
 use super::{
     Bits32Type, Bits64Type, EnumExt, Field, FieldBase, FieldRule, FieldType, LengthDelimitedType,
-    MessageExt, VariantType,
+    MessageExt, VariantType, PURORO_INTERNAL,
 };
 use crate::syn::{
     parse2, Arm, Expr, ExprMethodCall, Field as SynField, FieldValue, Ident, ImplItemMethod,
@@ -128,7 +128,7 @@ impl<T: ?Sized + Field> FieldExt for T {
         let number = self.number()?;
         let r#type = gen_struct_field_type(self)?;
         Ok(parse2(quote! {
-            #number => <#r#type as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+            #number => <#r#type as #PURORO_INTERNAL::field_type::FieldType>::deser_from_iter(
                 &mut self.#ident,
                 &mut self._bitfield,
                 #field_data_expr,
@@ -140,7 +140,7 @@ impl<T: ?Sized + Field> FieldExt for T {
         let number = self.number()?;
         let r#type = gen_struct_field_type(self)?;
         Ok(parse2(quote! {
-            <#r#type as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+            <#r#type as #PURORO_INTERNAL::field_type::FieldType>::ser_to_write(
                 &self.#ident,
                 &self._bitfield,
                 #number,
@@ -238,7 +238,7 @@ fn gen_struct_field_type(this: &(impl ?Sized + Field)) -> Result<Rc<Type>> {
                 },
             })?;
             Ok(Rc::new(parse2(quote! {
-                self::_puroro::internal::field_type::#type_name_segment
+                #PURORO_INTERNAL::field_type::#type_name_segment
             })?))
         })
         .cloned()
@@ -289,7 +289,7 @@ fn gen_struct_field_methods_for_repeated(
     Ok(vec![
         parse2(quote! {
             pub fn #getter_ident(&self) -> &[#getter_item_type] {
-                use self::_puroro::internal::field_type::RepeatedFieldType;
+                use #PURORO_INTERNAL::field_type::RepeatedFieldType;
                 <#field_type as RepeatedFieldType>::get_field(
                     &self.#field_ident, &self._bitfield,
                 )
@@ -297,7 +297,7 @@ fn gen_struct_field_methods_for_repeated(
         })?,
         parse2(quote! {
             pub fn #getter_mut_ident(&mut self) -> &mut ::std::vec::Vec::<#mut_item_type> {
-                use self::_puroro::internal::field_type::RepeatedFieldType;
+                use #PURORO_INTERNAL::field_type::RepeatedFieldType;
                 <#field_type as RepeatedFieldType>::get_field_mut(
                     &mut self.#field_ident, &mut self._bitfield,
                 )
@@ -305,7 +305,7 @@ fn gen_struct_field_methods_for_repeated(
         })?,
         parse2(quote! {
             pub fn #clear_ident(&mut self) {
-                use self::_puroro::internal::field_type::RepeatedFieldType;
+                use #PURORO_INTERNAL::field_type::RepeatedFieldType;
                 <#field_type as RepeatedFieldType>::clear(
                     &mut self.#field_ident, &mut self._bitfield,
                 )
@@ -346,7 +346,7 @@ fn gen_struct_field_methods_for_non_repeated(
     Ok(vec![
         parse2(quote! {
             pub fn #getter_ident(&self) -> #getter_type {
-               use self::_puroro::internal::field_type::NonRepeatedFieldType;
+               use #PURORO_INTERNAL::field_type::NonRepeatedFieldType;
                 <#field_type as NonRepeatedFieldType>::get_field_or_else(
                     &self.#field_ident, &self._bitfield, #default_fn,
                 )
@@ -354,7 +354,7 @@ fn gen_struct_field_methods_for_non_repeated(
         })?,
         parse2(quote! {
             pub fn #getter_opt_ident(&self) -> #getter_opt_type {
-                use self::_puroro::internal::field_type::NonRepeatedFieldType;
+                use #PURORO_INTERNAL::field_type::NonRepeatedFieldType;
                 <#field_type as NonRepeatedFieldType>::get_field_opt(
                     &self.#field_ident, &self._bitfield,
                 )
@@ -362,7 +362,7 @@ fn gen_struct_field_methods_for_non_repeated(
         })?,
         parse2(quote! {
             pub fn #getter_mut_ident(&mut self) -> #getter_mut_type {
-                use self::_puroro::internal::field_type::NonRepeatedFieldType;
+                use #PURORO_INTERNAL::field_type::NonRepeatedFieldType;
                 <#field_type as NonRepeatedFieldType>::get_field_mut(
                     &mut self.#field_ident, &mut self._bitfield, #default_fn,
                 )
@@ -370,7 +370,7 @@ fn gen_struct_field_methods_for_non_repeated(
         })?,
         parse2(quote! {
             pub fn #getter_has_ident(&self) -> bool {
-                use self::_puroro::internal::field_type::NonRepeatedFieldType;
+                use #PURORO_INTERNAL::field_type::NonRepeatedFieldType;
                 <#field_type as NonRepeatedFieldType>::get_field_opt(
                     &self.#field_ident, &self._bitfield,
                 ).is_some()
@@ -378,7 +378,7 @@ fn gen_struct_field_methods_for_non_repeated(
         })?,
         parse2(quote! {
             pub fn #clear_ident(&mut self) {
-                use self::_puroro::internal::field_type::NonRepeatedFieldType;
+                use #PURORO_INTERNAL::field_type::NonRepeatedFieldType;
                 <#field_type as NonRepeatedFieldType>::clear(
                     &mut self.#field_ident, &mut self._bitfield,
                 )

--- a/codegen/src/codegen/gen/field.rs
+++ b/codegen/src/codegen/gen/field.rs
@@ -128,7 +128,7 @@ impl<T: ?Sized + Field> FieldExt for T {
         let number = self.number()?;
         let r#type = gen_struct_field_type(self)?;
         Ok(parse2(quote! {
-            #number => <#r#type as #PURORO_INTERNAL::field_type::FieldType>::deser_from_iter(
+            #number => <#r#type as #PURORO_INTERNAL::FieldType>::deser_from_iter(
                 &mut self.#ident,
                 &mut self._bitfield,
                 #field_data_expr,
@@ -140,7 +140,7 @@ impl<T: ?Sized + Field> FieldExt for T {
         let number = self.number()?;
         let r#type = gen_struct_field_type(self)?;
         Ok(parse2(quote! {
-            <#r#type as #PURORO_INTERNAL::field_type::FieldType>::ser_to_write(
+            <#r#type as #PURORO_INTERNAL::FieldType>::ser_to_write(
                 &self.#ident,
                 &self._bitfield,
                 #number,
@@ -238,7 +238,7 @@ fn gen_struct_field_type(this: &(impl ?Sized + Field)) -> Result<Rc<Type>> {
                 },
             })?;
             Ok(Rc::new(parse2(quote! {
-                #PURORO_INTERNAL::field_type::#type_name_segment
+                #PURORO_INTERNAL::#type_name_segment
             })?))
         })
         .cloned()
@@ -289,7 +289,7 @@ fn gen_struct_field_methods_for_repeated(
     Ok(vec![
         parse2(quote! {
             pub fn #getter_ident(&self) -> &[#getter_item_type] {
-                use #PURORO_INTERNAL::field_type::RepeatedFieldType;
+                use #PURORO_INTERNAL::RepeatedFieldType;
                 <#field_type as RepeatedFieldType>::get_field(
                     &self.#field_ident, &self._bitfield,
                 )
@@ -297,7 +297,7 @@ fn gen_struct_field_methods_for_repeated(
         })?,
         parse2(quote! {
             pub fn #getter_mut_ident(&mut self) -> &mut ::std::vec::Vec::<#mut_item_type> {
-                use #PURORO_INTERNAL::field_type::RepeatedFieldType;
+                use #PURORO_INTERNAL::RepeatedFieldType;
                 <#field_type as RepeatedFieldType>::get_field_mut(
                     &mut self.#field_ident, &mut self._bitfield,
                 )
@@ -305,7 +305,7 @@ fn gen_struct_field_methods_for_repeated(
         })?,
         parse2(quote! {
             pub fn #clear_ident(&mut self) {
-                use #PURORO_INTERNAL::field_type::RepeatedFieldType;
+                use #PURORO_INTERNAL::RepeatedFieldType;
                 <#field_type as RepeatedFieldType>::clear(
                     &mut self.#field_ident, &mut self._bitfield,
                 )
@@ -346,7 +346,7 @@ fn gen_struct_field_methods_for_non_repeated(
     Ok(vec![
         parse2(quote! {
             pub fn #getter_ident(&self) -> #getter_type {
-               use #PURORO_INTERNAL::field_type::NonRepeatedFieldType;
+               use #PURORO_INTERNAL::NonRepeatedFieldType;
                 <#field_type as NonRepeatedFieldType>::get_field_or_else(
                     &self.#field_ident, &self._bitfield, #default_fn,
                 )
@@ -354,7 +354,7 @@ fn gen_struct_field_methods_for_non_repeated(
         })?,
         parse2(quote! {
             pub fn #getter_opt_ident(&self) -> #getter_opt_type {
-                use #PURORO_INTERNAL::field_type::NonRepeatedFieldType;
+                use #PURORO_INTERNAL::NonRepeatedFieldType;
                 <#field_type as NonRepeatedFieldType>::get_field_opt(
                     &self.#field_ident, &self._bitfield,
                 )
@@ -362,7 +362,7 @@ fn gen_struct_field_methods_for_non_repeated(
         })?,
         parse2(quote! {
             pub fn #getter_mut_ident(&mut self) -> #getter_mut_type {
-                use #PURORO_INTERNAL::field_type::NonRepeatedFieldType;
+                use #PURORO_INTERNAL::NonRepeatedFieldType;
                 <#field_type as NonRepeatedFieldType>::get_field_mut(
                     &mut self.#field_ident, &mut self._bitfield, #default_fn,
                 )
@@ -370,7 +370,7 @@ fn gen_struct_field_methods_for_non_repeated(
         })?,
         parse2(quote! {
             pub fn #getter_has_ident(&self) -> bool {
-                use #PURORO_INTERNAL::field_type::NonRepeatedFieldType;
+                use #PURORO_INTERNAL::NonRepeatedFieldType;
                 <#field_type as NonRepeatedFieldType>::get_field_opt(
                     &self.#field_ident, &self._bitfield,
                 ).is_some()
@@ -378,7 +378,7 @@ fn gen_struct_field_methods_for_non_repeated(
         })?,
         parse2(quote! {
             pub fn #clear_ident(&mut self) {
-                use #PURORO_INTERNAL::field_type::NonRepeatedFieldType;
+                use #PURORO_INTERNAL::NonRepeatedFieldType;
                 <#field_type as NonRepeatedFieldType>::clear(
                     &mut self.#field_ident, &mut self._bitfield,
                 )

--- a/codegen/src/codegen/gen/field.rs
+++ b/codegen/src/codegen/gen/field.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use super::super::util::*;
-use super::super::{
+use super::{
     Bits32Type, Bits64Type, EnumExt, Field, FieldBase, FieldRule, FieldType, LengthDelimitedType,
     MessageExt, VariantType,
 };

--- a/codegen/src/codegen/gen/field_type.rs
+++ b/codegen/src/codegen/gen/field_type.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use super::super::util::*;
-use super::super::{
+use super::{
     Bits32Type, Bits64Type, EnumExt, FieldType, LengthDelimitedType, MessageExt, VariantType,
 };
 use crate::syn::{parse2, Lifetime, Type};

--- a/codegen/src/codegen/gen/field_type.rs
+++ b/codegen/src/codegen/gen/field_type.rs
@@ -15,6 +15,7 @@
 use super::super::util::*;
 use super::{
     Bits32Type, Bits64Type, EnumExt, FieldType, LengthDelimitedType, MessageExt, VariantType,
+    PURORO_INTERNAL,
 };
 use crate::syn::{parse2, Lifetime, Type};
 use crate::Result;
@@ -91,7 +92,7 @@ impl VariantType {
             }
         };
         Ok(Rc::new(parse2(quote! {
-            self::_puroro::internal::tags::#tag_name
+            #PURORO_INTERNAL::tags::#tag_name
         })?))
     }
 }
@@ -139,7 +140,7 @@ impl LengthDelimitedType {
             }
         };
         Ok(Rc::new(parse2(quote! {
-            self::_puroro::internal::tags::#tag_name
+            #PURORO_INTERNAL::tags::#tag_name
         })?))
     }
 }
@@ -160,7 +161,7 @@ impl Bits32Type {
             Float => quote! { Float },
         };
         Ok(Rc::new(parse2(quote! {
-            self::_puroro::internal::tags::#tag_name
+            #PURORO_INTERNAL::tags::#tag_name
         })?))
     }
 }
@@ -181,7 +182,7 @@ impl Bits64Type {
             Double => quote! { Double },
         };
         Ok(Rc::new(parse2(quote! {
-            self::_puroro::internal::tags::#tag_name
+            #PURORO_INTERNAL::tags::#tag_name
         })?))
     }
 }

--- a/codegen/src/codegen/gen/message.rs
+++ b/codegen/src/codegen/gen/message.rs
@@ -119,7 +119,7 @@ impl<T: ?Sized + Message> MessageExt for T {
             pub struct #ident {
                 #(#fields,)*
                 #(#oneof_fields,)*
-                _bitfield: #PURORO_INTERNAL::bitvec::BitArray<#bitfield_size_in_u32_array>,
+                _bitfield: #PURORO_INTERNAL::BitArray<#bitfield_size_in_u32_array>,
             }
         })?;
         let impl_struct = parse2(quote! {
@@ -188,7 +188,7 @@ fn gen_struct_message_impl(this: &(impl ?Sized + Message)) -> Result<ItemImpl> {
 
             fn merge_from_bytes_iter<I: ::std::iter::Iterator<Item =::std::io::Result<u8>>>(&mut self, mut iter: I) -> #PURORO_LIB::Result<()> {
                 use #PURORO_INTERNAL::ser::FieldData;
-                #[allow(unused)] use #PURORO_INTERNAL::oneof_type::OneofUnion as _;
+                #[allow(unused)] use #PURORO_INTERNAL::OneofUnion as _;
                 while let Some((number, #field_data_ident)) = FieldData::from_bytes_iter(iter.by_ref())? {
                     match number {
                         #(#field_deser_arms)*
@@ -200,7 +200,7 @@ fn gen_struct_message_impl(this: &(impl ?Sized + Message)) -> Result<ItemImpl> {
             }
 
             fn to_bytes<W: ::std::io::Write>(&self, #[allow(unused)] #out_ident: &mut W) -> #PURORO_LIB::Result<()> {
-                #[allow(unused)] use #PURORO_INTERNAL::oneof_type::OneofUnion as _;
+                #[allow(unused)] use #PURORO_INTERNAL::OneofUnion as _;
                 #(#ser_fields)*
                 #(#ser_oneof_stmts)*
                 ::std::result::Result::Ok(())
@@ -242,7 +242,7 @@ fn gen_struct_impl_drop(this: &(impl ?Sized + Message)) -> Result<ItemImpl> {
     Ok(parse2(quote! {
         impl ::std::ops::Drop for #ident {
             fn drop(&mut self) {
-                #[allow(unused)] use #PURORO_INTERNAL::oneof_type::OneofUnion as _;
+                #[allow(unused)] use #PURORO_INTERNAL::OneofUnion as _;
 
                 #(self.#oneof_idents.clear(&mut self._bitfield);)*
             }
@@ -286,7 +286,7 @@ fn gen_struct_impl_partial_eq(this: &(impl ?Sized + Message)) -> Result<ItemImpl
     Ok(parse2(quote! {
         impl ::std::cmp::PartialEq for #ident {
             fn eq(&self, rhs: &Self) -> bool {
-                #[allow(unused)] use #PURORO_INTERNAL::oneof_type::OneofUnion as _;
+                #[allow(unused)] use #PURORO_INTERNAL::OneofUnion as _;
 
                 true
                     #( && #field_cmps)*

--- a/codegen/src/codegen/gen/message.rs
+++ b/codegen/src/codegen/gen/message.rs
@@ -13,8 +13,7 @@
 // limitations under the License.
 
 use super::super::util::*;
-use super::{FieldExt, Message, PackageOrMessageExt};
-use super::{OneofExt, OneofFieldExt};
+use super::{FieldExt, Message, OneofExt, OneofFieldExt, PackageOrMessageExt, PURORO_INTERNAL};
 use crate::syn::{parse2, Expr, Ident, Item, ItemImpl, Type};
 use crate::Result;
 use ::itertools::Itertools;
@@ -118,7 +117,7 @@ impl<T: ?Sized + Message> MessageExt for T {
             pub struct #ident {
                 #(#fields,)*
                 #(#oneof_fields,)*
-                _bitfield: self::_puroro::internal::bitvec::BitArray<#bitfield_size_in_u32_array>,
+                _bitfield: #PURORO_INTERNAL::bitvec::BitArray<#bitfield_size_in_u32_array>,
             }
         })?;
         let impl_struct = parse2(quote! {
@@ -186,8 +185,8 @@ fn gen_struct_message_impl(this: &(impl ?Sized + Message)) -> Result<ItemImpl> {
             }
 
             fn merge_from_bytes_iter<I: ::std::iter::Iterator<Item =::std::io::Result<u8>>>(&mut self, mut iter: I) -> self::_puroro::Result<()> {
-                use self::_puroro::internal::ser::FieldData;
-                #[allow(unused)] use self::_puroro::internal::oneof_type::OneofUnion as _;
+                use #PURORO_INTERNAL::ser::FieldData;
+                #[allow(unused)] use #PURORO_INTERNAL::oneof_type::OneofUnion as _;
                 while let Some((number, #field_data_ident)) = FieldData::from_bytes_iter(iter.by_ref())? {
                     match number {
                         #(#field_deser_arms)*
@@ -199,7 +198,7 @@ fn gen_struct_message_impl(this: &(impl ?Sized + Message)) -> Result<ItemImpl> {
             }
 
             fn to_bytes<W: ::std::io::Write>(&self, #[allow(unused)] #out_ident: &mut W) -> self::_puroro::Result<()> {
-                #[allow(unused)] use self::_puroro::internal::oneof_type::OneofUnion as _;
+                #[allow(unused)] use #PURORO_INTERNAL::oneof_type::OneofUnion as _;
                 #(#ser_fields)*
                 #(#ser_oneof_stmts)*
                 ::std::result::Result::Ok(())
@@ -241,7 +240,7 @@ fn gen_struct_impl_drop(this: &(impl ?Sized + Message)) -> Result<ItemImpl> {
     Ok(parse2(quote! {
         impl ::std::ops::Drop for #ident {
             fn drop(&mut self) {
-                #[allow(unused)] use self::_puroro::internal::oneof_type::OneofUnion as _;
+                #[allow(unused)] use #PURORO_INTERNAL::oneof_type::OneofUnion as _;
 
                 #(self.#oneof_idents.clear(&mut self._bitfield);)*
             }
@@ -285,7 +284,7 @@ fn gen_struct_impl_partial_eq(this: &(impl ?Sized + Message)) -> Result<ItemImpl
     Ok(parse2(quote! {
         impl ::std::cmp::PartialEq for #ident {
             fn eq(&self, rhs: &Self) -> bool {
-                #[allow(unused)] use self::_puroro::internal::oneof_type::OneofUnion as _;
+                #[allow(unused)] use #PURORO_INTERNAL::oneof_type::OneofUnion as _;
 
                 true
                     #( && #field_cmps)*

--- a/codegen/src/codegen/gen/message.rs
+++ b/codegen/src/codegen/gen/message.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use super::super::util::*;
-use super::super::{FieldExt, Message, PackageOrMessageExt};
+use super::{FieldExt, Message, PackageOrMessageExt};
 use super::{OneofExt, OneofFieldExt};
 use crate::syn::{parse2, Expr, Ident, Item, ItemImpl, Type};
 use crate::Result;

--- a/codegen/src/codegen/gen/message.rs
+++ b/codegen/src/codegen/gen/message.rs
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 use super::super::util::*;
-use super::{FieldExt, Message, OneofExt, OneofFieldExt, PackageOrMessageExt, PURORO_INTERNAL};
+use super::{
+    FieldExt, Message, OneofExt, OneofFieldExt, PackageOrMessageExt, PURORO_INTERNAL, PURORO_LIB,
+};
 use crate::syn::{parse2, Expr, Ident, Item, ItemImpl, Type};
 use crate::Result;
 use ::itertools::Itertools;
@@ -177,14 +179,14 @@ fn gen_struct_message_impl(this: &(impl ?Sized + Message)) -> Result<ItemImpl> {
         .collect::<Result<Vec<_>>>()?;
 
     Ok(parse2(quote! {
-        impl self::_puroro::Message for #ident {
-            fn from_bytes_iter<I: ::std::iter::Iterator<Item=::std::io::Result<u8>>>(iter: I) -> self::_puroro::Result<Self> {
+        impl #PURORO_LIB::Message for #ident {
+            fn from_bytes_iter<I: ::std::iter::Iterator<Item=::std::io::Result<u8>>>(iter: I) -> #PURORO_LIB::Result<Self> {
                 let mut msg = <Self as ::std::default::Default>::default();
                 msg.merge_from_bytes_iter(iter)?;
                 ::std::result::Result::Ok(msg)
             }
 
-            fn merge_from_bytes_iter<I: ::std::iter::Iterator<Item =::std::io::Result<u8>>>(&mut self, mut iter: I) -> self::_puroro::Result<()> {
+            fn merge_from_bytes_iter<I: ::std::iter::Iterator<Item =::std::io::Result<u8>>>(&mut self, mut iter: I) -> #PURORO_LIB::Result<()> {
                 use #PURORO_INTERNAL::ser::FieldData;
                 #[allow(unused)] use #PURORO_INTERNAL::oneof_type::OneofUnion as _;
                 while let Some((number, #field_data_ident)) = FieldData::from_bytes_iter(iter.by_ref())? {
@@ -197,7 +199,7 @@ fn gen_struct_message_impl(this: &(impl ?Sized + Message)) -> Result<ItemImpl> {
                 ::std::result::Result::Ok(())
             }
 
-            fn to_bytes<W: ::std::io::Write>(&self, #[allow(unused)] #out_ident: &mut W) -> self::_puroro::Result<()> {
+            fn to_bytes<W: ::std::io::Write>(&self, #[allow(unused)] #out_ident: &mut W) -> #PURORO_LIB::Result<()> {
                 #[allow(unused)] use #PURORO_INTERNAL::oneof_type::OneofUnion as _;
                 #(#ser_fields)*
                 #(#ser_oneof_stmts)*

--- a/codegen/src/codegen/gen/oneof.rs
+++ b/codegen/src/codegen/gen/oneof.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use super::super::util::*;
-use super::super::{MessageExt, Oneof, OneofField};
+use super::{MessageExt, Oneof, OneofField};
 use super::{OneofFieldExt, PackageOrMessageExt};
 use crate::syn::{
     parse2, Arm, Expr, Field, FieldValue, Ident, ImplItemMethod, Item, ItemImpl, NamedField, Stmt,

--- a/codegen/src/codegen/gen/oneof.rs
+++ b/codegen/src/codegen/gen/oneof.rs
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 use super::super::util::*;
-use super::{MessageExt, Oneof, OneofField, OneofFieldExt, PackageOrMessageExt, PURORO_INTERNAL};
+use super::{
+    MessageExt, Oneof, OneofField, OneofFieldExt, PackageOrMessageExt, PURORO_INTERNAL, PURORO_LIB,
+};
 use crate::syn::{
     parse2, Arm, Expr, Field, FieldValue, Ident, ImplItemMethod, Item, ItemImpl, NamedField, Stmt,
     Type,
@@ -374,7 +376,7 @@ fn gen_oneof_union_impl(this: &(impl ?Sized + Oneof)) -> Result<ItemImpl> {
                 bitvec: &mut B,
                 field_data: #PURORO_INTERNAL::ser::FieldData<I>,
                 case: Self::Case,
-            ) -> self::_puroro::Result<()>
+            ) -> #PURORO_LIB::Result<()>
             where
                 I: ::std::iter::Iterator<Item = ::std::io::Result<u8>>,
                 B: #PURORO_INTERNAL::bitvec::BitSlice,
@@ -389,7 +391,7 @@ fn gen_oneof_union_impl(this: &(impl ?Sized + Oneof)) -> Result<ItemImpl> {
                 Ok(())
             }
 
-            fn ser_to_write<W, B>(&self, bitvec: &B, out: &mut W) -> self::_puroro::Result<()>
+            fn ser_to_write<W, B>(&self, bitvec: &B, out: &mut W) -> #PURORO_LIB::Result<()>
             where
                 W: ::std::io::Write,
                 B: #PURORO_INTERNAL::bitvec::BitSlice

--- a/codegen/src/codegen/gen/oneof.rs
+++ b/codegen/src/codegen/gen/oneof.rs
@@ -225,13 +225,13 @@ impl<T: ?Sized + Oneof> OneofExt for T {
         Ok(vec![
             parse2(quote! {
                 pub fn #getter_ident(&self) -> ::std::option::Option<#getter_type> {
-                    use #PURORO_INTERNAL::oneof_type::OneofUnion as _;
+                    use #PURORO_INTERNAL::OneofUnion as _;
                     self.#field_ident.case_ref(&self._bitfield)
                 }
             })?,
             parse2(quote! {
                 pub fn #clear_ident(&mut self) {
-                    use #PURORO_INTERNAL::oneof_type::OneofUnion as _;
+                    use #PURORO_INTERNAL::OneofUnion as _;
                     self.#field_ident.clear(&mut self._bitfield)
                 }
             })?,
@@ -241,7 +241,7 @@ impl<T: ?Sized + Oneof> OneofExt for T {
     fn gen_struct_impl_clone_field_value(&self) -> Result<FieldValue> {
         let ident = self.gen_struct_field_ident()?;
         Ok(parse2(quote! {
-            #ident: #PURORO_INTERNAL::oneof_type::OneofUnion::clone(&self.#ident, &self._bitfield)
+            #ident: #PURORO_INTERNAL::OneofUnion::clone(&self.#ident, &self._bitfield)
         })?)
     }
 
@@ -320,7 +320,7 @@ fn gen_oneof_union_impl(this: &(impl ?Sized + Oneof)) -> Result<ItemImpl> {
     let bitfield_end = this.bitfield_index_for_oneof()?.1;
 
     Ok(parse2(quote! {
-        impl< #(#generic_params),* > #PURORO_INTERNAL::oneof_type::OneofUnion
+        impl< #(#generic_params),* > #PURORO_INTERNAL::OneofUnion
         for #union_ident< #(#generic_params),* >
         where #( #generic_param_bounds, )*
         {
@@ -330,10 +330,10 @@ fn gen_oneof_union_impl(this: &(impl ?Sized + Oneof)) -> Result<ItemImpl> {
             ),*>
             where Self: 'a;
 
-            fn case_ref<B: #PURORO_INTERNAL::bitvec::BitSlice>(&self, bits: &B)
+            fn case_ref<B: #PURORO_INTERNAL::BitSlice>(&self, bits: &B)
                 -> ::std::option::Option<Self::CaseRef<'_>>
             {
-                use #PURORO_INTERNAL::oneof_type::OneofCase;
+                use #PURORO_INTERNAL::OneofCase;
                 use ::std::mem::ManuallyDrop;
                 use ::std::ops::Deref as _;
                 let case_opt = <self::#case_ident as OneofCase>::from_bitslice(bits);
@@ -346,8 +346,8 @@ fn gen_oneof_union_impl(this: &(impl ?Sized + Oneof)) -> Result<ItemImpl> {
                 })
             }
 
-            fn clear<B: #PURORO_INTERNAL::bitvec::BitSlice>(&mut self, bits: &mut B) {
-                use #PURORO_INTERNAL::oneof_type::OneofCase;
+            fn clear<B: #PURORO_INTERNAL::BitSlice>(&mut self, bits: &mut B) {
+                use #PURORO_INTERNAL::OneofCase;
                 use ::std::mem::ManuallyDrop;
                 #[allow(unused)] use ::std::option::Option::Some;
                 match <self::#case_ident as OneofCase>::from_bitslice(bits) {
@@ -359,8 +359,8 @@ fn gen_oneof_union_impl(this: &(impl ?Sized + Oneof)) -> Result<ItemImpl> {
                 bits.set_range(#bitfield_begin..#bitfield_end, 0);
             }
 
-            fn clone<B: #PURORO_INTERNAL::bitvec::BitSlice>(&self, bits: &B) -> Self {
-                use #PURORO_INTERNAL::oneof_type::OneofCase;
+            fn clone<B: #PURORO_INTERNAL::BitSlice>(&self, bits: &B) -> Self {
+                use #PURORO_INTERNAL::OneofCase;
                 #[allow(unused)] use ::std::option::Option::Some;
                 #[allow(unused)] use ::std::clone::Clone;
                 match <self::#case_ident as OneofCase>::from_bitslice(bits) {
@@ -376,10 +376,11 @@ fn gen_oneof_union_impl(this: &(impl ?Sized + Oneof)) -> Result<ItemImpl> {
                 bitvec: &mut B,
                 field_data: #PURORO_INTERNAL::ser::FieldData<I>,
                 case: Self::Case,
-            ) -> #PURORO_LIB::Result<()>
+            ) -> #PURORO_LIB::Result
+            <()>
             where
                 I: ::std::iter::Iterator<Item = ::std::io::Result<u8>>,
-                B: #PURORO_INTERNAL::bitvec::BitSlice,
+                B: #PURORO_INTERNAL::BitSlice,
             {
                 #[allow(unused)] use ::std::result::Result::Ok;
                 match case {
@@ -394,11 +395,11 @@ fn gen_oneof_union_impl(this: &(impl ?Sized + Oneof)) -> Result<ItemImpl> {
             fn ser_to_write<W, B>(&self, bitvec: &B, out: &mut W) -> #PURORO_LIB::Result<()>
             where
                 W: ::std::io::Write,
-                B: #PURORO_INTERNAL::bitvec::BitSlice
+                B: #PURORO_INTERNAL::BitSlice
             {
                 #[allow(unused)] use ::std::option::Option::Some;
                 #[allow(unused)] use ::std::result::Result::Ok;
-                use #PURORO_INTERNAL::oneof_type::OneofCase as _;
+                use #PURORO_INTERNAL::OneofCase as _;
                 match self::#case_ident::from_bitslice(bitvec) {
                     #(Some(self::#case_ident::#case_names(_)) => {
                         unsafe { &self.#union_field_idents }.ser_to_write(
@@ -422,7 +423,7 @@ fn gen_oneof_case_impl(this: &(impl ?Sized + Oneof)) -> Result<ItemImpl> {
     let bitfield_end = this.bitfield_index_for_oneof()?.1;
 
     Ok(parse2(quote! {
-        impl #PURORO_INTERNAL::oneof_type::OneofCase for #case_ident {
+        impl #PURORO_INTERNAL::OneofCase for #case_ident {
             const BITFIELD_BEGIN: usize = #bitfield_begin;
             const BITFIELD_END: usize = #bitfield_end;
             fn from_u32(x: u32) -> ::std::option::Option<Self> {

--- a/codegen/src/codegen/gen/oneof_field.rs
+++ b/codegen/src/codegen/gen/oneof_field.rs
@@ -15,7 +15,7 @@
 use super::super::util::*;
 use super::field::gen_default_fn;
 use super::PackageOrMessageExt;
-use super::{FieldType, LengthDelimitedType, MessageExt, OneofExt, OneofField};
+use super::{FieldType, LengthDelimitedType, MessageExt, OneofExt, OneofField, PURORO_INTERNAL};
 use crate::syn::{
     parse2, Expr, ExprMethodCall, Field, Ident, ImplItemMethod, Lifetime, NamedField, PathSegment,
     Type,
@@ -147,7 +147,7 @@ impl<T: ?Sized + OneofField> OneofFieldExt for T {
                     })?
                 };
                 Ok(Rc::new(parse2(quote! {
-                    self::_puroro::internal::oneof_field_type:: #inner_type_name_segment
+                    #PURORO_INTERNAL::oneof_field_type:: #inner_type_name_segment
                 })?))
             })
             .cloned()
@@ -178,15 +178,15 @@ impl<T: ?Sized + OneofField> OneofFieldExt for T {
 
         let generic_param_type_ident = self.gen_union_generic_param_ident()?;
         let getter_type: Type = parse2(quote! {
-            <#generic_param_type_ident as self::_puroro::internal::oneof_field_type::OneofFieldType>
+            <#generic_param_type_ident as #PURORO_INTERNAL::oneof_field_type::OneofFieldType>
                 ::GetterOrElseType<'_>
         })?;
         let getter_opt_type: Type = parse2(quote! {
-            <#generic_param_type_ident as self::_puroro::internal::oneof_field_type::OneofFieldType>
+            <#generic_param_type_ident as #PURORO_INTERNAL::oneof_field_type::OneofFieldType>
                 ::GetterOptType<'_>
         })?;
         let getter_mut_type: Type = parse2(quote! {
-            <#generic_param_type_ident as self::_puroro::internal::oneof_field_type::OneofFieldType>
+            <#generic_param_type_ident as #PURORO_INTERNAL::oneof_field_type::OneofFieldType>
                 ::GetterMutType<'_>
         })?;
 
@@ -200,12 +200,12 @@ impl<T: ?Sized + OneofField> OneofFieldExt for T {
 
         Ok(vec![
             parse2(quote! {
-                pub(crate) fn #getter_ident<B: self::_puroro::internal::bitvec::BitSlice>(&self, bits: &B) -> #getter_type {
+                pub(crate) fn #getter_ident<B: #PURORO_INTERNAL::bitvec::BitSlice>(&self, bits: &B) -> #getter_type {
                     #[allow(unused)] use ::std::option::Option::{None, Some};
                     #[allow(unused)] use ::std::default::Default;
-                    use self::_puroro::internal::oneof_field_type::OneofFieldType;
+                    use #PURORO_INTERNAL::oneof_field_type::OneofFieldType;
                     use ::std::ops::Deref as _;
-                    use self::_puroro::internal::oneof_type::OneofCase as _;
+                    use #PURORO_INTERNAL::oneof_type::OneofCase as _;
 
                     let case_opt = self::#case_ident::from_bitslice(bits);
                     let field_opt = matches!(case_opt, Some(self::#case_ident::#enum_item_ident(()))).then(|| {
@@ -217,11 +217,11 @@ impl<T: ?Sized + OneofField> OneofFieldExt for T {
                 }
             })?,
             parse2(quote! {
-                pub(crate) fn #getter_opt_ident<B: self::_puroro::internal::bitvec::BitSlice>(&self, bits: &B) -> #getter_opt_type {
+                pub(crate) fn #getter_opt_ident<B: #PURORO_INTERNAL::bitvec::BitSlice>(&self, bits: &B) -> #getter_opt_type {
                     #[allow(unused)] use ::std::option::Option::{None, Some};
-                    use self::_puroro::internal::oneof_field_type::OneofFieldType;
+                    use #PURORO_INTERNAL::oneof_field_type::OneofFieldType;
                     use ::std::ops::Deref as _;
-                    use self::_puroro::internal::oneof_type::OneofCase as _;
+                    use #PURORO_INTERNAL::oneof_type::OneofCase as _;
 
                     let case_opt = self::#case_ident::from_bitslice(bits);
                     let field_opt = matches!(case_opt, Some(self::#case_ident::#enum_item_ident(()))).then(|| {
@@ -233,13 +233,13 @@ impl<T: ?Sized + OneofField> OneofFieldExt for T {
                 }
             })?,
             parse2(quote! {
-                pub(crate) fn #getter_mut_ident<B: self::_puroro::internal::bitvec::BitSlice>(&mut self, bits: &mut B) -> #getter_mut_type {
+                pub(crate) fn #getter_mut_ident<B: #PURORO_INTERNAL::bitvec::BitSlice>(&mut self, bits: &mut B) -> #getter_mut_type {
                     #[allow(unused)] use ::std::option::Option::Some;
                     #[allow(unused)] use ::std::default::Default;
                     use ::std::mem::ManuallyDrop;
                     use ::std::ops::DerefMut as _;
-                    use self::_puroro::internal::oneof_type::{OneofCase as _, OneofUnion};
-                    use self::_puroro::internal::oneof_field_type::OneofFieldType;
+                    use #PURORO_INTERNAL::oneof_type::{OneofCase as _, OneofUnion};
+                    use #PURORO_INTERNAL::oneof_field_type::OneofFieldType;
 
                     let case_opt = self::#case_ident::from_bitslice(bits);
                     if let Some(self::#case_ident::#enum_item_ident(())) = case_opt {
@@ -314,8 +314,8 @@ impl<T: ?Sized + OneofField> OneofFieldExt for T {
             parse2(quote! {
                 pub fn #clear_ident(&mut self) {
                     #[allow(unused)] use ::std::option::Option::Some;
-                    use self::_puroro::internal::oneof_type::OneofCase;
-                    use self::_puroro::internal::oneof_type::OneofUnion;
+                    use #PURORO_INTERNAL::oneof_type::OneofCase;
+                    use #PURORO_INTERNAL::oneof_type::OneofUnion;
                     if let Some(#case_path::#enum_item_ident(_)) = OneofCase::from_bitslice(&self._bitfield) {
                         self.#oneof_struct_field_ident.clear(&mut self._bitfield)
                     }

--- a/codegen/src/codegen/gen/oneof_field.rs
+++ b/codegen/src/codegen/gen/oneof_field.rs
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 use super::super::util::*;
-use super::super::{FieldType, LengthDelimitedType, MessageExt, OneofExt, OneofField};
 use super::field::gen_default_fn;
 use super::PackageOrMessageExt;
+use super::{FieldType, LengthDelimitedType, MessageExt, OneofExt, OneofField};
 use crate::syn::{
     parse2, Expr, ExprMethodCall, Field, Ident, ImplItemMethod, Lifetime, NamedField, PathSegment,
     Type,

--- a/codegen/src/codegen/gen/oneof_field.rs
+++ b/codegen/src/codegen/gen/oneof_field.rs
@@ -125,7 +125,7 @@ impl<T: ?Sized + OneofField> OneofFieldExt for T {
             .get_or_try_init(|| {
                 let ident = self.gen_union_generic_param_ident()?;
                 Ok(Rc::new(quote! {
-                    #ident: #PURORO_INTERNAL::oneof_field_type::OneofFieldType
+                    #ident: #PURORO_INTERNAL::OneofFieldType
                 }))
             })
             .cloned()
@@ -170,7 +170,7 @@ impl<T: ?Sized + OneofField> OneofFieldExt for T {
                     })?
                 };
                 Ok(Rc::new(parse2(quote! {
-                    #PURORO_INTERNAL::oneof_field_type:: #inner_type_name_segment
+                    #PURORO_INTERNAL:: #inner_type_name_segment
                 })?))
             })
             .cloned()
@@ -201,15 +201,15 @@ impl<T: ?Sized + OneofField> OneofFieldExt for T {
 
         let generic_param_type_ident = self.gen_union_generic_param_ident()?;
         let getter_type: Type = parse2(quote! {
-            <#generic_param_type_ident as #PURORO_INTERNAL::oneof_field_type::OneofFieldType>
+            <#generic_param_type_ident as #PURORO_INTERNAL::OneofFieldType>
                 ::GetterOrElseType<'_>
         })?;
         let getter_opt_type: Type = parse2(quote! {
-            <#generic_param_type_ident as #PURORO_INTERNAL::oneof_field_type::OneofFieldType>
+            <#generic_param_type_ident as #PURORO_INTERNAL::OneofFieldType>
                 ::GetterOptType<'_>
         })?;
         let getter_mut_type: Type = parse2(quote! {
-            <#generic_param_type_ident as #PURORO_INTERNAL::oneof_field_type::OneofFieldType>
+            <#generic_param_type_ident as #PURORO_INTERNAL::OneofFieldType>
                 ::GetterMutType<'_>
         })?;
 
@@ -223,12 +223,12 @@ impl<T: ?Sized + OneofField> OneofFieldExt for T {
 
         Ok(vec![
             parse2(quote! {
-                pub(crate) fn #getter_ident<B: #PURORO_INTERNAL::bitvec::BitSlice>(&self, bits: &B) -> #getter_type {
+                pub(crate) fn #getter_ident<B: #PURORO_INTERNAL::BitSlice>(&self, bits: &B) -> #getter_type {
                     #[allow(unused)] use ::std::option::Option::{None, Some};
                     #[allow(unused)] use ::std::default::Default;
-                    use #PURORO_INTERNAL::oneof_field_type::OneofFieldType;
+                    use #PURORO_INTERNAL::OneofFieldType;
                     use ::std::ops::Deref as _;
-                    use #PURORO_INTERNAL::oneof_type::OneofCase as _;
+                    use #PURORO_INTERNAL::OneofCase as _;
 
                     let case_opt = self::#case_ident::from_bitslice(bits);
                     let field_opt = matches!(case_opt, Some(self::#case_ident::#enum_item_ident(()))).then(|| {
@@ -240,11 +240,11 @@ impl<T: ?Sized + OneofField> OneofFieldExt for T {
                 }
             })?,
             parse2(quote! {
-                pub(crate) fn #getter_opt_ident<B: #PURORO_INTERNAL::bitvec::BitSlice>(&self, bits: &B) -> #getter_opt_type {
+                pub(crate) fn #getter_opt_ident<B: #PURORO_INTERNAL::BitSlice>(&self, bits: &B) -> #getter_opt_type {
                     #[allow(unused)] use ::std::option::Option::{None, Some};
-                    use #PURORO_INTERNAL::oneof_field_type::OneofFieldType;
+                    use #PURORO_INTERNAL::OneofFieldType;
                     use ::std::ops::Deref as _;
-                    use #PURORO_INTERNAL::oneof_type::OneofCase as _;
+                    use #PURORO_INTERNAL::OneofCase as _;
 
                     let case_opt = self::#case_ident::from_bitslice(bits);
                     let field_opt = matches!(case_opt, Some(self::#case_ident::#enum_item_ident(()))).then(|| {
@@ -256,13 +256,13 @@ impl<T: ?Sized + OneofField> OneofFieldExt for T {
                 }
             })?,
             parse2(quote! {
-                pub(crate) fn #getter_mut_ident<B: #PURORO_INTERNAL::bitvec::BitSlice>(&mut self, bits: &mut B) -> #getter_mut_type {
+                pub(crate) fn #getter_mut_ident<B: #PURORO_INTERNAL::BitSlice>(&mut self, bits: &mut B) -> #getter_mut_type {
                     #[allow(unused)] use ::std::option::Option::Some;
                     #[allow(unused)] use ::std::default::Default;
                     use ::std::mem::ManuallyDrop;
                     use ::std::ops::DerefMut as _;
-                    use #PURORO_INTERNAL::oneof_type::{OneofCase as _, OneofUnion};
-                    use #PURORO_INTERNAL::oneof_field_type::OneofFieldType;
+                    use #PURORO_INTERNAL::{OneofCase as _, OneofUnion};
+                    use #PURORO_INTERNAL::OneofFieldType;
 
                     let case_opt = self::#case_ident::from_bitslice(bits);
                     if let Some(self::#case_ident::#enum_item_ident(())) = case_opt {
@@ -337,8 +337,8 @@ impl<T: ?Sized + OneofField> OneofFieldExt for T {
             parse2(quote! {
                 pub fn #clear_ident(&mut self) {
                     #[allow(unused)] use ::std::option::Option::Some;
-                    use #PURORO_INTERNAL::oneof_type::OneofCase;
-                    use #PURORO_INTERNAL::oneof_type::OneofUnion;
+                    use #PURORO_INTERNAL::OneofCase;
+                    use #PURORO_INTERNAL::OneofUnion;
                     if let Some(#case_path::#enum_item_ident(_)) = OneofCase::from_bitslice(&self._bitfield) {
                         self.#oneof_struct_field_ident.clear(&mut self._bitfield)
                     }

--- a/codegen/src/codegen/gen/package_or_message.rs
+++ b/codegen/src/codegen/gen/package_or_message.rs
@@ -14,8 +14,8 @@
 
 use super::super::util::*;
 use super::{
-    EnumExt, MessageExt, OneofExt, PackageOrMessage, PURORO_INTERNAL_IDENT, PURORO_ROOT,
-    PURORO_ROOT_IDENT,
+    EnumExt, MessageExt, OneofExt, PackageOrMessage, PURORO_INTERNAL_IDENT, PURORO_LIB_IDENT,
+    PURORO_ROOT, PURORO_ROOT_IDENT,
 };
 use crate::syn::{parse2, File, Item, Path};
 use crate::Result;
@@ -162,7 +162,7 @@ impl<T: ?Sized + PackageOrMessage> PackageOrMessageExt for T {
         let content_items = gen_messages_enums_oneofs_in_module(self)?;
         Ok(parse2(quote! {
             #header
-            mod _puroro {
+            mod #PURORO_LIB_IDENT {
                 #[allow(unused)]
                 pub(crate) use ::puroro::*;
             }
@@ -228,7 +228,7 @@ impl<T: ?Sized + PackageOrMessage> PackageOrMessageExt for T {
 
         Ok(quote! {
             #header
-            mod _puroro {
+            mod #PURORO_LIB_IDENT {
                 #[allow(unused)]
                 pub(crate) use ::puroro::*;
             }

--- a/codegen/src/codegen/gen/package_or_message.rs
+++ b/codegen/src/codegen/gen/package_or_message.rs
@@ -13,8 +13,7 @@
 // limitations under the License.
 
 use super::super::util::*;
-use super::super::{EnumExt, MessageExt, PackageOrMessage};
-use super::OneofExt;
+use super::{EnumExt, MessageExt, OneofExt, PackageOrMessage};
 use crate::syn::{parse2, File, Item, Path};
 use crate::Result;
 use ::itertools::Itertools;

--- a/puroro-doc-samples/src/lib.rs
+++ b/puroro-doc-samples/src/lib.rs
@@ -3,12 +3,16 @@ pub use ::puroro;
 /// re-export the primitive types in puroro namespace.
 /// by using the "*", it can be hidden by the same typename explicitly defined in this file.
 pub use ::puroro::*;
-mod _puroro_root {
+mod _root {
     #[allow(unused)]
     pub(crate) use super::*;
 }
 mod _puroro {
     #[allow(unused)]
     pub(crate) use ::puroro::*;
+}
+mod _pinternal {
+    #[allow(unused)]
+    pub(crate) use ::puroro::internal::*;
 }
 pub mod library;

--- a/puroro-doc-samples/src/library.rs
+++ b/puroro-doc-samples/src/library.rs
@@ -1,32 +1,36 @@
-mod _puroro_root {
+mod _root {
     #[allow(unused)]
-    pub(crate) use super::super::_puroro_root::*;
+    pub(crate) use super::super::_root::*;
 }
 mod _puroro {
     #[allow(unused)]
     pub(crate) use ::puroro::*;
 }
+mod _pinternal {
+    #[allow(unused)]
+    pub(crate) use ::puroro::internal::*;
+}
 #[derive(::std::default::Default)]
 pub struct Book {
-    title: self::_puroro::internal::field_type::SingularUnsizedField::<
+    title: self::_pinternal::field_type::SingularUnsizedField::<
         ::std::string::String,
-        self::_puroro::internal::tags::String,
+        self::_pinternal::tags::String,
     >,
-    num_pages: self::_puroro::internal::field_type::SingularNumericalField::<
+    num_pages: self::_pinternal::field_type::SingularNumericalField::<
         u32,
-        self::_puroro::internal::tags::UInt32,
+        self::_pinternal::tags::UInt32,
     >,
-    author: self::_puroro::internal::field_type::SingularHeapMessageField::<
-        self::_puroro_root::library::Author,
+    author: self::_pinternal::field_type::SingularHeapMessageField::<
+        self::_root::library::Author,
     >,
-    _bitfield: self::_puroro::internal::bitvec::BitArray<0usize>,
+    _bitfield: self::_pinternal::bitvec::BitArray<0usize>,
 }
 impl Book {
     pub fn title(&self) -> &str {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.title,
             &self._bitfield,
@@ -34,17 +38,17 @@ impl Book {
         )
     }
     pub fn title_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
         > as NonRepeatedFieldType>::get_field_opt(&self.title, &self._bitfield)
     }
     pub fn title_mut(&mut self) -> &mut ::std::string::String {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.title,
             &mut self._bitfield,
@@ -52,25 +56,25 @@ impl Book {
         )
     }
     pub fn has_title(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
         > as NonRepeatedFieldType>::get_field_opt(&self.title, &self._bitfield)
             .is_some()
     }
     pub fn clear_title(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
         > as NonRepeatedFieldType>::clear(&mut self.title, &mut self._bitfield)
     }
     pub fn num_pages(&self) -> u32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             u32,
-            self::_puroro::internal::tags::UInt32,
+            self::_pinternal::tags::UInt32,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.num_pages,
             &self._bitfield,
@@ -78,17 +82,17 @@ impl Book {
         )
     }
     pub fn num_pages_opt(&self) -> ::std::option::Option::<u32> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             u32,
-            self::_puroro::internal::tags::UInt32,
+            self::_pinternal::tags::UInt32,
         > as NonRepeatedFieldType>::get_field_opt(&self.num_pages, &self._bitfield)
     }
     pub fn num_pages_mut(&mut self) -> &mut u32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             u32,
-            self::_puroro::internal::tags::UInt32,
+            self::_pinternal::tags::UInt32,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.num_pages,
             &mut self._bitfield,
@@ -96,44 +100,40 @@ impl Book {
         )
     }
     pub fn has_num_pages(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             u32,
-            self::_puroro::internal::tags::UInt32,
+            self::_pinternal::tags::UInt32,
         > as NonRepeatedFieldType>::get_field_opt(&self.num_pages, &self._bitfield)
             .is_some()
     }
     pub fn clear_num_pages(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             u32,
-            self::_puroro::internal::tags::UInt32,
+            self::_pinternal::tags::UInt32,
         > as NonRepeatedFieldType>::clear(&mut self.num_pages, &mut self._bitfield)
     }
-    pub fn author(
-        &self,
-    ) -> ::std::option::Option::<&self::_puroro_root::library::Author> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::library::Author,
+    pub fn author(&self) -> ::std::option::Option::<&self::_root::library::Author> {
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::library::Author,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.author,
             &self._bitfield,
             ::std::default::Default::default,
         )
     }
-    pub fn author_opt(
-        &self,
-    ) -> ::std::option::Option::<&self::_puroro_root::library::Author> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::library::Author,
+    pub fn author_opt(&self) -> ::std::option::Option::<&self::_root::library::Author> {
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::library::Author,
         > as NonRepeatedFieldType>::get_field_opt(&self.author, &self._bitfield)
     }
-    pub fn author_mut(&mut self) -> &mut self::_puroro_root::library::Author {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::library::Author,
+    pub fn author_mut(&mut self) -> &mut self::_root::library::Author {
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::library::Author,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.author,
             &mut self._bitfield,
@@ -141,16 +141,16 @@ impl Book {
         )
     }
     pub fn has_author(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::library::Author,
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::library::Author,
         > as NonRepeatedFieldType>::get_field_opt(&self.author, &self._bitfield)
             .is_some()
     }
     pub fn clear_author(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::library::Author,
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::library::Author,
         > as NonRepeatedFieldType>::clear(&mut self.author, &mut self._bitfield)
     }
 }
@@ -166,36 +166,36 @@ impl self::_puroro::Message for Book {
         &mut self,
         mut iter: I,
     ) -> self::_puroro::Result<()> {
-        use self::_puroro::internal::ser::FieldData;
+        use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 1i32 => {
-                    <self::_puroro::internal::field_type::SingularUnsizedField::<
+                    <self::_pinternal::field_type::SingularUnsizedField::<
                         ::std::string::String,
-                        self::_puroro::internal::tags::String,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                        self::_pinternal::tags::String,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.title,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 2i32 => {
-                    <self::_puroro::internal::field_type::SingularNumericalField::<
+                    <self::_pinternal::field_type::SingularNumericalField::<
                         u32,
-                        self::_puroro::internal::tags::UInt32,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                        self::_pinternal::tags::UInt32,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.num_pages,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 3i32 => {
-                    <self::_puroro::internal::field_type::SingularHeapMessageField::<
-                        self::_puroro_root::library::Author,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    <self::_pinternal::field_type::SingularHeapMessageField::<
+                        self::_root::library::Author,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.author,
                         &mut self._bitfield,
                         field_data,
@@ -212,28 +212,28 @@ impl self::_puroro::Message for Book {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
-        <self::_puroro::internal::field_type::SingularUnsizedField::<
+        use self::_pinternal::oneof_type::OneofUnion as _;
+        <self::_pinternal::field_type::SingularUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+            self::_pinternal::tags::String,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.title,
             &self._bitfield,
             1i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        <self::_pinternal::field_type::SingularNumericalField::<
             u32,
-            self::_puroro::internal::tags::UInt32,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+            self::_pinternal::tags::UInt32,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.num_pages,
             &self._bitfield,
             2i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::library::Author,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::library::Author,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.author,
             &self._bitfield,
             3i32,
@@ -245,16 +245,16 @@ impl self::_puroro::Message for Book {
 impl ::std::clone::Clone for Book {
     fn clone(&self) -> Self {
         Self {
-            title: <self::_puroro::internal::field_type::SingularUnsizedField::<
+            title: <self::_pinternal::field_type::SingularUnsizedField::<
                 ::std::string::String,
-                self::_puroro::internal::tags::String,
+                self::_pinternal::tags::String,
             > as ::std::clone::Clone>::clone(&self.title),
-            num_pages: <self::_puroro::internal::field_type::SingularNumericalField::<
+            num_pages: <self::_pinternal::field_type::SingularNumericalField::<
                 u32,
-                self::_puroro::internal::tags::UInt32,
+                self::_pinternal::tags::UInt32,
             > as ::std::clone::Clone>::clone(&self.num_pages),
-            author: <self::_puroro::internal::field_type::SingularHeapMessageField::<
-                self::_puroro_root::library::Author,
+            author: <self::_pinternal::field_type::SingularHeapMessageField::<
+                self::_root::library::Author,
             > as ::std::clone::Clone>::clone(&self.author),
             _bitfield: ::std::clone::Clone::clone(&self._bitfield),
         }
@@ -263,7 +263,7 @@ impl ::std::clone::Clone for Book {
 impl ::std::ops::Drop for Book {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for Book {
@@ -281,7 +281,7 @@ impl ::std::fmt::Debug for Book {
 impl ::std::cmp::PartialEq for Book {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         true && self.title_opt() == rhs.title_opt()
             && self.num_pages_opt() == rhs.num_pages_opt()
             && self.author_opt() == rhs.author_opt()
@@ -289,18 +289,18 @@ impl ::std::cmp::PartialEq for Book {
 }
 #[derive(::std::default::Default)]
 pub struct Author {
-    name: self::_puroro::internal::field_type::SingularUnsizedField::<
+    name: self::_pinternal::field_type::SingularUnsizedField::<
         ::std::string::String,
-        self::_puroro::internal::tags::String,
+        self::_pinternal::tags::String,
     >,
-    _bitfield: self::_puroro::internal::bitvec::BitArray<0usize>,
+    _bitfield: self::_pinternal::bitvec::BitArray<0usize>,
 }
 impl Author {
     pub fn name(&self) -> &str {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.name,
             &self._bitfield,
@@ -308,17 +308,17 @@ impl Author {
         )
     }
     pub fn name_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
         > as NonRepeatedFieldType>::get_field_opt(&self.name, &self._bitfield)
     }
     pub fn name_mut(&mut self) -> &mut ::std::string::String {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.name,
             &mut self._bitfield,
@@ -326,18 +326,18 @@ impl Author {
         )
     }
     pub fn has_name(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
         > as NonRepeatedFieldType>::get_field_opt(&self.name, &self._bitfield)
             .is_some()
     }
     pub fn clear_name(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
         > as NonRepeatedFieldType>::clear(&mut self.name, &mut self._bitfield)
     }
 }
@@ -353,17 +353,17 @@ impl self::_puroro::Message for Author {
         &mut self,
         mut iter: I,
     ) -> self::_puroro::Result<()> {
-        use self::_puroro::internal::ser::FieldData;
+        use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 1i32 => {
-                    <self::_puroro::internal::field_type::SingularUnsizedField::<
+                    <self::_pinternal::field_type::SingularUnsizedField::<
                         ::std::string::String,
-                        self::_puroro::internal::tags::String,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                        self::_pinternal::tags::String,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.name,
                         &mut self._bitfield,
                         field_data,
@@ -380,11 +380,11 @@ impl self::_puroro::Message for Author {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
-        <self::_puroro::internal::field_type::SingularUnsizedField::<
+        use self::_pinternal::oneof_type::OneofUnion as _;
+        <self::_pinternal::field_type::SingularUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+            self::_pinternal::tags::String,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.name,
             &self._bitfield,
             1i32,
@@ -396,9 +396,9 @@ impl self::_puroro::Message for Author {
 impl ::std::clone::Clone for Author {
     fn clone(&self) -> Self {
         Self {
-            name: <self::_puroro::internal::field_type::SingularUnsizedField::<
+            name: <self::_pinternal::field_type::SingularUnsizedField::<
                 ::std::string::String,
-                self::_puroro::internal::tags::String,
+                self::_pinternal::tags::String,
             > as ::std::clone::Clone>::clone(&self.name),
             _bitfield: ::std::clone::Clone::clone(&self._bitfield),
         }
@@ -407,7 +407,7 @@ impl ::std::clone::Clone for Author {
 impl ::std::ops::Drop for Author {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for Author {
@@ -423,7 +423,7 @@ impl ::std::fmt::Debug for Author {
 impl ::std::cmp::PartialEq for Author {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         true && self.name_opt() == rhs.name_opt()
     }
 }

--- a/puroro-doc-samples/src/library.rs
+++ b/puroro-doc-samples/src/library.rs
@@ -12,23 +12,21 @@ mod _pinternal {
 }
 #[derive(::std::default::Default)]
 pub struct Book {
-    title: self::_pinternal::field_type::SingularUnsizedField::<
+    title: self::_pinternal::SingularUnsizedField::<
         ::std::string::String,
         self::_pinternal::tags::String,
     >,
-    num_pages: self::_pinternal::field_type::SingularNumericalField::<
+    num_pages: self::_pinternal::SingularNumericalField::<
         u32,
         self::_pinternal::tags::UInt32,
     >,
-    author: self::_pinternal::field_type::SingularHeapMessageField::<
-        self::_root::library::Author,
-    >,
-    _bitfield: self::_pinternal::bitvec::BitArray<0usize>,
+    author: self::_pinternal::SingularHeapMessageField::<self::_root::library::Author>,
+    _bitfield: self::_pinternal::BitArray<0usize>,
 }
 impl Book {
     pub fn title(&self) -> &str {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
         > as NonRepeatedFieldType>::get_field_or_else(
@@ -38,15 +36,15 @@ impl Book {
         )
     }
     pub fn title_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
         > as NonRepeatedFieldType>::get_field_opt(&self.title, &self._bitfield)
     }
     pub fn title_mut(&mut self) -> &mut ::std::string::String {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
         > as NonRepeatedFieldType>::get_field_mut(
@@ -56,23 +54,23 @@ impl Book {
         )
     }
     pub fn has_title(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
         > as NonRepeatedFieldType>::get_field_opt(&self.title, &self._bitfield)
             .is_some()
     }
     pub fn clear_title(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
         > as NonRepeatedFieldType>::clear(&mut self.title, &mut self._bitfield)
     }
     pub fn num_pages(&self) -> u32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             u32,
             self::_pinternal::tags::UInt32,
         > as NonRepeatedFieldType>::get_field_or_else(
@@ -82,15 +80,15 @@ impl Book {
         )
     }
     pub fn num_pages_opt(&self) -> ::std::option::Option::<u32> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             u32,
             self::_pinternal::tags::UInt32,
         > as NonRepeatedFieldType>::get_field_opt(&self.num_pages, &self._bitfield)
     }
     pub fn num_pages_mut(&mut self) -> &mut u32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             u32,
             self::_pinternal::tags::UInt32,
         > as NonRepeatedFieldType>::get_field_mut(
@@ -100,23 +98,23 @@ impl Book {
         )
     }
     pub fn has_num_pages(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             u32,
             self::_pinternal::tags::UInt32,
         > as NonRepeatedFieldType>::get_field_opt(&self.num_pages, &self._bitfield)
             .is_some()
     }
     pub fn clear_num_pages(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             u32,
             self::_pinternal::tags::UInt32,
         > as NonRepeatedFieldType>::clear(&mut self.num_pages, &mut self._bitfield)
     }
     pub fn author(&self) -> ::std::option::Option::<&self::_root::library::Author> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::library::Author,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.author,
@@ -125,14 +123,14 @@ impl Book {
         )
     }
     pub fn author_opt(&self) -> ::std::option::Option::<&self::_root::library::Author> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::library::Author,
         > as NonRepeatedFieldType>::get_field_opt(&self.author, &self._bitfield)
     }
     pub fn author_mut(&mut self) -> &mut self::_root::library::Author {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::library::Author,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.author,
@@ -141,15 +139,15 @@ impl Book {
         )
     }
     pub fn has_author(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::library::Author,
         > as NonRepeatedFieldType>::get_field_opt(&self.author, &self._bitfield)
             .is_some()
     }
     pub fn clear_author(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::library::Author,
         > as NonRepeatedFieldType>::clear(&mut self.author, &mut self._bitfield)
     }
@@ -168,34 +166,34 @@ impl self::_puroro::Message for Book {
     ) -> self::_puroro::Result<()> {
         use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 1i32 => {
-                    <self::_pinternal::field_type::SingularUnsizedField::<
+                    <self::_pinternal::SingularUnsizedField::<
                         ::std::string::String,
                         self::_pinternal::tags::String,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.title,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 2i32 => {
-                    <self::_pinternal::field_type::SingularNumericalField::<
+                    <self::_pinternal::SingularNumericalField::<
                         u32,
                         self::_pinternal::tags::UInt32,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.num_pages,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 3i32 => {
-                    <self::_pinternal::field_type::SingularHeapMessageField::<
+                    <self::_pinternal::SingularHeapMessageField::<
                         self::_root::library::Author,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.author,
                         &mut self._bitfield,
                         field_data,
@@ -212,28 +210,28 @@ impl self::_puroro::Message for Book {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
-        <self::_pinternal::field_type::SingularUnsizedField::<
+        use self::_pinternal::OneofUnion as _;
+        <self::_pinternal::SingularUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.title,
             &self._bitfield,
             1i32,
             out,
         )?;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        <self::_pinternal::SingularNumericalField::<
             u32,
             self::_pinternal::tags::UInt32,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.num_pages,
             &self._bitfield,
             2i32,
             out,
         )?;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::library::Author,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.author,
             &self._bitfield,
             3i32,
@@ -245,15 +243,15 @@ impl self::_puroro::Message for Book {
 impl ::std::clone::Clone for Book {
     fn clone(&self) -> Self {
         Self {
-            title: <self::_pinternal::field_type::SingularUnsizedField::<
+            title: <self::_pinternal::SingularUnsizedField::<
                 ::std::string::String,
                 self::_pinternal::tags::String,
             > as ::std::clone::Clone>::clone(&self.title),
-            num_pages: <self::_pinternal::field_type::SingularNumericalField::<
+            num_pages: <self::_pinternal::SingularNumericalField::<
                 u32,
                 self::_pinternal::tags::UInt32,
             > as ::std::clone::Clone>::clone(&self.num_pages),
-            author: <self::_pinternal::field_type::SingularHeapMessageField::<
+            author: <self::_pinternal::SingularHeapMessageField::<
                 self::_root::library::Author,
             > as ::std::clone::Clone>::clone(&self.author),
             _bitfield: ::std::clone::Clone::clone(&self._bitfield),
@@ -263,7 +261,7 @@ impl ::std::clone::Clone for Book {
 impl ::std::ops::Drop for Book {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for Book {
@@ -281,7 +279,7 @@ impl ::std::fmt::Debug for Book {
 impl ::std::cmp::PartialEq for Book {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         true && self.title_opt() == rhs.title_opt()
             && self.num_pages_opt() == rhs.num_pages_opt()
             && self.author_opt() == rhs.author_opt()
@@ -289,16 +287,16 @@ impl ::std::cmp::PartialEq for Book {
 }
 #[derive(::std::default::Default)]
 pub struct Author {
-    name: self::_pinternal::field_type::SingularUnsizedField::<
+    name: self::_pinternal::SingularUnsizedField::<
         ::std::string::String,
         self::_pinternal::tags::String,
     >,
-    _bitfield: self::_pinternal::bitvec::BitArray<0usize>,
+    _bitfield: self::_pinternal::BitArray<0usize>,
 }
 impl Author {
     pub fn name(&self) -> &str {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
         > as NonRepeatedFieldType>::get_field_or_else(
@@ -308,15 +306,15 @@ impl Author {
         )
     }
     pub fn name_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
         > as NonRepeatedFieldType>::get_field_opt(&self.name, &self._bitfield)
     }
     pub fn name_mut(&mut self) -> &mut ::std::string::String {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
         > as NonRepeatedFieldType>::get_field_mut(
@@ -326,16 +324,16 @@ impl Author {
         )
     }
     pub fn has_name(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
         > as NonRepeatedFieldType>::get_field_opt(&self.name, &self._bitfield)
             .is_some()
     }
     pub fn clear_name(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
         > as NonRepeatedFieldType>::clear(&mut self.name, &mut self._bitfield)
@@ -355,15 +353,15 @@ impl self::_puroro::Message for Author {
     ) -> self::_puroro::Result<()> {
         use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 1i32 => {
-                    <self::_pinternal::field_type::SingularUnsizedField::<
+                    <self::_pinternal::SingularUnsizedField::<
                         ::std::string::String,
                         self::_pinternal::tags::String,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.name,
                         &mut self._bitfield,
                         field_data,
@@ -380,11 +378,11 @@ impl self::_puroro::Message for Author {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
-        <self::_pinternal::field_type::SingularUnsizedField::<
+        use self::_pinternal::OneofUnion as _;
+        <self::_pinternal::SingularUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.name,
             &self._bitfield,
             1i32,
@@ -396,7 +394,7 @@ impl self::_puroro::Message for Author {
 impl ::std::clone::Clone for Author {
     fn clone(&self) -> Self {
         Self {
-            name: <self::_pinternal::field_type::SingularUnsizedField::<
+            name: <self::_pinternal::SingularUnsizedField::<
                 ::std::string::String,
                 self::_pinternal::tags::String,
             > as ::std::clone::Clone>::clone(&self.name),
@@ -407,7 +405,7 @@ impl ::std::clone::Clone for Author {
 impl ::std::ops::Drop for Author {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for Author {
@@ -423,7 +421,7 @@ impl ::std::fmt::Debug for Author {
 impl ::std::cmp::PartialEq for Author {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         true && self.name_opt() == rhs.name_opt()
     }
 }

--- a/puroro-protobuf-compiled/src/google.rs
+++ b/puroro-protobuf-compiled/src/google.rs
@@ -1,9 +1,13 @@
-mod _puroro_root {
+mod _root {
     #[allow(unused)]
-    pub(crate) use super::super::_puroro_root::*;
+    pub(crate) use super::super::_root::*;
 }
 mod _puroro {
     #[allow(unused)]
     pub(crate) use ::puroro::*;
+}
+mod _pinternal {
+    #[allow(unused)]
+    pub(crate) use ::puroro::internal::*;
 }
 pub mod protobuf;

--- a/puroro-protobuf-compiled/src/google/protobuf.rs
+++ b/puroro-protobuf-compiled/src/google/protobuf.rs
@@ -1,10 +1,14 @@
-mod _puroro_root {
+mod _root {
     #[allow(unused)]
-    pub(crate) use super::super::_puroro_root::*;
+    pub(crate) use super::super::_root::*;
 }
 mod _puroro {
     #[allow(unused)]
     pub(crate) use ::puroro::*;
+}
+mod _pinternal {
+    #[allow(unused)]
+    pub(crate) use ::puroro::internal::*;
 }
 pub mod compiler;
 pub mod descriptor_proto;
@@ -18,32 +22,30 @@ pub mod source_code_info;
 pub mod uninterpreted_option;
 #[derive(::std::default::Default)]
 pub struct FileDescriptorSet {
-    file: self::_puroro::internal::field_type::RepeatedMessageField::<
-        self::_puroro_root::google::protobuf::FileDescriptorProto,
+    file: self::_pinternal::field_type::RepeatedMessageField::<
+        self::_root::google::protobuf::FileDescriptorProto,
     >,
-    _bitfield: self::_puroro::internal::bitvec::BitArray<0usize>,
+    _bitfield: self::_pinternal::bitvec::BitArray<0usize>,
 }
 impl FileDescriptorSet {
-    pub fn file(&self) -> &[self::_puroro_root::google::protobuf::FileDescriptorProto] {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::FileDescriptorProto,
+    pub fn file(&self) -> &[self::_root::google::protobuf::FileDescriptorProto] {
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::FileDescriptorProto,
         > as RepeatedFieldType>::get_field(&self.file, &self._bitfield)
     }
     pub fn file_mut(
         &mut self,
-    ) -> &mut ::std::vec::Vec::<
-        self::_puroro_root::google::protobuf::FileDescriptorProto,
-    > {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::FileDescriptorProto,
+    ) -> &mut ::std::vec::Vec::<self::_root::google::protobuf::FileDescriptorProto> {
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::FileDescriptorProto,
         > as RepeatedFieldType>::get_field_mut(&mut self.file, &mut self._bitfield)
     }
     pub fn clear_file(&mut self) {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::FileDescriptorProto,
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::FileDescriptorProto,
         > as RepeatedFieldType>::clear(&mut self.file, &mut self._bitfield)
     }
 }
@@ -59,16 +61,16 @@ impl self::_puroro::Message for FileDescriptorSet {
         &mut self,
         mut iter: I,
     ) -> self::_puroro::Result<()> {
-        use self::_puroro::internal::ser::FieldData;
+        use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 1i32 => {
-                    <self::_puroro::internal::field_type::RepeatedMessageField::<
-                        self::_puroro_root::google::protobuf::FileDescriptorProto,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    <self::_pinternal::field_type::RepeatedMessageField::<
+                        self::_root::google::protobuf::FileDescriptorProto,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.file,
                         &mut self._bitfield,
                         field_data,
@@ -85,10 +87,10 @@ impl self::_puroro::Message for FileDescriptorSet {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::FileDescriptorProto,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        use self::_pinternal::oneof_type::OneofUnion as _;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::FileDescriptorProto,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.file,
             &self._bitfield,
             1i32,
@@ -100,8 +102,8 @@ impl self::_puroro::Message for FileDescriptorSet {
 impl ::std::clone::Clone for FileDescriptorSet {
     fn clone(&self) -> Self {
         Self {
-            file: <self::_puroro::internal::field_type::RepeatedMessageField::<
-                self::_puroro_root::google::protobuf::FileDescriptorProto,
+            file: <self::_pinternal::field_type::RepeatedMessageField::<
+                self::_root::google::protobuf::FileDescriptorProto,
             > as ::std::clone::Clone>::clone(&self.file),
             _bitfield: ::std::clone::Clone::clone(&self._bitfield),
         }
@@ -110,7 +112,7 @@ impl ::std::clone::Clone for FileDescriptorSet {
 impl ::std::ops::Drop for FileDescriptorSet {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for FileDescriptorSet {
@@ -126,65 +128,65 @@ impl ::std::fmt::Debug for FileDescriptorSet {
 impl ::std::cmp::PartialEq for FileDescriptorSet {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         true && self.file() == rhs.file()
     }
 }
 #[derive(::std::default::Default)]
 pub struct FileDescriptorProto {
-    name: self::_puroro::internal::field_type::OptionalUnsizedField::<
+    name: self::_pinternal::field_type::OptionalUnsizedField::<
         ::std::string::String,
-        self::_puroro::internal::tags::String,
+        self::_pinternal::tags::String,
         0usize,
     >,
-    package: self::_puroro::internal::field_type::OptionalUnsizedField::<
+    package: self::_pinternal::field_type::OptionalUnsizedField::<
         ::std::string::String,
-        self::_puroro::internal::tags::String,
+        self::_pinternal::tags::String,
         1usize,
     >,
-    dependency: self::_puroro::internal::field_type::RepeatedUnsizedField::<
+    dependency: self::_pinternal::field_type::RepeatedUnsizedField::<
         ::std::string::String,
-        self::_puroro::internal::tags::String,
+        self::_pinternal::tags::String,
     >,
-    public_dependency: self::_puroro::internal::field_type::RepeatedNumericalField::<
+    public_dependency: self::_pinternal::field_type::RepeatedNumericalField::<
         i32,
-        self::_puroro::internal::tags::Int32,
+        self::_pinternal::tags::Int32,
     >,
-    weak_dependency: self::_puroro::internal::field_type::RepeatedNumericalField::<
+    weak_dependency: self::_pinternal::field_type::RepeatedNumericalField::<
         i32,
-        self::_puroro::internal::tags::Int32,
+        self::_pinternal::tags::Int32,
     >,
-    message_type: self::_puroro::internal::field_type::RepeatedMessageField::<
-        self::_puroro_root::google::protobuf::DescriptorProto,
+    message_type: self::_pinternal::field_type::RepeatedMessageField::<
+        self::_root::google::protobuf::DescriptorProto,
     >,
-    enum_type: self::_puroro::internal::field_type::RepeatedMessageField::<
-        self::_puroro_root::google::protobuf::EnumDescriptorProto,
+    enum_type: self::_pinternal::field_type::RepeatedMessageField::<
+        self::_root::google::protobuf::EnumDescriptorProto,
     >,
-    service: self::_puroro::internal::field_type::RepeatedMessageField::<
-        self::_puroro_root::google::protobuf::ServiceDescriptorProto,
+    service: self::_pinternal::field_type::RepeatedMessageField::<
+        self::_root::google::protobuf::ServiceDescriptorProto,
     >,
-    extension: self::_puroro::internal::field_type::RepeatedMessageField::<
-        self::_puroro_root::google::protobuf::FieldDescriptorProto,
+    extension: self::_pinternal::field_type::RepeatedMessageField::<
+        self::_root::google::protobuf::FieldDescriptorProto,
     >,
-    options: self::_puroro::internal::field_type::SingularHeapMessageField::<
-        self::_puroro_root::google::protobuf::FileOptions,
+    options: self::_pinternal::field_type::SingularHeapMessageField::<
+        self::_root::google::protobuf::FileOptions,
     >,
-    source_code_info: self::_puroro::internal::field_type::SingularHeapMessageField::<
-        self::_puroro_root::google::protobuf::SourceCodeInfo,
+    source_code_info: self::_pinternal::field_type::SingularHeapMessageField::<
+        self::_root::google::protobuf::SourceCodeInfo,
     >,
-    syntax: self::_puroro::internal::field_type::OptionalUnsizedField::<
+    syntax: self::_pinternal::field_type::OptionalUnsizedField::<
         ::std::string::String,
-        self::_puroro::internal::tags::String,
+        self::_pinternal::tags::String,
         2usize,
     >,
-    _bitfield: self::_puroro::internal::bitvec::BitArray<1usize>,
+    _bitfield: self::_pinternal::bitvec::BitArray<1usize>,
 }
 impl FileDescriptorProto {
     pub fn name(&self) -> &str {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.name,
@@ -193,18 +195,18 @@ impl FileDescriptorProto {
         )
     }
     pub fn name_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.name, &self._bitfield)
     }
     pub fn name_mut(&mut self) -> &mut ::std::string::String {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.name,
@@ -213,27 +215,27 @@ impl FileDescriptorProto {
         )
     }
     pub fn has_name(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.name, &self._bitfield)
             .is_some()
     }
     pub fn clear_name(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::clear(&mut self.name, &mut self._bitfield)
     }
     pub fn package(&self) -> &str {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             1usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.package,
@@ -242,18 +244,18 @@ impl FileDescriptorProto {
         )
     }
     pub fn package_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             1usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.package, &self._bitfield)
     }
     pub fn package_mut(&mut self) -> &mut ::std::string::String {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             1usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.package,
@@ -262,19 +264,19 @@ impl FileDescriptorProto {
         )
     }
     pub fn has_package(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             1usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.package, &self._bitfield)
             .is_some()
     }
     pub fn clear_package(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             1usize,
         > as NonRepeatedFieldType>::clear(&mut self.package, &mut self._bitfield)
     }
@@ -283,177 +285,163 @@ impl FileDescriptorProto {
     ) -> &[impl ::std::ops::Deref::<
         Target = str,
     > + ::std::fmt::Debug + ::std::cmp::PartialEq] {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedUnsizedField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
         > as RepeatedFieldType>::get_field(&self.dependency, &self._bitfield)
     }
     pub fn dependency_mut(&mut self) -> &mut ::std::vec::Vec::<::std::string::String> {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedUnsizedField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
         > as RepeatedFieldType>::get_field_mut(&mut self.dependency, &mut self._bitfield)
     }
     pub fn clear_dependency(&mut self) {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedUnsizedField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
         > as RepeatedFieldType>::clear(&mut self.dependency, &mut self._bitfield)
     }
     pub fn public_dependency(&self) -> &[i32] {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
         > as RepeatedFieldType>::get_field(&self.public_dependency, &self._bitfield)
     }
     pub fn public_dependency_mut(&mut self) -> &mut ::std::vec::Vec::<i32> {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
         > as RepeatedFieldType>::get_field_mut(
             &mut self.public_dependency,
             &mut self._bitfield,
         )
     }
     pub fn clear_public_dependency(&mut self) {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
         > as RepeatedFieldType>::clear(&mut self.public_dependency, &mut self._bitfield)
     }
     pub fn weak_dependency(&self) -> &[i32] {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
         > as RepeatedFieldType>::get_field(&self.weak_dependency, &self._bitfield)
     }
     pub fn weak_dependency_mut(&mut self) -> &mut ::std::vec::Vec::<i32> {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
         > as RepeatedFieldType>::get_field_mut(
             &mut self.weak_dependency,
             &mut self._bitfield,
         )
     }
     pub fn clear_weak_dependency(&mut self) {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
         > as RepeatedFieldType>::clear(&mut self.weak_dependency, &mut self._bitfield)
     }
-    pub fn message_type(
-        &self,
-    ) -> &[self::_puroro_root::google::protobuf::DescriptorProto] {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::DescriptorProto,
+    pub fn message_type(&self) -> &[self::_root::google::protobuf::DescriptorProto] {
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::DescriptorProto,
         > as RepeatedFieldType>::get_field(&self.message_type, &self._bitfield)
     }
     pub fn message_type_mut(
         &mut self,
-    ) -> &mut ::std::vec::Vec::<self::_puroro_root::google::protobuf::DescriptorProto> {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::DescriptorProto,
+    ) -> &mut ::std::vec::Vec::<self::_root::google::protobuf::DescriptorProto> {
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::DescriptorProto,
         > as RepeatedFieldType>::get_field_mut(
             &mut self.message_type,
             &mut self._bitfield,
         )
     }
     pub fn clear_message_type(&mut self) {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::DescriptorProto,
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::DescriptorProto,
         > as RepeatedFieldType>::clear(&mut self.message_type, &mut self._bitfield)
     }
-    pub fn enum_type(
-        &self,
-    ) -> &[self::_puroro_root::google::protobuf::EnumDescriptorProto] {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::EnumDescriptorProto,
+    pub fn enum_type(&self) -> &[self::_root::google::protobuf::EnumDescriptorProto] {
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::EnumDescriptorProto,
         > as RepeatedFieldType>::get_field(&self.enum_type, &self._bitfield)
     }
     pub fn enum_type_mut(
         &mut self,
-    ) -> &mut ::std::vec::Vec::<
-        self::_puroro_root::google::protobuf::EnumDescriptorProto,
-    > {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::EnumDescriptorProto,
+    ) -> &mut ::std::vec::Vec::<self::_root::google::protobuf::EnumDescriptorProto> {
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::EnumDescriptorProto,
         > as RepeatedFieldType>::get_field_mut(&mut self.enum_type, &mut self._bitfield)
     }
     pub fn clear_enum_type(&mut self) {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::EnumDescriptorProto,
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::EnumDescriptorProto,
         > as RepeatedFieldType>::clear(&mut self.enum_type, &mut self._bitfield)
     }
-    pub fn service(
-        &self,
-    ) -> &[self::_puroro_root::google::protobuf::ServiceDescriptorProto] {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::ServiceDescriptorProto,
+    pub fn service(&self) -> &[self::_root::google::protobuf::ServiceDescriptorProto] {
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::ServiceDescriptorProto,
         > as RepeatedFieldType>::get_field(&self.service, &self._bitfield)
     }
     pub fn service_mut(
         &mut self,
-    ) -> &mut ::std::vec::Vec::<
-        self::_puroro_root::google::protobuf::ServiceDescriptorProto,
-    > {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::ServiceDescriptorProto,
+    ) -> &mut ::std::vec::Vec::<self::_root::google::protobuf::ServiceDescriptorProto> {
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::ServiceDescriptorProto,
         > as RepeatedFieldType>::get_field_mut(&mut self.service, &mut self._bitfield)
     }
     pub fn clear_service(&mut self) {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::ServiceDescriptorProto,
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::ServiceDescriptorProto,
         > as RepeatedFieldType>::clear(&mut self.service, &mut self._bitfield)
     }
-    pub fn extension(
-        &self,
-    ) -> &[self::_puroro_root::google::protobuf::FieldDescriptorProto] {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::FieldDescriptorProto,
+    pub fn extension(&self) -> &[self::_root::google::protobuf::FieldDescriptorProto] {
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::FieldDescriptorProto,
         > as RepeatedFieldType>::get_field(&self.extension, &self._bitfield)
     }
     pub fn extension_mut(
         &mut self,
-    ) -> &mut ::std::vec::Vec::<
-        self::_puroro_root::google::protobuf::FieldDescriptorProto,
-    > {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::FieldDescriptorProto,
+    ) -> &mut ::std::vec::Vec::<self::_root::google::protobuf::FieldDescriptorProto> {
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::FieldDescriptorProto,
         > as RepeatedFieldType>::get_field_mut(&mut self.extension, &mut self._bitfield)
     }
     pub fn clear_extension(&mut self) {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::FieldDescriptorProto,
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::FieldDescriptorProto,
         > as RepeatedFieldType>::clear(&mut self.extension, &mut self._bitfield)
     }
     pub fn options(
         &self,
-    ) -> ::std::option::Option::<&self::_puroro_root::google::protobuf::FileOptions> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::google::protobuf::FileOptions,
+    ) -> ::std::option::Option::<&self::_root::google::protobuf::FileOptions> {
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::google::protobuf::FileOptions,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.options,
             &self._bitfield,
@@ -462,18 +450,16 @@ impl FileDescriptorProto {
     }
     pub fn options_opt(
         &self,
-    ) -> ::std::option::Option::<&self::_puroro_root::google::protobuf::FileOptions> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::google::protobuf::FileOptions,
+    ) -> ::std::option::Option::<&self::_root::google::protobuf::FileOptions> {
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::google::protobuf::FileOptions,
         > as NonRepeatedFieldType>::get_field_opt(&self.options, &self._bitfield)
     }
-    pub fn options_mut(
-        &mut self,
-    ) -> &mut self::_puroro_root::google::protobuf::FileOptions {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::google::protobuf::FileOptions,
+    pub fn options_mut(&mut self) -> &mut self::_root::google::protobuf::FileOptions {
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::google::protobuf::FileOptions,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.options,
             &mut self._bitfield,
@@ -481,24 +467,24 @@ impl FileDescriptorProto {
         )
     }
     pub fn has_options(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::google::protobuf::FileOptions,
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::google::protobuf::FileOptions,
         > as NonRepeatedFieldType>::get_field_opt(&self.options, &self._bitfield)
             .is_some()
     }
     pub fn clear_options(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::google::protobuf::FileOptions,
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::google::protobuf::FileOptions,
         > as NonRepeatedFieldType>::clear(&mut self.options, &mut self._bitfield)
     }
     pub fn source_code_info(
         &self,
-    ) -> ::std::option::Option::<&self::_puroro_root::google::protobuf::SourceCodeInfo> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::google::protobuf::SourceCodeInfo,
+    ) -> ::std::option::Option::<&self::_root::google::protobuf::SourceCodeInfo> {
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::google::protobuf::SourceCodeInfo,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.source_code_info,
             &self._bitfield,
@@ -507,10 +493,10 @@ impl FileDescriptorProto {
     }
     pub fn source_code_info_opt(
         &self,
-    ) -> ::std::option::Option::<&self::_puroro_root::google::protobuf::SourceCodeInfo> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::google::protobuf::SourceCodeInfo,
+    ) -> ::std::option::Option::<&self::_root::google::protobuf::SourceCodeInfo> {
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::google::protobuf::SourceCodeInfo,
         > as NonRepeatedFieldType>::get_field_opt(
             &self.source_code_info,
             &self._bitfield,
@@ -518,10 +504,10 @@ impl FileDescriptorProto {
     }
     pub fn source_code_info_mut(
         &mut self,
-    ) -> &mut self::_puroro_root::google::protobuf::SourceCodeInfo {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::google::protobuf::SourceCodeInfo,
+    ) -> &mut self::_root::google::protobuf::SourceCodeInfo {
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::google::protobuf::SourceCodeInfo,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.source_code_info,
             &mut self._bitfield,
@@ -529,9 +515,9 @@ impl FileDescriptorProto {
         )
     }
     pub fn has_source_code_info(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::google::protobuf::SourceCodeInfo,
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::google::protobuf::SourceCodeInfo,
         > as NonRepeatedFieldType>::get_field_opt(
                 &self.source_code_info,
                 &self._bitfield,
@@ -539,19 +525,19 @@ impl FileDescriptorProto {
             .is_some()
     }
     pub fn clear_source_code_info(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::google::protobuf::SourceCodeInfo,
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::google::protobuf::SourceCodeInfo,
         > as NonRepeatedFieldType>::clear(
             &mut self.source_code_info,
             &mut self._bitfield,
         )
     }
     pub fn syntax(&self) -> &str {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             2usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.syntax,
@@ -560,18 +546,18 @@ impl FileDescriptorProto {
         )
     }
     pub fn syntax_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             2usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.syntax, &self._bitfield)
     }
     pub fn syntax_mut(&mut self) -> &mut ::std::string::String {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             2usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.syntax,
@@ -580,19 +566,19 @@ impl FileDescriptorProto {
         )
     }
     pub fn has_syntax(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             2usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.syntax, &self._bitfield)
             .is_some()
     }
     pub fn clear_syntax(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             2usize,
         > as NonRepeatedFieldType>::clear(&mut self.syntax, &mut self._bitfield)
     }
@@ -609,124 +595,124 @@ impl self::_puroro::Message for FileDescriptorProto {
         &mut self,
         mut iter: I,
     ) -> self::_puroro::Result<()> {
-        use self::_puroro::internal::ser::FieldData;
+        use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 1i32 => {
-                    <self::_puroro::internal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::field_type::OptionalUnsizedField::<
                         ::std::string::String,
-                        self::_puroro::internal::tags::String,
+                        self::_pinternal::tags::String,
                         0usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.name,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 2i32 => {
-                    <self::_puroro::internal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::field_type::OptionalUnsizedField::<
                         ::std::string::String,
-                        self::_puroro::internal::tags::String,
+                        self::_pinternal::tags::String,
                         1usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.package,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 3i32 => {
-                    <self::_puroro::internal::field_type::RepeatedUnsizedField::<
+                    <self::_pinternal::field_type::RepeatedUnsizedField::<
                         ::std::string::String,
-                        self::_puroro::internal::tags::String,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                        self::_pinternal::tags::String,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.dependency,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 10i32 => {
-                    <self::_puroro::internal::field_type::RepeatedNumericalField::<
+                    <self::_pinternal::field_type::RepeatedNumericalField::<
                         i32,
-                        self::_puroro::internal::tags::Int32,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                        self::_pinternal::tags::Int32,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.public_dependency,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 11i32 => {
-                    <self::_puroro::internal::field_type::RepeatedNumericalField::<
+                    <self::_pinternal::field_type::RepeatedNumericalField::<
                         i32,
-                        self::_puroro::internal::tags::Int32,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                        self::_pinternal::tags::Int32,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.weak_dependency,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 4i32 => {
-                    <self::_puroro::internal::field_type::RepeatedMessageField::<
-                        self::_puroro_root::google::protobuf::DescriptorProto,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    <self::_pinternal::field_type::RepeatedMessageField::<
+                        self::_root::google::protobuf::DescriptorProto,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.message_type,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 5i32 => {
-                    <self::_puroro::internal::field_type::RepeatedMessageField::<
-                        self::_puroro_root::google::protobuf::EnumDescriptorProto,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    <self::_pinternal::field_type::RepeatedMessageField::<
+                        self::_root::google::protobuf::EnumDescriptorProto,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.enum_type,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 6i32 => {
-                    <self::_puroro::internal::field_type::RepeatedMessageField::<
-                        self::_puroro_root::google::protobuf::ServiceDescriptorProto,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    <self::_pinternal::field_type::RepeatedMessageField::<
+                        self::_root::google::protobuf::ServiceDescriptorProto,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.service,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 7i32 => {
-                    <self::_puroro::internal::field_type::RepeatedMessageField::<
-                        self::_puroro_root::google::protobuf::FieldDescriptorProto,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    <self::_pinternal::field_type::RepeatedMessageField::<
+                        self::_root::google::protobuf::FieldDescriptorProto,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.extension,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 8i32 => {
-                    <self::_puroro::internal::field_type::SingularHeapMessageField::<
-                        self::_puroro_root::google::protobuf::FileOptions,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    <self::_pinternal::field_type::SingularHeapMessageField::<
+                        self::_root::google::protobuf::FileOptions,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.options,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 9i32 => {
-                    <self::_puroro::internal::field_type::SingularHeapMessageField::<
-                        self::_puroro_root::google::protobuf::SourceCodeInfo,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    <self::_pinternal::field_type::SingularHeapMessageField::<
+                        self::_root::google::protobuf::SourceCodeInfo,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.source_code_info,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 12i32 => {
-                    <self::_puroro::internal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::field_type::OptionalUnsizedField::<
                         ::std::string::String,
-                        self::_puroro::internal::tags::String,
+                        self::_pinternal::tags::String,
                         2usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.syntax,
                         &mut self._bitfield,
                         field_data,
@@ -743,107 +729,107 @@ impl self::_puroro::Message for FileDescriptorProto {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::oneof_type::OneofUnion as _;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.name,
             &self._bitfield,
             1i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             1usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.package,
             &self._bitfield,
             2i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::RepeatedUnsizedField::<
+        <self::_pinternal::field_type::RepeatedUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+            self::_pinternal::tags::String,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.dependency,
             &self._bitfield,
             3i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+            self::_pinternal::tags::Int32,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.public_dependency,
             &self._bitfield,
             10i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+            self::_pinternal::tags::Int32,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.weak_dependency,
             &self._bitfield,
             11i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::DescriptorProto,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::DescriptorProto,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.message_type,
             &self._bitfield,
             4i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::EnumDescriptorProto,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::EnumDescriptorProto,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.enum_type,
             &self._bitfield,
             5i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::ServiceDescriptorProto,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::ServiceDescriptorProto,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.service,
             &self._bitfield,
             6i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::FieldDescriptorProto,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::FieldDescriptorProto,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.extension,
             &self._bitfield,
             7i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::google::protobuf::FileOptions,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::google::protobuf::FileOptions,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.options,
             &self._bitfield,
             8i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::google::protobuf::SourceCodeInfo,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::google::protobuf::SourceCodeInfo,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.source_code_info,
             &self._bitfield,
             9i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             2usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.syntax,
             &self._bitfield,
             12i32,
@@ -855,49 +841,49 @@ impl self::_puroro::Message for FileDescriptorProto {
 impl ::std::clone::Clone for FileDescriptorProto {
     fn clone(&self) -> Self {
         Self {
-            name: <self::_puroro::internal::field_type::OptionalUnsizedField::<
+            name: <self::_pinternal::field_type::OptionalUnsizedField::<
                 ::std::string::String,
-                self::_puroro::internal::tags::String,
+                self::_pinternal::tags::String,
                 0usize,
             > as ::std::clone::Clone>::clone(&self.name),
-            package: <self::_puroro::internal::field_type::OptionalUnsizedField::<
+            package: <self::_pinternal::field_type::OptionalUnsizedField::<
                 ::std::string::String,
-                self::_puroro::internal::tags::String,
+                self::_pinternal::tags::String,
                 1usize,
             > as ::std::clone::Clone>::clone(&self.package),
-            dependency: <self::_puroro::internal::field_type::RepeatedUnsizedField::<
+            dependency: <self::_pinternal::field_type::RepeatedUnsizedField::<
                 ::std::string::String,
-                self::_puroro::internal::tags::String,
+                self::_pinternal::tags::String,
             > as ::std::clone::Clone>::clone(&self.dependency),
-            public_dependency: <self::_puroro::internal::field_type::RepeatedNumericalField::<
+            public_dependency: <self::_pinternal::field_type::RepeatedNumericalField::<
                 i32,
-                self::_puroro::internal::tags::Int32,
+                self::_pinternal::tags::Int32,
             > as ::std::clone::Clone>::clone(&self.public_dependency),
-            weak_dependency: <self::_puroro::internal::field_type::RepeatedNumericalField::<
+            weak_dependency: <self::_pinternal::field_type::RepeatedNumericalField::<
                 i32,
-                self::_puroro::internal::tags::Int32,
+                self::_pinternal::tags::Int32,
             > as ::std::clone::Clone>::clone(&self.weak_dependency),
-            message_type: <self::_puroro::internal::field_type::RepeatedMessageField::<
-                self::_puroro_root::google::protobuf::DescriptorProto,
+            message_type: <self::_pinternal::field_type::RepeatedMessageField::<
+                self::_root::google::protobuf::DescriptorProto,
             > as ::std::clone::Clone>::clone(&self.message_type),
-            enum_type: <self::_puroro::internal::field_type::RepeatedMessageField::<
-                self::_puroro_root::google::protobuf::EnumDescriptorProto,
+            enum_type: <self::_pinternal::field_type::RepeatedMessageField::<
+                self::_root::google::protobuf::EnumDescriptorProto,
             > as ::std::clone::Clone>::clone(&self.enum_type),
-            service: <self::_puroro::internal::field_type::RepeatedMessageField::<
-                self::_puroro_root::google::protobuf::ServiceDescriptorProto,
+            service: <self::_pinternal::field_type::RepeatedMessageField::<
+                self::_root::google::protobuf::ServiceDescriptorProto,
             > as ::std::clone::Clone>::clone(&self.service),
-            extension: <self::_puroro::internal::field_type::RepeatedMessageField::<
-                self::_puroro_root::google::protobuf::FieldDescriptorProto,
+            extension: <self::_pinternal::field_type::RepeatedMessageField::<
+                self::_root::google::protobuf::FieldDescriptorProto,
             > as ::std::clone::Clone>::clone(&self.extension),
-            options: <self::_puroro::internal::field_type::SingularHeapMessageField::<
-                self::_puroro_root::google::protobuf::FileOptions,
+            options: <self::_pinternal::field_type::SingularHeapMessageField::<
+                self::_root::google::protobuf::FileOptions,
             > as ::std::clone::Clone>::clone(&self.options),
-            source_code_info: <self::_puroro::internal::field_type::SingularHeapMessageField::<
-                self::_puroro_root::google::protobuf::SourceCodeInfo,
+            source_code_info: <self::_pinternal::field_type::SingularHeapMessageField::<
+                self::_root::google::protobuf::SourceCodeInfo,
             > as ::std::clone::Clone>::clone(&self.source_code_info),
-            syntax: <self::_puroro::internal::field_type::OptionalUnsizedField::<
+            syntax: <self::_pinternal::field_type::OptionalUnsizedField::<
                 ::std::string::String,
-                self::_puroro::internal::tags::String,
+                self::_pinternal::tags::String,
                 2usize,
             > as ::std::clone::Clone>::clone(&self.syntax),
             _bitfield: ::std::clone::Clone::clone(&self._bitfield),
@@ -907,7 +893,7 @@ impl ::std::clone::Clone for FileDescriptorProto {
 impl ::std::ops::Drop for FileDescriptorProto {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for FileDescriptorProto {
@@ -934,7 +920,7 @@ impl ::std::fmt::Debug for FileDescriptorProto {
 impl ::std::cmp::PartialEq for FileDescriptorProto {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         true && self.name_opt() == rhs.name_opt()
             && self.package_opt() == rhs.package_opt()
             && self.dependency() == rhs.dependency()
@@ -950,47 +936,47 @@ impl ::std::cmp::PartialEq for FileDescriptorProto {
 }
 #[derive(::std::default::Default)]
 pub struct DescriptorProto {
-    name: self::_puroro::internal::field_type::OptionalUnsizedField::<
+    name: self::_pinternal::field_type::OptionalUnsizedField::<
         ::std::string::String,
-        self::_puroro::internal::tags::String,
+        self::_pinternal::tags::String,
         0usize,
     >,
-    field: self::_puroro::internal::field_type::RepeatedMessageField::<
-        self::_puroro_root::google::protobuf::FieldDescriptorProto,
+    field: self::_pinternal::field_type::RepeatedMessageField::<
+        self::_root::google::protobuf::FieldDescriptorProto,
     >,
-    extension: self::_puroro::internal::field_type::RepeatedMessageField::<
-        self::_puroro_root::google::protobuf::FieldDescriptorProto,
+    extension: self::_pinternal::field_type::RepeatedMessageField::<
+        self::_root::google::protobuf::FieldDescriptorProto,
     >,
-    nested_type: self::_puroro::internal::field_type::RepeatedMessageField::<
-        self::_puroro_root::google::protobuf::DescriptorProto,
+    nested_type: self::_pinternal::field_type::RepeatedMessageField::<
+        self::_root::google::protobuf::DescriptorProto,
     >,
-    enum_type: self::_puroro::internal::field_type::RepeatedMessageField::<
-        self::_puroro_root::google::protobuf::EnumDescriptorProto,
+    enum_type: self::_pinternal::field_type::RepeatedMessageField::<
+        self::_root::google::protobuf::EnumDescriptorProto,
     >,
-    extension_range: self::_puroro::internal::field_type::RepeatedMessageField::<
-        self::_puroro_root::google::protobuf::descriptor_proto::ExtensionRange,
+    extension_range: self::_pinternal::field_type::RepeatedMessageField::<
+        self::_root::google::protobuf::descriptor_proto::ExtensionRange,
     >,
-    oneof_decl: self::_puroro::internal::field_type::RepeatedMessageField::<
-        self::_puroro_root::google::protobuf::OneofDescriptorProto,
+    oneof_decl: self::_pinternal::field_type::RepeatedMessageField::<
+        self::_root::google::protobuf::OneofDescriptorProto,
     >,
-    options: self::_puroro::internal::field_type::SingularHeapMessageField::<
-        self::_puroro_root::google::protobuf::MessageOptions,
+    options: self::_pinternal::field_type::SingularHeapMessageField::<
+        self::_root::google::protobuf::MessageOptions,
     >,
-    reserved_range: self::_puroro::internal::field_type::RepeatedMessageField::<
-        self::_puroro_root::google::protobuf::descriptor_proto::ReservedRange,
+    reserved_range: self::_pinternal::field_type::RepeatedMessageField::<
+        self::_root::google::protobuf::descriptor_proto::ReservedRange,
     >,
-    reserved_name: self::_puroro::internal::field_type::RepeatedUnsizedField::<
+    reserved_name: self::_pinternal::field_type::RepeatedUnsizedField::<
         ::std::string::String,
-        self::_puroro::internal::tags::String,
+        self::_pinternal::tags::String,
     >,
-    _bitfield: self::_puroro::internal::bitvec::BitArray<1usize>,
+    _bitfield: self::_pinternal::bitvec::BitArray<1usize>,
 }
 impl DescriptorProto {
     pub fn name(&self) -> &str {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.name,
@@ -999,18 +985,18 @@ impl DescriptorProto {
         )
     }
     pub fn name_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.name, &self._bitfield)
     }
     pub fn name_mut(&mut self) -> &mut ::std::string::String {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.name,
@@ -1019,176 +1005,158 @@ impl DescriptorProto {
         )
     }
     pub fn has_name(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.name, &self._bitfield)
             .is_some()
     }
     pub fn clear_name(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::clear(&mut self.name, &mut self._bitfield)
     }
-    pub fn field(
-        &self,
-    ) -> &[self::_puroro_root::google::protobuf::FieldDescriptorProto] {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::FieldDescriptorProto,
+    pub fn field(&self) -> &[self::_root::google::protobuf::FieldDescriptorProto] {
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::FieldDescriptorProto,
         > as RepeatedFieldType>::get_field(&self.field, &self._bitfield)
     }
     pub fn field_mut(
         &mut self,
-    ) -> &mut ::std::vec::Vec::<
-        self::_puroro_root::google::protobuf::FieldDescriptorProto,
-    > {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::FieldDescriptorProto,
+    ) -> &mut ::std::vec::Vec::<self::_root::google::protobuf::FieldDescriptorProto> {
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::FieldDescriptorProto,
         > as RepeatedFieldType>::get_field_mut(&mut self.field, &mut self._bitfield)
     }
     pub fn clear_field(&mut self) {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::FieldDescriptorProto,
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::FieldDescriptorProto,
         > as RepeatedFieldType>::clear(&mut self.field, &mut self._bitfield)
     }
-    pub fn extension(
-        &self,
-    ) -> &[self::_puroro_root::google::protobuf::FieldDescriptorProto] {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::FieldDescriptorProto,
+    pub fn extension(&self) -> &[self::_root::google::protobuf::FieldDescriptorProto] {
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::FieldDescriptorProto,
         > as RepeatedFieldType>::get_field(&self.extension, &self._bitfield)
     }
     pub fn extension_mut(
         &mut self,
-    ) -> &mut ::std::vec::Vec::<
-        self::_puroro_root::google::protobuf::FieldDescriptorProto,
-    > {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::FieldDescriptorProto,
+    ) -> &mut ::std::vec::Vec::<self::_root::google::protobuf::FieldDescriptorProto> {
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::FieldDescriptorProto,
         > as RepeatedFieldType>::get_field_mut(&mut self.extension, &mut self._bitfield)
     }
     pub fn clear_extension(&mut self) {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::FieldDescriptorProto,
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::FieldDescriptorProto,
         > as RepeatedFieldType>::clear(&mut self.extension, &mut self._bitfield)
     }
-    pub fn nested_type(
-        &self,
-    ) -> &[self::_puroro_root::google::protobuf::DescriptorProto] {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::DescriptorProto,
+    pub fn nested_type(&self) -> &[self::_root::google::protobuf::DescriptorProto] {
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::DescriptorProto,
         > as RepeatedFieldType>::get_field(&self.nested_type, &self._bitfield)
     }
     pub fn nested_type_mut(
         &mut self,
-    ) -> &mut ::std::vec::Vec::<self::_puroro_root::google::protobuf::DescriptorProto> {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::DescriptorProto,
+    ) -> &mut ::std::vec::Vec::<self::_root::google::protobuf::DescriptorProto> {
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::DescriptorProto,
         > as RepeatedFieldType>::get_field_mut(
             &mut self.nested_type,
             &mut self._bitfield,
         )
     }
     pub fn clear_nested_type(&mut self) {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::DescriptorProto,
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::DescriptorProto,
         > as RepeatedFieldType>::clear(&mut self.nested_type, &mut self._bitfield)
     }
-    pub fn enum_type(
-        &self,
-    ) -> &[self::_puroro_root::google::protobuf::EnumDescriptorProto] {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::EnumDescriptorProto,
+    pub fn enum_type(&self) -> &[self::_root::google::protobuf::EnumDescriptorProto] {
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::EnumDescriptorProto,
         > as RepeatedFieldType>::get_field(&self.enum_type, &self._bitfield)
     }
     pub fn enum_type_mut(
         &mut self,
-    ) -> &mut ::std::vec::Vec::<
-        self::_puroro_root::google::protobuf::EnumDescriptorProto,
-    > {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::EnumDescriptorProto,
+    ) -> &mut ::std::vec::Vec::<self::_root::google::protobuf::EnumDescriptorProto> {
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::EnumDescriptorProto,
         > as RepeatedFieldType>::get_field_mut(&mut self.enum_type, &mut self._bitfield)
     }
     pub fn clear_enum_type(&mut self) {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::EnumDescriptorProto,
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::EnumDescriptorProto,
         > as RepeatedFieldType>::clear(&mut self.enum_type, &mut self._bitfield)
     }
     pub fn extension_range(
         &self,
-    ) -> &[self::_puroro_root::google::protobuf::descriptor_proto::ExtensionRange] {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::descriptor_proto::ExtensionRange,
+    ) -> &[self::_root::google::protobuf::descriptor_proto::ExtensionRange] {
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::descriptor_proto::ExtensionRange,
         > as RepeatedFieldType>::get_field(&self.extension_range, &self._bitfield)
     }
     pub fn extension_range_mut(
         &mut self,
     ) -> &mut ::std::vec::Vec::<
-        self::_puroro_root::google::protobuf::descriptor_proto::ExtensionRange,
+        self::_root::google::protobuf::descriptor_proto::ExtensionRange,
     > {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::descriptor_proto::ExtensionRange,
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::descriptor_proto::ExtensionRange,
         > as RepeatedFieldType>::get_field_mut(
             &mut self.extension_range,
             &mut self._bitfield,
         )
     }
     pub fn clear_extension_range(&mut self) {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::descriptor_proto::ExtensionRange,
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::descriptor_proto::ExtensionRange,
         > as RepeatedFieldType>::clear(&mut self.extension_range, &mut self._bitfield)
     }
-    pub fn oneof_decl(
-        &self,
-    ) -> &[self::_puroro_root::google::protobuf::OneofDescriptorProto] {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::OneofDescriptorProto,
+    pub fn oneof_decl(&self) -> &[self::_root::google::protobuf::OneofDescriptorProto] {
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::OneofDescriptorProto,
         > as RepeatedFieldType>::get_field(&self.oneof_decl, &self._bitfield)
     }
     pub fn oneof_decl_mut(
         &mut self,
-    ) -> &mut ::std::vec::Vec::<
-        self::_puroro_root::google::protobuf::OneofDescriptorProto,
-    > {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::OneofDescriptorProto,
+    ) -> &mut ::std::vec::Vec::<self::_root::google::protobuf::OneofDescriptorProto> {
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::OneofDescriptorProto,
         > as RepeatedFieldType>::get_field_mut(&mut self.oneof_decl, &mut self._bitfield)
     }
     pub fn clear_oneof_decl(&mut self) {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::OneofDescriptorProto,
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::OneofDescriptorProto,
         > as RepeatedFieldType>::clear(&mut self.oneof_decl, &mut self._bitfield)
     }
     pub fn options(
         &self,
-    ) -> ::std::option::Option::<&self::_puroro_root::google::protobuf::MessageOptions> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::google::protobuf::MessageOptions,
+    ) -> ::std::option::Option::<&self::_root::google::protobuf::MessageOptions> {
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::google::protobuf::MessageOptions,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.options,
             &self._bitfield,
@@ -1197,18 +1165,16 @@ impl DescriptorProto {
     }
     pub fn options_opt(
         &self,
-    ) -> ::std::option::Option::<&self::_puroro_root::google::protobuf::MessageOptions> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::google::protobuf::MessageOptions,
+    ) -> ::std::option::Option::<&self::_root::google::protobuf::MessageOptions> {
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::google::protobuf::MessageOptions,
         > as NonRepeatedFieldType>::get_field_opt(&self.options, &self._bitfield)
     }
-    pub fn options_mut(
-        &mut self,
-    ) -> &mut self::_puroro_root::google::protobuf::MessageOptions {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::google::protobuf::MessageOptions,
+    pub fn options_mut(&mut self) -> &mut self::_root::google::protobuf::MessageOptions {
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::google::protobuf::MessageOptions,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.options,
             &mut self._bitfield,
@@ -1216,43 +1182,43 @@ impl DescriptorProto {
         )
     }
     pub fn has_options(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::google::protobuf::MessageOptions,
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::google::protobuf::MessageOptions,
         > as NonRepeatedFieldType>::get_field_opt(&self.options, &self._bitfield)
             .is_some()
     }
     pub fn clear_options(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::google::protobuf::MessageOptions,
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::google::protobuf::MessageOptions,
         > as NonRepeatedFieldType>::clear(&mut self.options, &mut self._bitfield)
     }
     pub fn reserved_range(
         &self,
-    ) -> &[self::_puroro_root::google::protobuf::descriptor_proto::ReservedRange] {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::descriptor_proto::ReservedRange,
+    ) -> &[self::_root::google::protobuf::descriptor_proto::ReservedRange] {
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::descriptor_proto::ReservedRange,
         > as RepeatedFieldType>::get_field(&self.reserved_range, &self._bitfield)
     }
     pub fn reserved_range_mut(
         &mut self,
     ) -> &mut ::std::vec::Vec::<
-        self::_puroro_root::google::protobuf::descriptor_proto::ReservedRange,
+        self::_root::google::protobuf::descriptor_proto::ReservedRange,
     > {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::descriptor_proto::ReservedRange,
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::descriptor_proto::ReservedRange,
         > as RepeatedFieldType>::get_field_mut(
             &mut self.reserved_range,
             &mut self._bitfield,
         )
     }
     pub fn clear_reserved_range(&mut self) {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::descriptor_proto::ReservedRange,
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::descriptor_proto::ReservedRange,
         > as RepeatedFieldType>::clear(&mut self.reserved_range, &mut self._bitfield)
     }
     pub fn reserved_name(
@@ -1260,29 +1226,29 @@ impl DescriptorProto {
     ) -> &[impl ::std::ops::Deref::<
         Target = str,
     > + ::std::fmt::Debug + ::std::cmp::PartialEq] {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedUnsizedField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
         > as RepeatedFieldType>::get_field(&self.reserved_name, &self._bitfield)
     }
     pub fn reserved_name_mut(
         &mut self,
     ) -> &mut ::std::vec::Vec::<::std::string::String> {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedUnsizedField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
         > as RepeatedFieldType>::get_field_mut(
             &mut self.reserved_name,
             &mut self._bitfield,
         )
     }
     pub fn clear_reserved_name(&mut self) {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedUnsizedField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
         > as RepeatedFieldType>::clear(&mut self.reserved_name, &mut self._bitfield)
     }
 }
@@ -1298,100 +1264,100 @@ impl self::_puroro::Message for DescriptorProto {
         &mut self,
         mut iter: I,
     ) -> self::_puroro::Result<()> {
-        use self::_puroro::internal::ser::FieldData;
+        use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 1i32 => {
-                    <self::_puroro::internal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::field_type::OptionalUnsizedField::<
                         ::std::string::String,
-                        self::_puroro::internal::tags::String,
+                        self::_pinternal::tags::String,
                         0usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.name,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 2i32 => {
-                    <self::_puroro::internal::field_type::RepeatedMessageField::<
-                        self::_puroro_root::google::protobuf::FieldDescriptorProto,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    <self::_pinternal::field_type::RepeatedMessageField::<
+                        self::_root::google::protobuf::FieldDescriptorProto,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.field,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 6i32 => {
-                    <self::_puroro::internal::field_type::RepeatedMessageField::<
-                        self::_puroro_root::google::protobuf::FieldDescriptorProto,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    <self::_pinternal::field_type::RepeatedMessageField::<
+                        self::_root::google::protobuf::FieldDescriptorProto,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.extension,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 3i32 => {
-                    <self::_puroro::internal::field_type::RepeatedMessageField::<
-                        self::_puroro_root::google::protobuf::DescriptorProto,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    <self::_pinternal::field_type::RepeatedMessageField::<
+                        self::_root::google::protobuf::DescriptorProto,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.nested_type,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 4i32 => {
-                    <self::_puroro::internal::field_type::RepeatedMessageField::<
-                        self::_puroro_root::google::protobuf::EnumDescriptorProto,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    <self::_pinternal::field_type::RepeatedMessageField::<
+                        self::_root::google::protobuf::EnumDescriptorProto,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.enum_type,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 5i32 => {
-                    <self::_puroro::internal::field_type::RepeatedMessageField::<
-                        self::_puroro_root::google::protobuf::descriptor_proto::ExtensionRange,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    <self::_pinternal::field_type::RepeatedMessageField::<
+                        self::_root::google::protobuf::descriptor_proto::ExtensionRange,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.extension_range,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 8i32 => {
-                    <self::_puroro::internal::field_type::RepeatedMessageField::<
-                        self::_puroro_root::google::protobuf::OneofDescriptorProto,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    <self::_pinternal::field_type::RepeatedMessageField::<
+                        self::_root::google::protobuf::OneofDescriptorProto,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.oneof_decl,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 7i32 => {
-                    <self::_puroro::internal::field_type::SingularHeapMessageField::<
-                        self::_puroro_root::google::protobuf::MessageOptions,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    <self::_pinternal::field_type::SingularHeapMessageField::<
+                        self::_root::google::protobuf::MessageOptions,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.options,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 9i32 => {
-                    <self::_puroro::internal::field_type::RepeatedMessageField::<
-                        self::_puroro_root::google::protobuf::descriptor_proto::ReservedRange,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    <self::_pinternal::field_type::RepeatedMessageField::<
+                        self::_root::google::protobuf::descriptor_proto::ReservedRange,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.reserved_range,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 10i32 => {
-                    <self::_puroro::internal::field_type::RepeatedUnsizedField::<
+                    <self::_pinternal::field_type::RepeatedUnsizedField::<
                         ::std::string::String,
-                        self::_puroro::internal::tags::String,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                        self::_pinternal::tags::String,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.reserved_name,
                         &mut self._bitfield,
                         field_data,
@@ -1408,85 +1374,85 @@ impl self::_puroro::Message for DescriptorProto {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::oneof_type::OneofUnion as _;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.name,
             &self._bitfield,
             1i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::FieldDescriptorProto,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::FieldDescriptorProto,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.field,
             &self._bitfield,
             2i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::FieldDescriptorProto,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::FieldDescriptorProto,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.extension,
             &self._bitfield,
             6i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::DescriptorProto,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::DescriptorProto,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.nested_type,
             &self._bitfield,
             3i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::EnumDescriptorProto,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::EnumDescriptorProto,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.enum_type,
             &self._bitfield,
             4i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::descriptor_proto::ExtensionRange,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::descriptor_proto::ExtensionRange,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.extension_range,
             &self._bitfield,
             5i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::OneofDescriptorProto,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::OneofDescriptorProto,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.oneof_decl,
             &self._bitfield,
             8i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::google::protobuf::MessageOptions,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::google::protobuf::MessageOptions,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.options,
             &self._bitfield,
             7i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::descriptor_proto::ReservedRange,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::descriptor_proto::ReservedRange,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.reserved_range,
             &self._bitfield,
             9i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::RepeatedUnsizedField::<
+        <self::_pinternal::field_type::RepeatedUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+            self::_pinternal::tags::String,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.reserved_name,
             &self._bitfield,
             10i32,
@@ -1498,38 +1464,38 @@ impl self::_puroro::Message for DescriptorProto {
 impl ::std::clone::Clone for DescriptorProto {
     fn clone(&self) -> Self {
         Self {
-            name: <self::_puroro::internal::field_type::OptionalUnsizedField::<
+            name: <self::_pinternal::field_type::OptionalUnsizedField::<
                 ::std::string::String,
-                self::_puroro::internal::tags::String,
+                self::_pinternal::tags::String,
                 0usize,
             > as ::std::clone::Clone>::clone(&self.name),
-            field: <self::_puroro::internal::field_type::RepeatedMessageField::<
-                self::_puroro_root::google::protobuf::FieldDescriptorProto,
+            field: <self::_pinternal::field_type::RepeatedMessageField::<
+                self::_root::google::protobuf::FieldDescriptorProto,
             > as ::std::clone::Clone>::clone(&self.field),
-            extension: <self::_puroro::internal::field_type::RepeatedMessageField::<
-                self::_puroro_root::google::protobuf::FieldDescriptorProto,
+            extension: <self::_pinternal::field_type::RepeatedMessageField::<
+                self::_root::google::protobuf::FieldDescriptorProto,
             > as ::std::clone::Clone>::clone(&self.extension),
-            nested_type: <self::_puroro::internal::field_type::RepeatedMessageField::<
-                self::_puroro_root::google::protobuf::DescriptorProto,
+            nested_type: <self::_pinternal::field_type::RepeatedMessageField::<
+                self::_root::google::protobuf::DescriptorProto,
             > as ::std::clone::Clone>::clone(&self.nested_type),
-            enum_type: <self::_puroro::internal::field_type::RepeatedMessageField::<
-                self::_puroro_root::google::protobuf::EnumDescriptorProto,
+            enum_type: <self::_pinternal::field_type::RepeatedMessageField::<
+                self::_root::google::protobuf::EnumDescriptorProto,
             > as ::std::clone::Clone>::clone(&self.enum_type),
-            extension_range: <self::_puroro::internal::field_type::RepeatedMessageField::<
-                self::_puroro_root::google::protobuf::descriptor_proto::ExtensionRange,
+            extension_range: <self::_pinternal::field_type::RepeatedMessageField::<
+                self::_root::google::protobuf::descriptor_proto::ExtensionRange,
             > as ::std::clone::Clone>::clone(&self.extension_range),
-            oneof_decl: <self::_puroro::internal::field_type::RepeatedMessageField::<
-                self::_puroro_root::google::protobuf::OneofDescriptorProto,
+            oneof_decl: <self::_pinternal::field_type::RepeatedMessageField::<
+                self::_root::google::protobuf::OneofDescriptorProto,
             > as ::std::clone::Clone>::clone(&self.oneof_decl),
-            options: <self::_puroro::internal::field_type::SingularHeapMessageField::<
-                self::_puroro_root::google::protobuf::MessageOptions,
+            options: <self::_pinternal::field_type::SingularHeapMessageField::<
+                self::_root::google::protobuf::MessageOptions,
             > as ::std::clone::Clone>::clone(&self.options),
-            reserved_range: <self::_puroro::internal::field_type::RepeatedMessageField::<
-                self::_puroro_root::google::protobuf::descriptor_proto::ReservedRange,
+            reserved_range: <self::_pinternal::field_type::RepeatedMessageField::<
+                self::_root::google::protobuf::descriptor_proto::ReservedRange,
             > as ::std::clone::Clone>::clone(&self.reserved_range),
-            reserved_name: <self::_puroro::internal::field_type::RepeatedUnsizedField::<
+            reserved_name: <self::_pinternal::field_type::RepeatedUnsizedField::<
                 ::std::string::String,
-                self::_puroro::internal::tags::String,
+                self::_pinternal::tags::String,
             > as ::std::clone::Clone>::clone(&self.reserved_name),
             _bitfield: ::std::clone::Clone::clone(&self._bitfield),
         }
@@ -1538,7 +1504,7 @@ impl ::std::clone::Clone for DescriptorProto {
 impl ::std::ops::Drop for DescriptorProto {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for DescriptorProto {
@@ -1563,7 +1529,7 @@ impl ::std::fmt::Debug for DescriptorProto {
 impl ::std::cmp::PartialEq for DescriptorProto {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         true && self.name_opt() == rhs.name_opt() && self.field() == rhs.field()
             && self.extension() == rhs.extension()
             && self.nested_type() == rhs.nested_type()
@@ -1577,37 +1543,35 @@ impl ::std::cmp::PartialEq for DescriptorProto {
 }
 #[derive(::std::default::Default)]
 pub struct ExtensionRangeOptions {
-    uninterpreted_option: self::_puroro::internal::field_type::RepeatedMessageField::<
-        self::_puroro_root::google::protobuf::UninterpretedOption,
+    uninterpreted_option: self::_pinternal::field_type::RepeatedMessageField::<
+        self::_root::google::protobuf::UninterpretedOption,
     >,
-    _bitfield: self::_puroro::internal::bitvec::BitArray<0usize>,
+    _bitfield: self::_pinternal::bitvec::BitArray<0usize>,
 }
 impl ExtensionRangeOptions {
     pub fn uninterpreted_option(
         &self,
-    ) -> &[self::_puroro_root::google::protobuf::UninterpretedOption] {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::UninterpretedOption,
+    ) -> &[self::_root::google::protobuf::UninterpretedOption] {
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::UninterpretedOption,
         > as RepeatedFieldType>::get_field(&self.uninterpreted_option, &self._bitfield)
     }
     pub fn uninterpreted_option_mut(
         &mut self,
-    ) -> &mut ::std::vec::Vec::<
-        self::_puroro_root::google::protobuf::UninterpretedOption,
-    > {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::UninterpretedOption,
+    ) -> &mut ::std::vec::Vec::<self::_root::google::protobuf::UninterpretedOption> {
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::UninterpretedOption,
         > as RepeatedFieldType>::get_field_mut(
             &mut self.uninterpreted_option,
             &mut self._bitfield,
         )
     }
     pub fn clear_uninterpreted_option(&mut self) {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::UninterpretedOption,
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::UninterpretedOption,
         > as RepeatedFieldType>::clear(
             &mut self.uninterpreted_option,
             &mut self._bitfield,
@@ -1626,16 +1590,16 @@ impl self::_puroro::Message for ExtensionRangeOptions {
         &mut self,
         mut iter: I,
     ) -> self::_puroro::Result<()> {
-        use self::_puroro::internal::ser::FieldData;
+        use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 999i32 => {
-                    <self::_puroro::internal::field_type::RepeatedMessageField::<
-                        self::_puroro_root::google::protobuf::UninterpretedOption,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    <self::_pinternal::field_type::RepeatedMessageField::<
+                        self::_root::google::protobuf::UninterpretedOption,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.uninterpreted_option,
                         &mut self._bitfield,
                         field_data,
@@ -1652,10 +1616,10 @@ impl self::_puroro::Message for ExtensionRangeOptions {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::UninterpretedOption,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        use self::_pinternal::oneof_type::OneofUnion as _;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::UninterpretedOption,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.uninterpreted_option,
             &self._bitfield,
             999i32,
@@ -1667,8 +1631,8 @@ impl self::_puroro::Message for ExtensionRangeOptions {
 impl ::std::clone::Clone for ExtensionRangeOptions {
     fn clone(&self) -> Self {
         Self {
-            uninterpreted_option: <self::_puroro::internal::field_type::RepeatedMessageField::<
-                self::_puroro_root::google::protobuf::UninterpretedOption,
+            uninterpreted_option: <self::_pinternal::field_type::RepeatedMessageField::<
+                self::_root::google::protobuf::UninterpretedOption,
             > as ::std::clone::Clone>::clone(&self.uninterpreted_option),
             _bitfield: ::std::clone::Clone::clone(&self._bitfield),
         }
@@ -1677,7 +1641,7 @@ impl ::std::clone::Clone for ExtensionRangeOptions {
 impl ::std::ops::Drop for ExtensionRangeOptions {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for ExtensionRangeOptions {
@@ -1693,77 +1657,77 @@ impl ::std::fmt::Debug for ExtensionRangeOptions {
 impl ::std::cmp::PartialEq for ExtensionRangeOptions {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         true && self.uninterpreted_option() == rhs.uninterpreted_option()
     }
 }
 #[derive(::std::default::Default)]
 pub struct FieldDescriptorProto {
-    name: self::_puroro::internal::field_type::OptionalUnsizedField::<
+    name: self::_pinternal::field_type::OptionalUnsizedField::<
         ::std::string::String,
-        self::_puroro::internal::tags::String,
+        self::_pinternal::tags::String,
         0usize,
     >,
-    number: self::_puroro::internal::field_type::OptionalNumericalField::<
+    number: self::_pinternal::field_type::OptionalNumericalField::<
         i32,
-        self::_puroro::internal::tags::Int32,
+        self::_pinternal::tags::Int32,
         1usize,
     >,
-    label: self::_puroro::internal::field_type::OptionalNumericalField::<
-        self::_puroro_root::google::protobuf::field_descriptor_proto::Label,
-        self::_puroro::internal::tags::Enum2::<
-            self::_puroro_root::google::protobuf::field_descriptor_proto::Label,
+    label: self::_pinternal::field_type::OptionalNumericalField::<
+        self::_root::google::protobuf::field_descriptor_proto::Label,
+        self::_pinternal::tags::Enum2::<
+            self::_root::google::protobuf::field_descriptor_proto::Label,
         >,
         2usize,
     >,
-    r#type: self::_puroro::internal::field_type::OptionalNumericalField::<
-        self::_puroro_root::google::protobuf::field_descriptor_proto::Type,
-        self::_puroro::internal::tags::Enum2::<
-            self::_puroro_root::google::protobuf::field_descriptor_proto::Type,
+    r#type: self::_pinternal::field_type::OptionalNumericalField::<
+        self::_root::google::protobuf::field_descriptor_proto::Type,
+        self::_pinternal::tags::Enum2::<
+            self::_root::google::protobuf::field_descriptor_proto::Type,
         >,
         3usize,
     >,
-    type_name: self::_puroro::internal::field_type::OptionalUnsizedField::<
+    type_name: self::_pinternal::field_type::OptionalUnsizedField::<
         ::std::string::String,
-        self::_puroro::internal::tags::String,
+        self::_pinternal::tags::String,
         4usize,
     >,
-    extendee: self::_puroro::internal::field_type::OptionalUnsizedField::<
+    extendee: self::_pinternal::field_type::OptionalUnsizedField::<
         ::std::string::String,
-        self::_puroro::internal::tags::String,
+        self::_pinternal::tags::String,
         5usize,
     >,
-    default_value: self::_puroro::internal::field_type::OptionalUnsizedField::<
+    default_value: self::_pinternal::field_type::OptionalUnsizedField::<
         ::std::string::String,
-        self::_puroro::internal::tags::String,
+        self::_pinternal::tags::String,
         6usize,
     >,
-    oneof_index: self::_puroro::internal::field_type::OptionalNumericalField::<
+    oneof_index: self::_pinternal::field_type::OptionalNumericalField::<
         i32,
-        self::_puroro::internal::tags::Int32,
+        self::_pinternal::tags::Int32,
         7usize,
     >,
-    json_name: self::_puroro::internal::field_type::OptionalUnsizedField::<
+    json_name: self::_pinternal::field_type::OptionalUnsizedField::<
         ::std::string::String,
-        self::_puroro::internal::tags::String,
+        self::_pinternal::tags::String,
         8usize,
     >,
-    options: self::_puroro::internal::field_type::SingularHeapMessageField::<
-        self::_puroro_root::google::protobuf::FieldOptions,
+    options: self::_pinternal::field_type::SingularHeapMessageField::<
+        self::_root::google::protobuf::FieldOptions,
     >,
-    proto3_optional: self::_puroro::internal::field_type::OptionalNumericalField::<
+    proto3_optional: self::_pinternal::field_type::OptionalNumericalField::<
         bool,
-        self::_puroro::internal::tags::Bool,
+        self::_pinternal::tags::Bool,
         9usize,
     >,
-    _bitfield: self::_puroro::internal::bitvec::BitArray<1usize>,
+    _bitfield: self::_pinternal::bitvec::BitArray<1usize>,
 }
 impl FieldDescriptorProto {
     pub fn name(&self) -> &str {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.name,
@@ -1772,18 +1736,18 @@ impl FieldDescriptorProto {
         )
     }
     pub fn name_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.name, &self._bitfield)
     }
     pub fn name_mut(&mut self) -> &mut ::std::string::String {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.name,
@@ -1792,27 +1756,27 @@ impl FieldDescriptorProto {
         )
     }
     pub fn has_name(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.name, &self._bitfield)
             .is_some()
     }
     pub fn clear_name(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::clear(&mut self.name, &mut self._bitfield)
     }
     pub fn number(&self) -> i32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             1usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.number,
@@ -1821,18 +1785,18 @@ impl FieldDescriptorProto {
         )
     }
     pub fn number_opt(&self) -> ::std::option::Option::<i32> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             1usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.number, &self._bitfield)
     }
     pub fn number_mut(&mut self) -> &mut i32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             1usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.number,
@@ -1841,30 +1805,28 @@ impl FieldDescriptorProto {
         )
     }
     pub fn has_number(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             1usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.number, &self._bitfield)
             .is_some()
     }
     pub fn clear_number(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             1usize,
         > as NonRepeatedFieldType>::clear(&mut self.number, &mut self._bitfield)
     }
-    pub fn label(
-        &self,
-    ) -> self::_puroro_root::google::protobuf::field_descriptor_proto::Label {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
-            self::_puroro_root::google::protobuf::field_descriptor_proto::Label,
-            self::_puroro::internal::tags::Enum2::<
-                self::_puroro_root::google::protobuf::field_descriptor_proto::Label,
+    pub fn label(&self) -> self::_root::google::protobuf::field_descriptor_proto::Label {
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
+            self::_root::google::protobuf::field_descriptor_proto::Label,
+            self::_pinternal::tags::Enum2::<
+                self::_root::google::protobuf::field_descriptor_proto::Label,
             >,
             2usize,
         > as NonRepeatedFieldType>::get_field_or_else(
@@ -1876,25 +1838,25 @@ impl FieldDescriptorProto {
     pub fn label_opt(
         &self,
     ) -> ::std::option::Option::<
-        self::_puroro_root::google::protobuf::field_descriptor_proto::Label,
+        self::_root::google::protobuf::field_descriptor_proto::Label,
     > {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
-            self::_puroro_root::google::protobuf::field_descriptor_proto::Label,
-            self::_puroro::internal::tags::Enum2::<
-                self::_puroro_root::google::protobuf::field_descriptor_proto::Label,
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
+            self::_root::google::protobuf::field_descriptor_proto::Label,
+            self::_pinternal::tags::Enum2::<
+                self::_root::google::protobuf::field_descriptor_proto::Label,
             >,
             2usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.label, &self._bitfield)
     }
     pub fn label_mut(
         &mut self,
-    ) -> &mut self::_puroro_root::google::protobuf::field_descriptor_proto::Label {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
-            self::_puroro_root::google::protobuf::field_descriptor_proto::Label,
-            self::_puroro::internal::tags::Enum2::<
-                self::_puroro_root::google::protobuf::field_descriptor_proto::Label,
+    ) -> &mut self::_root::google::protobuf::field_descriptor_proto::Label {
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
+            self::_root::google::protobuf::field_descriptor_proto::Label,
+            self::_pinternal::tags::Enum2::<
+                self::_root::google::protobuf::field_descriptor_proto::Label,
             >,
             2usize,
         > as NonRepeatedFieldType>::get_field_mut(
@@ -1904,34 +1866,32 @@ impl FieldDescriptorProto {
         )
     }
     pub fn has_label(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
-            self::_puroro_root::google::protobuf::field_descriptor_proto::Label,
-            self::_puroro::internal::tags::Enum2::<
-                self::_puroro_root::google::protobuf::field_descriptor_proto::Label,
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
+            self::_root::google::protobuf::field_descriptor_proto::Label,
+            self::_pinternal::tags::Enum2::<
+                self::_root::google::protobuf::field_descriptor_proto::Label,
             >,
             2usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.label, &self._bitfield)
             .is_some()
     }
     pub fn clear_label(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
-            self::_puroro_root::google::protobuf::field_descriptor_proto::Label,
-            self::_puroro::internal::tags::Enum2::<
-                self::_puroro_root::google::protobuf::field_descriptor_proto::Label,
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
+            self::_root::google::protobuf::field_descriptor_proto::Label,
+            self::_pinternal::tags::Enum2::<
+                self::_root::google::protobuf::field_descriptor_proto::Label,
             >,
             2usize,
         > as NonRepeatedFieldType>::clear(&mut self.label, &mut self._bitfield)
     }
-    pub fn r#type(
-        &self,
-    ) -> self::_puroro_root::google::protobuf::field_descriptor_proto::Type {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
-            self::_puroro_root::google::protobuf::field_descriptor_proto::Type,
-            self::_puroro::internal::tags::Enum2::<
-                self::_puroro_root::google::protobuf::field_descriptor_proto::Type,
+    pub fn r#type(&self) -> self::_root::google::protobuf::field_descriptor_proto::Type {
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
+            self::_root::google::protobuf::field_descriptor_proto::Type,
+            self::_pinternal::tags::Enum2::<
+                self::_root::google::protobuf::field_descriptor_proto::Type,
             >,
             3usize,
         > as NonRepeatedFieldType>::get_field_or_else(
@@ -1943,25 +1903,25 @@ impl FieldDescriptorProto {
     pub fn type_opt(
         &self,
     ) -> ::std::option::Option::<
-        self::_puroro_root::google::protobuf::field_descriptor_proto::Type,
+        self::_root::google::protobuf::field_descriptor_proto::Type,
     > {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
-            self::_puroro_root::google::protobuf::field_descriptor_proto::Type,
-            self::_puroro::internal::tags::Enum2::<
-                self::_puroro_root::google::protobuf::field_descriptor_proto::Type,
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
+            self::_root::google::protobuf::field_descriptor_proto::Type,
+            self::_pinternal::tags::Enum2::<
+                self::_root::google::protobuf::field_descriptor_proto::Type,
             >,
             3usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.r#type, &self._bitfield)
     }
     pub fn type_mut(
         &mut self,
-    ) -> &mut self::_puroro_root::google::protobuf::field_descriptor_proto::Type {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
-            self::_puroro_root::google::protobuf::field_descriptor_proto::Type,
-            self::_puroro::internal::tags::Enum2::<
-                self::_puroro_root::google::protobuf::field_descriptor_proto::Type,
+    ) -> &mut self::_root::google::protobuf::field_descriptor_proto::Type {
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
+            self::_root::google::protobuf::field_descriptor_proto::Type,
+            self::_pinternal::tags::Enum2::<
+                self::_root::google::protobuf::field_descriptor_proto::Type,
             >,
             3usize,
         > as NonRepeatedFieldType>::get_field_mut(
@@ -1971,31 +1931,31 @@ impl FieldDescriptorProto {
         )
     }
     pub fn has_type(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
-            self::_puroro_root::google::protobuf::field_descriptor_proto::Type,
-            self::_puroro::internal::tags::Enum2::<
-                self::_puroro_root::google::protobuf::field_descriptor_proto::Type,
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
+            self::_root::google::protobuf::field_descriptor_proto::Type,
+            self::_pinternal::tags::Enum2::<
+                self::_root::google::protobuf::field_descriptor_proto::Type,
             >,
             3usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.r#type, &self._bitfield)
             .is_some()
     }
     pub fn clear_type(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
-            self::_puroro_root::google::protobuf::field_descriptor_proto::Type,
-            self::_puroro::internal::tags::Enum2::<
-                self::_puroro_root::google::protobuf::field_descriptor_proto::Type,
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
+            self::_root::google::protobuf::field_descriptor_proto::Type,
+            self::_pinternal::tags::Enum2::<
+                self::_root::google::protobuf::field_descriptor_proto::Type,
             >,
             3usize,
         > as NonRepeatedFieldType>::clear(&mut self.r#type, &mut self._bitfield)
     }
     pub fn type_name(&self) -> &str {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             4usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.type_name,
@@ -2004,18 +1964,18 @@ impl FieldDescriptorProto {
         )
     }
     pub fn type_name_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             4usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.type_name, &self._bitfield)
     }
     pub fn type_name_mut(&mut self) -> &mut ::std::string::String {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             4usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.type_name,
@@ -2024,27 +1984,27 @@ impl FieldDescriptorProto {
         )
     }
     pub fn has_type_name(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             4usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.type_name, &self._bitfield)
             .is_some()
     }
     pub fn clear_type_name(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             4usize,
         > as NonRepeatedFieldType>::clear(&mut self.type_name, &mut self._bitfield)
     }
     pub fn extendee(&self) -> &str {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             5usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.extendee,
@@ -2053,18 +2013,18 @@ impl FieldDescriptorProto {
         )
     }
     pub fn extendee_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             5usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.extendee, &self._bitfield)
     }
     pub fn extendee_mut(&mut self) -> &mut ::std::string::String {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             5usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.extendee,
@@ -2073,27 +2033,27 @@ impl FieldDescriptorProto {
         )
     }
     pub fn has_extendee(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             5usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.extendee, &self._bitfield)
             .is_some()
     }
     pub fn clear_extendee(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             5usize,
         > as NonRepeatedFieldType>::clear(&mut self.extendee, &mut self._bitfield)
     }
     pub fn default_value(&self) -> &str {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             6usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.default_value,
@@ -2102,18 +2062,18 @@ impl FieldDescriptorProto {
         )
     }
     pub fn default_value_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             6usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.default_value, &self._bitfield)
     }
     pub fn default_value_mut(&mut self) -> &mut ::std::string::String {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             6usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.default_value,
@@ -2122,27 +2082,27 @@ impl FieldDescriptorProto {
         )
     }
     pub fn has_default_value(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             6usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.default_value, &self._bitfield)
             .is_some()
     }
     pub fn clear_default_value(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             6usize,
         > as NonRepeatedFieldType>::clear(&mut self.default_value, &mut self._bitfield)
     }
     pub fn oneof_index(&self) -> i32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             7usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.oneof_index,
@@ -2151,18 +2111,18 @@ impl FieldDescriptorProto {
         )
     }
     pub fn oneof_index_opt(&self) -> ::std::option::Option::<i32> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             7usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.oneof_index, &self._bitfield)
     }
     pub fn oneof_index_mut(&mut self) -> &mut i32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             7usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.oneof_index,
@@ -2171,27 +2131,27 @@ impl FieldDescriptorProto {
         )
     }
     pub fn has_oneof_index(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             7usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.oneof_index, &self._bitfield)
             .is_some()
     }
     pub fn clear_oneof_index(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             7usize,
         > as NonRepeatedFieldType>::clear(&mut self.oneof_index, &mut self._bitfield)
     }
     pub fn json_name(&self) -> &str {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             8usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.json_name,
@@ -2200,18 +2160,18 @@ impl FieldDescriptorProto {
         )
     }
     pub fn json_name_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             8usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.json_name, &self._bitfield)
     }
     pub fn json_name_mut(&mut self) -> &mut ::std::string::String {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             8usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.json_name,
@@ -2220,28 +2180,28 @@ impl FieldDescriptorProto {
         )
     }
     pub fn has_json_name(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             8usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.json_name, &self._bitfield)
             .is_some()
     }
     pub fn clear_json_name(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             8usize,
         > as NonRepeatedFieldType>::clear(&mut self.json_name, &mut self._bitfield)
     }
     pub fn options(
         &self,
-    ) -> ::std::option::Option::<&self::_puroro_root::google::protobuf::FieldOptions> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::google::protobuf::FieldOptions,
+    ) -> ::std::option::Option::<&self::_root::google::protobuf::FieldOptions> {
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::google::protobuf::FieldOptions,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.options,
             &self._bitfield,
@@ -2250,18 +2210,16 @@ impl FieldDescriptorProto {
     }
     pub fn options_opt(
         &self,
-    ) -> ::std::option::Option::<&self::_puroro_root::google::protobuf::FieldOptions> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::google::protobuf::FieldOptions,
+    ) -> ::std::option::Option::<&self::_root::google::protobuf::FieldOptions> {
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::google::protobuf::FieldOptions,
         > as NonRepeatedFieldType>::get_field_opt(&self.options, &self._bitfield)
     }
-    pub fn options_mut(
-        &mut self,
-    ) -> &mut self::_puroro_root::google::protobuf::FieldOptions {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::google::protobuf::FieldOptions,
+    pub fn options_mut(&mut self) -> &mut self::_root::google::protobuf::FieldOptions {
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::google::protobuf::FieldOptions,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.options,
             &mut self._bitfield,
@@ -2269,23 +2227,23 @@ impl FieldDescriptorProto {
         )
     }
     pub fn has_options(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::google::protobuf::FieldOptions,
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::google::protobuf::FieldOptions,
         > as NonRepeatedFieldType>::get_field_opt(&self.options, &self._bitfield)
             .is_some()
     }
     pub fn clear_options(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::google::protobuf::FieldOptions,
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::google::protobuf::FieldOptions,
         > as NonRepeatedFieldType>::clear(&mut self.options, &mut self._bitfield)
     }
     pub fn proto3_optional(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             9usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.proto3_optional,
@@ -2294,18 +2252,18 @@ impl FieldDescriptorProto {
         )
     }
     pub fn proto3_optional_opt(&self) -> ::std::option::Option::<bool> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             9usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.proto3_optional, &self._bitfield)
     }
     pub fn proto3_optional_mut(&mut self) -> &mut bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             9usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.proto3_optional,
@@ -2314,19 +2272,19 @@ impl FieldDescriptorProto {
         )
     }
     pub fn has_proto3_optional(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             9usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.proto3_optional, &self._bitfield)
             .is_some()
     }
     pub fn clear_proto3_optional(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             9usize,
         > as NonRepeatedFieldType>::clear(&mut self.proto3_optional, &mut self._bitfield)
     }
@@ -2343,130 +2301,130 @@ impl self::_puroro::Message for FieldDescriptorProto {
         &mut self,
         mut iter: I,
     ) -> self::_puroro::Result<()> {
-        use self::_puroro::internal::ser::FieldData;
+        use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 1i32 => {
-                    <self::_puroro::internal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::field_type::OptionalUnsizedField::<
                         ::std::string::String,
-                        self::_puroro::internal::tags::String,
+                        self::_pinternal::tags::String,
                         0usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.name,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 3i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         i32,
-                        self::_puroro::internal::tags::Int32,
+                        self::_pinternal::tags::Int32,
                         1usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.number,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 4i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
-                        self::_puroro_root::google::protobuf::field_descriptor_proto::Label,
-                        self::_puroro::internal::tags::Enum2::<
-                            self::_puroro_root::google::protobuf::field_descriptor_proto::Label,
+                    <self::_pinternal::field_type::OptionalNumericalField::<
+                        self::_root::google::protobuf::field_descriptor_proto::Label,
+                        self::_pinternal::tags::Enum2::<
+                            self::_root::google::protobuf::field_descriptor_proto::Label,
                         >,
                         2usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.label,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 5i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
-                        self::_puroro_root::google::protobuf::field_descriptor_proto::Type,
-                        self::_puroro::internal::tags::Enum2::<
-                            self::_puroro_root::google::protobuf::field_descriptor_proto::Type,
+                    <self::_pinternal::field_type::OptionalNumericalField::<
+                        self::_root::google::protobuf::field_descriptor_proto::Type,
+                        self::_pinternal::tags::Enum2::<
+                            self::_root::google::protobuf::field_descriptor_proto::Type,
                         >,
                         3usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.r#type,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 6i32 => {
-                    <self::_puroro::internal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::field_type::OptionalUnsizedField::<
                         ::std::string::String,
-                        self::_puroro::internal::tags::String,
+                        self::_pinternal::tags::String,
                         4usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.type_name,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 2i32 => {
-                    <self::_puroro::internal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::field_type::OptionalUnsizedField::<
                         ::std::string::String,
-                        self::_puroro::internal::tags::String,
+                        self::_pinternal::tags::String,
                         5usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.extendee,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 7i32 => {
-                    <self::_puroro::internal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::field_type::OptionalUnsizedField::<
                         ::std::string::String,
-                        self::_puroro::internal::tags::String,
+                        self::_pinternal::tags::String,
                         6usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.default_value,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 9i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         i32,
-                        self::_puroro::internal::tags::Int32,
+                        self::_pinternal::tags::Int32,
                         7usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.oneof_index,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 10i32 => {
-                    <self::_puroro::internal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::field_type::OptionalUnsizedField::<
                         ::std::string::String,
-                        self::_puroro::internal::tags::String,
+                        self::_pinternal::tags::String,
                         8usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.json_name,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 8i32 => {
-                    <self::_puroro::internal::field_type::SingularHeapMessageField::<
-                        self::_puroro_root::google::protobuf::FieldOptions,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    <self::_pinternal::field_type::SingularHeapMessageField::<
+                        self::_root::google::protobuf::FieldOptions,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.options,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 17i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         bool,
-                        self::_puroro::internal::tags::Bool,
+                        self::_pinternal::tags::Bool,
                         9usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.proto3_optional,
                         &mut self._bitfield,
                         field_data,
@@ -2483,114 +2441,114 @@ impl self::_puroro::Message for FieldDescriptorProto {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::oneof_type::OneofUnion as _;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.name,
             &self._bitfield,
             1i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             1usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.number,
             &self._bitfield,
             3i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
-            self::_puroro_root::google::protobuf::field_descriptor_proto::Label,
-            self::_puroro::internal::tags::Enum2::<
-                self::_puroro_root::google::protobuf::field_descriptor_proto::Label,
+        <self::_pinternal::field_type::OptionalNumericalField::<
+            self::_root::google::protobuf::field_descriptor_proto::Label,
+            self::_pinternal::tags::Enum2::<
+                self::_root::google::protobuf::field_descriptor_proto::Label,
             >,
             2usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.label,
             &self._bitfield,
             4i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
-            self::_puroro_root::google::protobuf::field_descriptor_proto::Type,
-            self::_puroro::internal::tags::Enum2::<
-                self::_puroro_root::google::protobuf::field_descriptor_proto::Type,
+        <self::_pinternal::field_type::OptionalNumericalField::<
+            self::_root::google::protobuf::field_descriptor_proto::Type,
+            self::_pinternal::tags::Enum2::<
+                self::_root::google::protobuf::field_descriptor_proto::Type,
             >,
             3usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.r#type,
             &self._bitfield,
             5i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             4usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.type_name,
             &self._bitfield,
             6i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             5usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.extendee,
             &self._bitfield,
             2i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             6usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.default_value,
             &self._bitfield,
             7i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             7usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.oneof_index,
             &self._bitfield,
             9i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             8usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.json_name,
             &self._bitfield,
             10i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::google::protobuf::FieldOptions,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::google::protobuf::FieldOptions,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.options,
             &self._bitfield,
             8i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             9usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.proto3_optional,
             &self._bitfield,
             17i32,
@@ -2602,61 +2560,61 @@ impl self::_puroro::Message for FieldDescriptorProto {
 impl ::std::clone::Clone for FieldDescriptorProto {
     fn clone(&self) -> Self {
         Self {
-            name: <self::_puroro::internal::field_type::OptionalUnsizedField::<
+            name: <self::_pinternal::field_type::OptionalUnsizedField::<
                 ::std::string::String,
-                self::_puroro::internal::tags::String,
+                self::_pinternal::tags::String,
                 0usize,
             > as ::std::clone::Clone>::clone(&self.name),
-            number: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            number: <self::_pinternal::field_type::OptionalNumericalField::<
                 i32,
-                self::_puroro::internal::tags::Int32,
+                self::_pinternal::tags::Int32,
                 1usize,
             > as ::std::clone::Clone>::clone(&self.number),
-            label: <self::_puroro::internal::field_type::OptionalNumericalField::<
-                self::_puroro_root::google::protobuf::field_descriptor_proto::Label,
-                self::_puroro::internal::tags::Enum2::<
-                    self::_puroro_root::google::protobuf::field_descriptor_proto::Label,
+            label: <self::_pinternal::field_type::OptionalNumericalField::<
+                self::_root::google::protobuf::field_descriptor_proto::Label,
+                self::_pinternal::tags::Enum2::<
+                    self::_root::google::protobuf::field_descriptor_proto::Label,
                 >,
                 2usize,
             > as ::std::clone::Clone>::clone(&self.label),
-            r#type: <self::_puroro::internal::field_type::OptionalNumericalField::<
-                self::_puroro_root::google::protobuf::field_descriptor_proto::Type,
-                self::_puroro::internal::tags::Enum2::<
-                    self::_puroro_root::google::protobuf::field_descriptor_proto::Type,
+            r#type: <self::_pinternal::field_type::OptionalNumericalField::<
+                self::_root::google::protobuf::field_descriptor_proto::Type,
+                self::_pinternal::tags::Enum2::<
+                    self::_root::google::protobuf::field_descriptor_proto::Type,
                 >,
                 3usize,
             > as ::std::clone::Clone>::clone(&self.r#type),
-            type_name: <self::_puroro::internal::field_type::OptionalUnsizedField::<
+            type_name: <self::_pinternal::field_type::OptionalUnsizedField::<
                 ::std::string::String,
-                self::_puroro::internal::tags::String,
+                self::_pinternal::tags::String,
                 4usize,
             > as ::std::clone::Clone>::clone(&self.type_name),
-            extendee: <self::_puroro::internal::field_type::OptionalUnsizedField::<
+            extendee: <self::_pinternal::field_type::OptionalUnsizedField::<
                 ::std::string::String,
-                self::_puroro::internal::tags::String,
+                self::_pinternal::tags::String,
                 5usize,
             > as ::std::clone::Clone>::clone(&self.extendee),
-            default_value: <self::_puroro::internal::field_type::OptionalUnsizedField::<
+            default_value: <self::_pinternal::field_type::OptionalUnsizedField::<
                 ::std::string::String,
-                self::_puroro::internal::tags::String,
+                self::_pinternal::tags::String,
                 6usize,
             > as ::std::clone::Clone>::clone(&self.default_value),
-            oneof_index: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            oneof_index: <self::_pinternal::field_type::OptionalNumericalField::<
                 i32,
-                self::_puroro::internal::tags::Int32,
+                self::_pinternal::tags::Int32,
                 7usize,
             > as ::std::clone::Clone>::clone(&self.oneof_index),
-            json_name: <self::_puroro::internal::field_type::OptionalUnsizedField::<
+            json_name: <self::_pinternal::field_type::OptionalUnsizedField::<
                 ::std::string::String,
-                self::_puroro::internal::tags::String,
+                self::_pinternal::tags::String,
                 8usize,
             > as ::std::clone::Clone>::clone(&self.json_name),
-            options: <self::_puroro::internal::field_type::SingularHeapMessageField::<
-                self::_puroro_root::google::protobuf::FieldOptions,
+            options: <self::_pinternal::field_type::SingularHeapMessageField::<
+                self::_root::google::protobuf::FieldOptions,
             > as ::std::clone::Clone>::clone(&self.options),
-            proto3_optional: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            proto3_optional: <self::_pinternal::field_type::OptionalNumericalField::<
                 bool,
-                self::_puroro::internal::tags::Bool,
+                self::_pinternal::tags::Bool,
                 9usize,
             > as ::std::clone::Clone>::clone(&self.proto3_optional),
             _bitfield: ::std::clone::Clone::clone(&self._bitfield),
@@ -2666,7 +2624,7 @@ impl ::std::clone::Clone for FieldDescriptorProto {
 impl ::std::ops::Drop for FieldDescriptorProto {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for FieldDescriptorProto {
@@ -2692,7 +2650,7 @@ impl ::std::fmt::Debug for FieldDescriptorProto {
 impl ::std::cmp::PartialEq for FieldDescriptorProto {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         true && self.name_opt() == rhs.name_opt()
             && self.number_opt() == rhs.number_opt()
             && self.label_opt() == rhs.label_opt() && self.type_opt() == rhs.type_opt()
@@ -2707,22 +2665,22 @@ impl ::std::cmp::PartialEq for FieldDescriptorProto {
 }
 #[derive(::std::default::Default)]
 pub struct OneofDescriptorProto {
-    name: self::_puroro::internal::field_type::OptionalUnsizedField::<
+    name: self::_pinternal::field_type::OptionalUnsizedField::<
         ::std::string::String,
-        self::_puroro::internal::tags::String,
+        self::_pinternal::tags::String,
         0usize,
     >,
-    options: self::_puroro::internal::field_type::SingularHeapMessageField::<
-        self::_puroro_root::google::protobuf::OneofOptions,
+    options: self::_pinternal::field_type::SingularHeapMessageField::<
+        self::_root::google::protobuf::OneofOptions,
     >,
-    _bitfield: self::_puroro::internal::bitvec::BitArray<1usize>,
+    _bitfield: self::_pinternal::bitvec::BitArray<1usize>,
 }
 impl OneofDescriptorProto {
     pub fn name(&self) -> &str {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.name,
@@ -2731,18 +2689,18 @@ impl OneofDescriptorProto {
         )
     }
     pub fn name_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.name, &self._bitfield)
     }
     pub fn name_mut(&mut self) -> &mut ::std::string::String {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.name,
@@ -2751,28 +2709,28 @@ impl OneofDescriptorProto {
         )
     }
     pub fn has_name(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.name, &self._bitfield)
             .is_some()
     }
     pub fn clear_name(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::clear(&mut self.name, &mut self._bitfield)
     }
     pub fn options(
         &self,
-    ) -> ::std::option::Option::<&self::_puroro_root::google::protobuf::OneofOptions> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::google::protobuf::OneofOptions,
+    ) -> ::std::option::Option::<&self::_root::google::protobuf::OneofOptions> {
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::google::protobuf::OneofOptions,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.options,
             &self._bitfield,
@@ -2781,18 +2739,16 @@ impl OneofDescriptorProto {
     }
     pub fn options_opt(
         &self,
-    ) -> ::std::option::Option::<&self::_puroro_root::google::protobuf::OneofOptions> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::google::protobuf::OneofOptions,
+    ) -> ::std::option::Option::<&self::_root::google::protobuf::OneofOptions> {
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::google::protobuf::OneofOptions,
         > as NonRepeatedFieldType>::get_field_opt(&self.options, &self._bitfield)
     }
-    pub fn options_mut(
-        &mut self,
-    ) -> &mut self::_puroro_root::google::protobuf::OneofOptions {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::google::protobuf::OneofOptions,
+    pub fn options_mut(&mut self) -> &mut self::_root::google::protobuf::OneofOptions {
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::google::protobuf::OneofOptions,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.options,
             &mut self._bitfield,
@@ -2800,16 +2756,16 @@ impl OneofDescriptorProto {
         )
     }
     pub fn has_options(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::google::protobuf::OneofOptions,
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::google::protobuf::OneofOptions,
         > as NonRepeatedFieldType>::get_field_opt(&self.options, &self._bitfield)
             .is_some()
     }
     pub fn clear_options(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::google::protobuf::OneofOptions,
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::google::protobuf::OneofOptions,
         > as NonRepeatedFieldType>::clear(&mut self.options, &mut self._bitfield)
     }
 }
@@ -2825,27 +2781,27 @@ impl self::_puroro::Message for OneofDescriptorProto {
         &mut self,
         mut iter: I,
     ) -> self::_puroro::Result<()> {
-        use self::_puroro::internal::ser::FieldData;
+        use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 1i32 => {
-                    <self::_puroro::internal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::field_type::OptionalUnsizedField::<
                         ::std::string::String,
-                        self::_puroro::internal::tags::String,
+                        self::_pinternal::tags::String,
                         0usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.name,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 2i32 => {
-                    <self::_puroro::internal::field_type::SingularHeapMessageField::<
-                        self::_puroro_root::google::protobuf::OneofOptions,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    <self::_pinternal::field_type::SingularHeapMessageField::<
+                        self::_root::google::protobuf::OneofOptions,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.options,
                         &mut self._bitfield,
                         field_data,
@@ -2862,20 +2818,20 @@ impl self::_puroro::Message for OneofDescriptorProto {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::oneof_type::OneofUnion as _;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.name,
             &self._bitfield,
             1i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::google::protobuf::OneofOptions,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::google::protobuf::OneofOptions,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.options,
             &self._bitfield,
             2i32,
@@ -2887,13 +2843,13 @@ impl self::_puroro::Message for OneofDescriptorProto {
 impl ::std::clone::Clone for OneofDescriptorProto {
     fn clone(&self) -> Self {
         Self {
-            name: <self::_puroro::internal::field_type::OptionalUnsizedField::<
+            name: <self::_pinternal::field_type::OptionalUnsizedField::<
                 ::std::string::String,
-                self::_puroro::internal::tags::String,
+                self::_pinternal::tags::String,
                 0usize,
             > as ::std::clone::Clone>::clone(&self.name),
-            options: <self::_puroro::internal::field_type::SingularHeapMessageField::<
-                self::_puroro_root::google::protobuf::OneofOptions,
+            options: <self::_pinternal::field_type::SingularHeapMessageField::<
+                self::_root::google::protobuf::OneofOptions,
             > as ::std::clone::Clone>::clone(&self.options),
             _bitfield: ::std::clone::Clone::clone(&self._bitfield),
         }
@@ -2902,7 +2858,7 @@ impl ::std::clone::Clone for OneofDescriptorProto {
 impl ::std::ops::Drop for OneofDescriptorProto {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for OneofDescriptorProto {
@@ -2919,39 +2875,39 @@ impl ::std::fmt::Debug for OneofDescriptorProto {
 impl ::std::cmp::PartialEq for OneofDescriptorProto {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         true && self.name_opt() == rhs.name_opt()
             && self.options_opt() == rhs.options_opt()
     }
 }
 #[derive(::std::default::Default)]
 pub struct EnumDescriptorProto {
-    name: self::_puroro::internal::field_type::OptionalUnsizedField::<
+    name: self::_pinternal::field_type::OptionalUnsizedField::<
         ::std::string::String,
-        self::_puroro::internal::tags::String,
+        self::_pinternal::tags::String,
         0usize,
     >,
-    value: self::_puroro::internal::field_type::RepeatedMessageField::<
-        self::_puroro_root::google::protobuf::EnumValueDescriptorProto,
+    value: self::_pinternal::field_type::RepeatedMessageField::<
+        self::_root::google::protobuf::EnumValueDescriptorProto,
     >,
-    options: self::_puroro::internal::field_type::SingularHeapMessageField::<
-        self::_puroro_root::google::protobuf::EnumOptions,
+    options: self::_pinternal::field_type::SingularHeapMessageField::<
+        self::_root::google::protobuf::EnumOptions,
     >,
-    reserved_range: self::_puroro::internal::field_type::RepeatedMessageField::<
-        self::_puroro_root::google::protobuf::enum_descriptor_proto::EnumReservedRange,
+    reserved_range: self::_pinternal::field_type::RepeatedMessageField::<
+        self::_root::google::protobuf::enum_descriptor_proto::EnumReservedRange,
     >,
-    reserved_name: self::_puroro::internal::field_type::RepeatedUnsizedField::<
+    reserved_name: self::_pinternal::field_type::RepeatedUnsizedField::<
         ::std::string::String,
-        self::_puroro::internal::tags::String,
+        self::_pinternal::tags::String,
     >,
-    _bitfield: self::_puroro::internal::bitvec::BitArray<1usize>,
+    _bitfield: self::_pinternal::bitvec::BitArray<1usize>,
 }
 impl EnumDescriptorProto {
     pub fn name(&self) -> &str {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.name,
@@ -2960,18 +2916,18 @@ impl EnumDescriptorProto {
         )
     }
     pub fn name_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.name, &self._bitfield)
     }
     pub fn name_mut(&mut self) -> &mut ::std::string::String {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.name,
@@ -2980,52 +2936,50 @@ impl EnumDescriptorProto {
         )
     }
     pub fn has_name(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.name, &self._bitfield)
             .is_some()
     }
     pub fn clear_name(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::clear(&mut self.name, &mut self._bitfield)
     }
-    pub fn value(
-        &self,
-    ) -> &[self::_puroro_root::google::protobuf::EnumValueDescriptorProto] {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::EnumValueDescriptorProto,
+    pub fn value(&self) -> &[self::_root::google::protobuf::EnumValueDescriptorProto] {
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::EnumValueDescriptorProto,
         > as RepeatedFieldType>::get_field(&self.value, &self._bitfield)
     }
     pub fn value_mut(
         &mut self,
     ) -> &mut ::std::vec::Vec::<
-        self::_puroro_root::google::protobuf::EnumValueDescriptorProto,
+        self::_root::google::protobuf::EnumValueDescriptorProto,
     > {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::EnumValueDescriptorProto,
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::EnumValueDescriptorProto,
         > as RepeatedFieldType>::get_field_mut(&mut self.value, &mut self._bitfield)
     }
     pub fn clear_value(&mut self) {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::EnumValueDescriptorProto,
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::EnumValueDescriptorProto,
         > as RepeatedFieldType>::clear(&mut self.value, &mut self._bitfield)
     }
     pub fn options(
         &self,
-    ) -> ::std::option::Option::<&self::_puroro_root::google::protobuf::EnumOptions> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::google::protobuf::EnumOptions,
+    ) -> ::std::option::Option::<&self::_root::google::protobuf::EnumOptions> {
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::google::protobuf::EnumOptions,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.options,
             &self._bitfield,
@@ -3034,18 +2988,16 @@ impl EnumDescriptorProto {
     }
     pub fn options_opt(
         &self,
-    ) -> ::std::option::Option::<&self::_puroro_root::google::protobuf::EnumOptions> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::google::protobuf::EnumOptions,
+    ) -> ::std::option::Option::<&self::_root::google::protobuf::EnumOptions> {
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::google::protobuf::EnumOptions,
         > as NonRepeatedFieldType>::get_field_opt(&self.options, &self._bitfield)
     }
-    pub fn options_mut(
-        &mut self,
-    ) -> &mut self::_puroro_root::google::protobuf::EnumOptions {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::google::protobuf::EnumOptions,
+    pub fn options_mut(&mut self) -> &mut self::_root::google::protobuf::EnumOptions {
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::google::protobuf::EnumOptions,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.options,
             &mut self._bitfield,
@@ -3053,43 +3005,43 @@ impl EnumDescriptorProto {
         )
     }
     pub fn has_options(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::google::protobuf::EnumOptions,
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::google::protobuf::EnumOptions,
         > as NonRepeatedFieldType>::get_field_opt(&self.options, &self._bitfield)
             .is_some()
     }
     pub fn clear_options(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::google::protobuf::EnumOptions,
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::google::protobuf::EnumOptions,
         > as NonRepeatedFieldType>::clear(&mut self.options, &mut self._bitfield)
     }
     pub fn reserved_range(
         &self,
-    ) -> &[self::_puroro_root::google::protobuf::enum_descriptor_proto::EnumReservedRange] {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::enum_descriptor_proto::EnumReservedRange,
+    ) -> &[self::_root::google::protobuf::enum_descriptor_proto::EnumReservedRange] {
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::enum_descriptor_proto::EnumReservedRange,
         > as RepeatedFieldType>::get_field(&self.reserved_range, &self._bitfield)
     }
     pub fn reserved_range_mut(
         &mut self,
     ) -> &mut ::std::vec::Vec::<
-        self::_puroro_root::google::protobuf::enum_descriptor_proto::EnumReservedRange,
+        self::_root::google::protobuf::enum_descriptor_proto::EnumReservedRange,
     > {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::enum_descriptor_proto::EnumReservedRange,
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::enum_descriptor_proto::EnumReservedRange,
         > as RepeatedFieldType>::get_field_mut(
             &mut self.reserved_range,
             &mut self._bitfield,
         )
     }
     pub fn clear_reserved_range(&mut self) {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::enum_descriptor_proto::EnumReservedRange,
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::enum_descriptor_proto::EnumReservedRange,
         > as RepeatedFieldType>::clear(&mut self.reserved_range, &mut self._bitfield)
     }
     pub fn reserved_name(
@@ -3097,29 +3049,29 @@ impl EnumDescriptorProto {
     ) -> &[impl ::std::ops::Deref::<
         Target = str,
     > + ::std::fmt::Debug + ::std::cmp::PartialEq] {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedUnsizedField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
         > as RepeatedFieldType>::get_field(&self.reserved_name, &self._bitfield)
     }
     pub fn reserved_name_mut(
         &mut self,
     ) -> &mut ::std::vec::Vec::<::std::string::String> {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedUnsizedField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
         > as RepeatedFieldType>::get_field_mut(
             &mut self.reserved_name,
             &mut self._bitfield,
         )
     }
     pub fn clear_reserved_name(&mut self) {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedUnsizedField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
         > as RepeatedFieldType>::clear(&mut self.reserved_name, &mut self._bitfield)
     }
 }
@@ -3135,55 +3087,55 @@ impl self::_puroro::Message for EnumDescriptorProto {
         &mut self,
         mut iter: I,
     ) -> self::_puroro::Result<()> {
-        use self::_puroro::internal::ser::FieldData;
+        use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 1i32 => {
-                    <self::_puroro::internal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::field_type::OptionalUnsizedField::<
                         ::std::string::String,
-                        self::_puroro::internal::tags::String,
+                        self::_pinternal::tags::String,
                         0usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.name,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 2i32 => {
-                    <self::_puroro::internal::field_type::RepeatedMessageField::<
-                        self::_puroro_root::google::protobuf::EnumValueDescriptorProto,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    <self::_pinternal::field_type::RepeatedMessageField::<
+                        self::_root::google::protobuf::EnumValueDescriptorProto,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.value,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 3i32 => {
-                    <self::_puroro::internal::field_type::SingularHeapMessageField::<
-                        self::_puroro_root::google::protobuf::EnumOptions,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    <self::_pinternal::field_type::SingularHeapMessageField::<
+                        self::_root::google::protobuf::EnumOptions,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.options,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 4i32 => {
-                    <self::_puroro::internal::field_type::RepeatedMessageField::<
-                        self::_puroro_root::google::protobuf::enum_descriptor_proto::EnumReservedRange,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    <self::_pinternal::field_type::RepeatedMessageField::<
+                        self::_root::google::protobuf::enum_descriptor_proto::EnumReservedRange,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.reserved_range,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 5i32 => {
-                    <self::_puroro::internal::field_type::RepeatedUnsizedField::<
+                    <self::_pinternal::field_type::RepeatedUnsizedField::<
                         ::std::string::String,
-                        self::_puroro::internal::tags::String,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                        self::_pinternal::tags::String,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.reserved_name,
                         &mut self._bitfield,
                         field_data,
@@ -3200,45 +3152,45 @@ impl self::_puroro::Message for EnumDescriptorProto {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::oneof_type::OneofUnion as _;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.name,
             &self._bitfield,
             1i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::EnumValueDescriptorProto,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::EnumValueDescriptorProto,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.value,
             &self._bitfield,
             2i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::google::protobuf::EnumOptions,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::google::protobuf::EnumOptions,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.options,
             &self._bitfield,
             3i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::enum_descriptor_proto::EnumReservedRange,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::enum_descriptor_proto::EnumReservedRange,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.reserved_range,
             &self._bitfield,
             4i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::RepeatedUnsizedField::<
+        <self::_pinternal::field_type::RepeatedUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+            self::_pinternal::tags::String,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.reserved_name,
             &self._bitfield,
             5i32,
@@ -3250,23 +3202,23 @@ impl self::_puroro::Message for EnumDescriptorProto {
 impl ::std::clone::Clone for EnumDescriptorProto {
     fn clone(&self) -> Self {
         Self {
-            name: <self::_puroro::internal::field_type::OptionalUnsizedField::<
+            name: <self::_pinternal::field_type::OptionalUnsizedField::<
                 ::std::string::String,
-                self::_puroro::internal::tags::String,
+                self::_pinternal::tags::String,
                 0usize,
             > as ::std::clone::Clone>::clone(&self.name),
-            value: <self::_puroro::internal::field_type::RepeatedMessageField::<
-                self::_puroro_root::google::protobuf::EnumValueDescriptorProto,
+            value: <self::_pinternal::field_type::RepeatedMessageField::<
+                self::_root::google::protobuf::EnumValueDescriptorProto,
             > as ::std::clone::Clone>::clone(&self.value),
-            options: <self::_puroro::internal::field_type::SingularHeapMessageField::<
-                self::_puroro_root::google::protobuf::EnumOptions,
+            options: <self::_pinternal::field_type::SingularHeapMessageField::<
+                self::_root::google::protobuf::EnumOptions,
             > as ::std::clone::Clone>::clone(&self.options),
-            reserved_range: <self::_puroro::internal::field_type::RepeatedMessageField::<
-                self::_puroro_root::google::protobuf::enum_descriptor_proto::EnumReservedRange,
+            reserved_range: <self::_pinternal::field_type::RepeatedMessageField::<
+                self::_root::google::protobuf::enum_descriptor_proto::EnumReservedRange,
             > as ::std::clone::Clone>::clone(&self.reserved_range),
-            reserved_name: <self::_puroro::internal::field_type::RepeatedUnsizedField::<
+            reserved_name: <self::_pinternal::field_type::RepeatedUnsizedField::<
                 ::std::string::String,
-                self::_puroro::internal::tags::String,
+                self::_pinternal::tags::String,
             > as ::std::clone::Clone>::clone(&self.reserved_name),
             _bitfield: ::std::clone::Clone::clone(&self._bitfield),
         }
@@ -3275,7 +3227,7 @@ impl ::std::clone::Clone for EnumDescriptorProto {
 impl ::std::ops::Drop for EnumDescriptorProto {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for EnumDescriptorProto {
@@ -3295,7 +3247,7 @@ impl ::std::fmt::Debug for EnumDescriptorProto {
 impl ::std::cmp::PartialEq for EnumDescriptorProto {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         true && self.name_opt() == rhs.name_opt() && self.value() == rhs.value()
             && self.options_opt() == rhs.options_opt()
             && self.reserved_range() == rhs.reserved_range()
@@ -3304,27 +3256,27 @@ impl ::std::cmp::PartialEq for EnumDescriptorProto {
 }
 #[derive(::std::default::Default)]
 pub struct EnumValueDescriptorProto {
-    name: self::_puroro::internal::field_type::OptionalUnsizedField::<
+    name: self::_pinternal::field_type::OptionalUnsizedField::<
         ::std::string::String,
-        self::_puroro::internal::tags::String,
+        self::_pinternal::tags::String,
         0usize,
     >,
-    number: self::_puroro::internal::field_type::OptionalNumericalField::<
+    number: self::_pinternal::field_type::OptionalNumericalField::<
         i32,
-        self::_puroro::internal::tags::Int32,
+        self::_pinternal::tags::Int32,
         1usize,
     >,
-    options: self::_puroro::internal::field_type::SingularHeapMessageField::<
-        self::_puroro_root::google::protobuf::EnumValueOptions,
+    options: self::_pinternal::field_type::SingularHeapMessageField::<
+        self::_root::google::protobuf::EnumValueOptions,
     >,
-    _bitfield: self::_puroro::internal::bitvec::BitArray<1usize>,
+    _bitfield: self::_pinternal::bitvec::BitArray<1usize>,
 }
 impl EnumValueDescriptorProto {
     pub fn name(&self) -> &str {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.name,
@@ -3333,18 +3285,18 @@ impl EnumValueDescriptorProto {
         )
     }
     pub fn name_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.name, &self._bitfield)
     }
     pub fn name_mut(&mut self) -> &mut ::std::string::String {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.name,
@@ -3353,27 +3305,27 @@ impl EnumValueDescriptorProto {
         )
     }
     pub fn has_name(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.name, &self._bitfield)
             .is_some()
     }
     pub fn clear_name(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::clear(&mut self.name, &mut self._bitfield)
     }
     pub fn number(&self) -> i32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             1usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.number,
@@ -3382,18 +3334,18 @@ impl EnumValueDescriptorProto {
         )
     }
     pub fn number_opt(&self) -> ::std::option::Option::<i32> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             1usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.number, &self._bitfield)
     }
     pub fn number_mut(&mut self) -> &mut i32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             1usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.number,
@@ -3402,30 +3354,28 @@ impl EnumValueDescriptorProto {
         )
     }
     pub fn has_number(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             1usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.number, &self._bitfield)
             .is_some()
     }
     pub fn clear_number(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             1usize,
         > as NonRepeatedFieldType>::clear(&mut self.number, &mut self._bitfield)
     }
     pub fn options(
         &self,
-    ) -> ::std::option::Option::<
-        &self::_puroro_root::google::protobuf::EnumValueOptions,
-    > {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::google::protobuf::EnumValueOptions,
+    ) -> ::std::option::Option::<&self::_root::google::protobuf::EnumValueOptions> {
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::google::protobuf::EnumValueOptions,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.options,
             &self._bitfield,
@@ -3434,20 +3384,18 @@ impl EnumValueDescriptorProto {
     }
     pub fn options_opt(
         &self,
-    ) -> ::std::option::Option::<
-        &self::_puroro_root::google::protobuf::EnumValueOptions,
-    > {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::google::protobuf::EnumValueOptions,
+    ) -> ::std::option::Option::<&self::_root::google::protobuf::EnumValueOptions> {
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::google::protobuf::EnumValueOptions,
         > as NonRepeatedFieldType>::get_field_opt(&self.options, &self._bitfield)
     }
     pub fn options_mut(
         &mut self,
-    ) -> &mut self::_puroro_root::google::protobuf::EnumValueOptions {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::google::protobuf::EnumValueOptions,
+    ) -> &mut self::_root::google::protobuf::EnumValueOptions {
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::google::protobuf::EnumValueOptions,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.options,
             &mut self._bitfield,
@@ -3455,16 +3403,16 @@ impl EnumValueDescriptorProto {
         )
     }
     pub fn has_options(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::google::protobuf::EnumValueOptions,
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::google::protobuf::EnumValueOptions,
         > as NonRepeatedFieldType>::get_field_opt(&self.options, &self._bitfield)
             .is_some()
     }
     pub fn clear_options(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::google::protobuf::EnumValueOptions,
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::google::protobuf::EnumValueOptions,
         > as NonRepeatedFieldType>::clear(&mut self.options, &mut self._bitfield)
     }
 }
@@ -3480,38 +3428,38 @@ impl self::_puroro::Message for EnumValueDescriptorProto {
         &mut self,
         mut iter: I,
     ) -> self::_puroro::Result<()> {
-        use self::_puroro::internal::ser::FieldData;
+        use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 1i32 => {
-                    <self::_puroro::internal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::field_type::OptionalUnsizedField::<
                         ::std::string::String,
-                        self::_puroro::internal::tags::String,
+                        self::_pinternal::tags::String,
                         0usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.name,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 2i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         i32,
-                        self::_puroro::internal::tags::Int32,
+                        self::_pinternal::tags::Int32,
                         1usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.number,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 3i32 => {
-                    <self::_puroro::internal::field_type::SingularHeapMessageField::<
-                        self::_puroro_root::google::protobuf::EnumValueOptions,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    <self::_pinternal::field_type::SingularHeapMessageField::<
+                        self::_root::google::protobuf::EnumValueOptions,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.options,
                         &mut self._bitfield,
                         field_data,
@@ -3528,30 +3476,30 @@ impl self::_puroro::Message for EnumValueDescriptorProto {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::oneof_type::OneofUnion as _;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.name,
             &self._bitfield,
             1i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             1usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.number,
             &self._bitfield,
             2i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::google::protobuf::EnumValueOptions,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::google::protobuf::EnumValueOptions,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.options,
             &self._bitfield,
             3i32,
@@ -3563,18 +3511,18 @@ impl self::_puroro::Message for EnumValueDescriptorProto {
 impl ::std::clone::Clone for EnumValueDescriptorProto {
     fn clone(&self) -> Self {
         Self {
-            name: <self::_puroro::internal::field_type::OptionalUnsizedField::<
+            name: <self::_pinternal::field_type::OptionalUnsizedField::<
                 ::std::string::String,
-                self::_puroro::internal::tags::String,
+                self::_pinternal::tags::String,
                 0usize,
             > as ::std::clone::Clone>::clone(&self.name),
-            number: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            number: <self::_pinternal::field_type::OptionalNumericalField::<
                 i32,
-                self::_puroro::internal::tags::Int32,
+                self::_pinternal::tags::Int32,
                 1usize,
             > as ::std::clone::Clone>::clone(&self.number),
-            options: <self::_puroro::internal::field_type::SingularHeapMessageField::<
-                self::_puroro_root::google::protobuf::EnumValueOptions,
+            options: <self::_pinternal::field_type::SingularHeapMessageField::<
+                self::_root::google::protobuf::EnumValueOptions,
             > as ::std::clone::Clone>::clone(&self.options),
             _bitfield: ::std::clone::Clone::clone(&self._bitfield),
         }
@@ -3583,7 +3531,7 @@ impl ::std::clone::Clone for EnumValueDescriptorProto {
 impl ::std::ops::Drop for EnumValueDescriptorProto {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for EnumValueDescriptorProto {
@@ -3601,7 +3549,7 @@ impl ::std::fmt::Debug for EnumValueDescriptorProto {
 impl ::std::cmp::PartialEq for EnumValueDescriptorProto {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         true && self.name_opt() == rhs.name_opt()
             && self.number_opt() == rhs.number_opt()
             && self.options_opt() == rhs.options_opt()
@@ -3609,25 +3557,25 @@ impl ::std::cmp::PartialEq for EnumValueDescriptorProto {
 }
 #[derive(::std::default::Default)]
 pub struct ServiceDescriptorProto {
-    name: self::_puroro::internal::field_type::OptionalUnsizedField::<
+    name: self::_pinternal::field_type::OptionalUnsizedField::<
         ::std::string::String,
-        self::_puroro::internal::tags::String,
+        self::_pinternal::tags::String,
         0usize,
     >,
-    method: self::_puroro::internal::field_type::RepeatedMessageField::<
-        self::_puroro_root::google::protobuf::MethodDescriptorProto,
+    method: self::_pinternal::field_type::RepeatedMessageField::<
+        self::_root::google::protobuf::MethodDescriptorProto,
     >,
-    options: self::_puroro::internal::field_type::SingularHeapMessageField::<
-        self::_puroro_root::google::protobuf::ServiceOptions,
+    options: self::_pinternal::field_type::SingularHeapMessageField::<
+        self::_root::google::protobuf::ServiceOptions,
     >,
-    _bitfield: self::_puroro::internal::bitvec::BitArray<1usize>,
+    _bitfield: self::_pinternal::bitvec::BitArray<1usize>,
 }
 impl ServiceDescriptorProto {
     pub fn name(&self) -> &str {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.name,
@@ -3636,18 +3584,18 @@ impl ServiceDescriptorProto {
         )
     }
     pub fn name_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.name, &self._bitfield)
     }
     pub fn name_mut(&mut self) -> &mut ::std::string::String {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.name,
@@ -3656,52 +3604,48 @@ impl ServiceDescriptorProto {
         )
     }
     pub fn has_name(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.name, &self._bitfield)
             .is_some()
     }
     pub fn clear_name(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::clear(&mut self.name, &mut self._bitfield)
     }
-    pub fn method(
-        &self,
-    ) -> &[self::_puroro_root::google::protobuf::MethodDescriptorProto] {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::MethodDescriptorProto,
+    pub fn method(&self) -> &[self::_root::google::protobuf::MethodDescriptorProto] {
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::MethodDescriptorProto,
         > as RepeatedFieldType>::get_field(&self.method, &self._bitfield)
     }
     pub fn method_mut(
         &mut self,
-    ) -> &mut ::std::vec::Vec::<
-        self::_puroro_root::google::protobuf::MethodDescriptorProto,
-    > {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::MethodDescriptorProto,
+    ) -> &mut ::std::vec::Vec::<self::_root::google::protobuf::MethodDescriptorProto> {
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::MethodDescriptorProto,
         > as RepeatedFieldType>::get_field_mut(&mut self.method, &mut self._bitfield)
     }
     pub fn clear_method(&mut self) {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::MethodDescriptorProto,
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::MethodDescriptorProto,
         > as RepeatedFieldType>::clear(&mut self.method, &mut self._bitfield)
     }
     pub fn options(
         &self,
-    ) -> ::std::option::Option::<&self::_puroro_root::google::protobuf::ServiceOptions> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::google::protobuf::ServiceOptions,
+    ) -> ::std::option::Option::<&self::_root::google::protobuf::ServiceOptions> {
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::google::protobuf::ServiceOptions,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.options,
             &self._bitfield,
@@ -3710,18 +3654,16 @@ impl ServiceDescriptorProto {
     }
     pub fn options_opt(
         &self,
-    ) -> ::std::option::Option::<&self::_puroro_root::google::protobuf::ServiceOptions> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::google::protobuf::ServiceOptions,
+    ) -> ::std::option::Option::<&self::_root::google::protobuf::ServiceOptions> {
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::google::protobuf::ServiceOptions,
         > as NonRepeatedFieldType>::get_field_opt(&self.options, &self._bitfield)
     }
-    pub fn options_mut(
-        &mut self,
-    ) -> &mut self::_puroro_root::google::protobuf::ServiceOptions {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::google::protobuf::ServiceOptions,
+    pub fn options_mut(&mut self) -> &mut self::_root::google::protobuf::ServiceOptions {
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::google::protobuf::ServiceOptions,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.options,
             &mut self._bitfield,
@@ -3729,16 +3671,16 @@ impl ServiceDescriptorProto {
         )
     }
     pub fn has_options(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::google::protobuf::ServiceOptions,
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::google::protobuf::ServiceOptions,
         > as NonRepeatedFieldType>::get_field_opt(&self.options, &self._bitfield)
             .is_some()
     }
     pub fn clear_options(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::google::protobuf::ServiceOptions,
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::google::protobuf::ServiceOptions,
         > as NonRepeatedFieldType>::clear(&mut self.options, &mut self._bitfield)
     }
 }
@@ -3754,36 +3696,36 @@ impl self::_puroro::Message for ServiceDescriptorProto {
         &mut self,
         mut iter: I,
     ) -> self::_puroro::Result<()> {
-        use self::_puroro::internal::ser::FieldData;
+        use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 1i32 => {
-                    <self::_puroro::internal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::field_type::OptionalUnsizedField::<
                         ::std::string::String,
-                        self::_puroro::internal::tags::String,
+                        self::_pinternal::tags::String,
                         0usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.name,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 2i32 => {
-                    <self::_puroro::internal::field_type::RepeatedMessageField::<
-                        self::_puroro_root::google::protobuf::MethodDescriptorProto,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    <self::_pinternal::field_type::RepeatedMessageField::<
+                        self::_root::google::protobuf::MethodDescriptorProto,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.method,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 3i32 => {
-                    <self::_puroro::internal::field_type::SingularHeapMessageField::<
-                        self::_puroro_root::google::protobuf::ServiceOptions,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    <self::_pinternal::field_type::SingularHeapMessageField::<
+                        self::_root::google::protobuf::ServiceOptions,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.options,
                         &mut self._bitfield,
                         field_data,
@@ -3800,28 +3742,28 @@ impl self::_puroro::Message for ServiceDescriptorProto {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::oneof_type::OneofUnion as _;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.name,
             &self._bitfield,
             1i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::MethodDescriptorProto,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::MethodDescriptorProto,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.method,
             &self._bitfield,
             2i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::google::protobuf::ServiceOptions,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::google::protobuf::ServiceOptions,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.options,
             &self._bitfield,
             3i32,
@@ -3833,16 +3775,16 @@ impl self::_puroro::Message for ServiceDescriptorProto {
 impl ::std::clone::Clone for ServiceDescriptorProto {
     fn clone(&self) -> Self {
         Self {
-            name: <self::_puroro::internal::field_type::OptionalUnsizedField::<
+            name: <self::_pinternal::field_type::OptionalUnsizedField::<
                 ::std::string::String,
-                self::_puroro::internal::tags::String,
+                self::_pinternal::tags::String,
                 0usize,
             > as ::std::clone::Clone>::clone(&self.name),
-            method: <self::_puroro::internal::field_type::RepeatedMessageField::<
-                self::_puroro_root::google::protobuf::MethodDescriptorProto,
+            method: <self::_pinternal::field_type::RepeatedMessageField::<
+                self::_root::google::protobuf::MethodDescriptorProto,
             > as ::std::clone::Clone>::clone(&self.method),
-            options: <self::_puroro::internal::field_type::SingularHeapMessageField::<
-                self::_puroro_root::google::protobuf::ServiceOptions,
+            options: <self::_pinternal::field_type::SingularHeapMessageField::<
+                self::_root::google::protobuf::ServiceOptions,
             > as ::std::clone::Clone>::clone(&self.options),
             _bitfield: ::std::clone::Clone::clone(&self._bitfield),
         }
@@ -3851,7 +3793,7 @@ impl ::std::clone::Clone for ServiceDescriptorProto {
 impl ::std::ops::Drop for ServiceDescriptorProto {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for ServiceDescriptorProto {
@@ -3869,49 +3811,49 @@ impl ::std::fmt::Debug for ServiceDescriptorProto {
 impl ::std::cmp::PartialEq for ServiceDescriptorProto {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         true && self.name_opt() == rhs.name_opt() && self.method() == rhs.method()
             && self.options_opt() == rhs.options_opt()
     }
 }
 #[derive(::std::default::Default)]
 pub struct MethodDescriptorProto {
-    name: self::_puroro::internal::field_type::OptionalUnsizedField::<
+    name: self::_pinternal::field_type::OptionalUnsizedField::<
         ::std::string::String,
-        self::_puroro::internal::tags::String,
+        self::_pinternal::tags::String,
         0usize,
     >,
-    input_type: self::_puroro::internal::field_type::OptionalUnsizedField::<
+    input_type: self::_pinternal::field_type::OptionalUnsizedField::<
         ::std::string::String,
-        self::_puroro::internal::tags::String,
+        self::_pinternal::tags::String,
         1usize,
     >,
-    output_type: self::_puroro::internal::field_type::OptionalUnsizedField::<
+    output_type: self::_pinternal::field_type::OptionalUnsizedField::<
         ::std::string::String,
-        self::_puroro::internal::tags::String,
+        self::_pinternal::tags::String,
         2usize,
     >,
-    options: self::_puroro::internal::field_type::SingularHeapMessageField::<
-        self::_puroro_root::google::protobuf::MethodOptions,
+    options: self::_pinternal::field_type::SingularHeapMessageField::<
+        self::_root::google::protobuf::MethodOptions,
     >,
-    client_streaming: self::_puroro::internal::field_type::OptionalNumericalField::<
+    client_streaming: self::_pinternal::field_type::OptionalNumericalField::<
         bool,
-        self::_puroro::internal::tags::Bool,
+        self::_pinternal::tags::Bool,
         3usize,
     >,
-    server_streaming: self::_puroro::internal::field_type::OptionalNumericalField::<
+    server_streaming: self::_pinternal::field_type::OptionalNumericalField::<
         bool,
-        self::_puroro::internal::tags::Bool,
+        self::_pinternal::tags::Bool,
         4usize,
     >,
-    _bitfield: self::_puroro::internal::bitvec::BitArray<1usize>,
+    _bitfield: self::_pinternal::bitvec::BitArray<1usize>,
 }
 impl MethodDescriptorProto {
     pub fn name(&self) -> &str {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.name,
@@ -3920,18 +3862,18 @@ impl MethodDescriptorProto {
         )
     }
     pub fn name_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.name, &self._bitfield)
     }
     pub fn name_mut(&mut self) -> &mut ::std::string::String {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.name,
@@ -3940,27 +3882,27 @@ impl MethodDescriptorProto {
         )
     }
     pub fn has_name(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.name, &self._bitfield)
             .is_some()
     }
     pub fn clear_name(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::clear(&mut self.name, &mut self._bitfield)
     }
     pub fn input_type(&self) -> &str {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             1usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.input_type,
@@ -3969,18 +3911,18 @@ impl MethodDescriptorProto {
         )
     }
     pub fn input_type_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             1usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.input_type, &self._bitfield)
     }
     pub fn input_type_mut(&mut self) -> &mut ::std::string::String {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             1usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.input_type,
@@ -3989,27 +3931,27 @@ impl MethodDescriptorProto {
         )
     }
     pub fn has_input_type(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             1usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.input_type, &self._bitfield)
             .is_some()
     }
     pub fn clear_input_type(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             1usize,
         > as NonRepeatedFieldType>::clear(&mut self.input_type, &mut self._bitfield)
     }
     pub fn output_type(&self) -> &str {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             2usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.output_type,
@@ -4018,18 +3960,18 @@ impl MethodDescriptorProto {
         )
     }
     pub fn output_type_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             2usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.output_type, &self._bitfield)
     }
     pub fn output_type_mut(&mut self) -> &mut ::std::string::String {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             2usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.output_type,
@@ -4038,28 +3980,28 @@ impl MethodDescriptorProto {
         )
     }
     pub fn has_output_type(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             2usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.output_type, &self._bitfield)
             .is_some()
     }
     pub fn clear_output_type(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             2usize,
         > as NonRepeatedFieldType>::clear(&mut self.output_type, &mut self._bitfield)
     }
     pub fn options(
         &self,
-    ) -> ::std::option::Option::<&self::_puroro_root::google::protobuf::MethodOptions> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::google::protobuf::MethodOptions,
+    ) -> ::std::option::Option::<&self::_root::google::protobuf::MethodOptions> {
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::google::protobuf::MethodOptions,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.options,
             &self._bitfield,
@@ -4068,18 +4010,16 @@ impl MethodDescriptorProto {
     }
     pub fn options_opt(
         &self,
-    ) -> ::std::option::Option::<&self::_puroro_root::google::protobuf::MethodOptions> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::google::protobuf::MethodOptions,
+    ) -> ::std::option::Option::<&self::_root::google::protobuf::MethodOptions> {
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::google::protobuf::MethodOptions,
         > as NonRepeatedFieldType>::get_field_opt(&self.options, &self._bitfield)
     }
-    pub fn options_mut(
-        &mut self,
-    ) -> &mut self::_puroro_root::google::protobuf::MethodOptions {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::google::protobuf::MethodOptions,
+    pub fn options_mut(&mut self) -> &mut self::_root::google::protobuf::MethodOptions {
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::google::protobuf::MethodOptions,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.options,
             &mut self._bitfield,
@@ -4087,23 +4027,23 @@ impl MethodDescriptorProto {
         )
     }
     pub fn has_options(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::google::protobuf::MethodOptions,
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::google::protobuf::MethodOptions,
         > as NonRepeatedFieldType>::get_field_opt(&self.options, &self._bitfield)
             .is_some()
     }
     pub fn clear_options(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::google::protobuf::MethodOptions,
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::google::protobuf::MethodOptions,
         > as NonRepeatedFieldType>::clear(&mut self.options, &mut self._bitfield)
     }
     pub fn client_streaming(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             3usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.client_streaming,
@@ -4112,10 +4052,10 @@ impl MethodDescriptorProto {
         )
     }
     pub fn client_streaming_opt(&self) -> ::std::option::Option::<bool> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             3usize,
         > as NonRepeatedFieldType>::get_field_opt(
             &self.client_streaming,
@@ -4123,10 +4063,10 @@ impl MethodDescriptorProto {
         )
     }
     pub fn client_streaming_mut(&mut self) -> &mut bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             3usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.client_streaming,
@@ -4135,10 +4075,10 @@ impl MethodDescriptorProto {
         )
     }
     pub fn has_client_streaming(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             3usize,
         > as NonRepeatedFieldType>::get_field_opt(
                 &self.client_streaming,
@@ -4147,10 +4087,10 @@ impl MethodDescriptorProto {
             .is_some()
     }
     pub fn clear_client_streaming(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             3usize,
         > as NonRepeatedFieldType>::clear(
             &mut self.client_streaming,
@@ -4158,10 +4098,10 @@ impl MethodDescriptorProto {
         )
     }
     pub fn server_streaming(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             4usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.server_streaming,
@@ -4170,10 +4110,10 @@ impl MethodDescriptorProto {
         )
     }
     pub fn server_streaming_opt(&self) -> ::std::option::Option::<bool> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             4usize,
         > as NonRepeatedFieldType>::get_field_opt(
             &self.server_streaming,
@@ -4181,10 +4121,10 @@ impl MethodDescriptorProto {
         )
     }
     pub fn server_streaming_mut(&mut self) -> &mut bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             4usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.server_streaming,
@@ -4193,10 +4133,10 @@ impl MethodDescriptorProto {
         )
     }
     pub fn has_server_streaming(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             4usize,
         > as NonRepeatedFieldType>::get_field_opt(
                 &self.server_streaming,
@@ -4205,10 +4145,10 @@ impl MethodDescriptorProto {
             .is_some()
     }
     pub fn clear_server_streaming(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             4usize,
         > as NonRepeatedFieldType>::clear(
             &mut self.server_streaming,
@@ -4228,71 +4168,71 @@ impl self::_puroro::Message for MethodDescriptorProto {
         &mut self,
         mut iter: I,
     ) -> self::_puroro::Result<()> {
-        use self::_puroro::internal::ser::FieldData;
+        use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 1i32 => {
-                    <self::_puroro::internal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::field_type::OptionalUnsizedField::<
                         ::std::string::String,
-                        self::_puroro::internal::tags::String,
+                        self::_pinternal::tags::String,
                         0usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.name,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 2i32 => {
-                    <self::_puroro::internal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::field_type::OptionalUnsizedField::<
                         ::std::string::String,
-                        self::_puroro::internal::tags::String,
+                        self::_pinternal::tags::String,
                         1usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.input_type,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 3i32 => {
-                    <self::_puroro::internal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::field_type::OptionalUnsizedField::<
                         ::std::string::String,
-                        self::_puroro::internal::tags::String,
+                        self::_pinternal::tags::String,
                         2usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.output_type,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 4i32 => {
-                    <self::_puroro::internal::field_type::SingularHeapMessageField::<
-                        self::_puroro_root::google::protobuf::MethodOptions,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    <self::_pinternal::field_type::SingularHeapMessageField::<
+                        self::_root::google::protobuf::MethodOptions,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.options,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 5i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         bool,
-                        self::_puroro::internal::tags::Bool,
+                        self::_pinternal::tags::Bool,
                         3usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.client_streaming,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 6i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         bool,
-                        self::_puroro::internal::tags::Bool,
+                        self::_pinternal::tags::Bool,
                         4usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.server_streaming,
                         &mut self._bitfield,
                         field_data,
@@ -4309,60 +4249,60 @@ impl self::_puroro::Message for MethodDescriptorProto {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::oneof_type::OneofUnion as _;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.name,
             &self._bitfield,
             1i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             1usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.input_type,
             &self._bitfield,
             2i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             2usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.output_type,
             &self._bitfield,
             3i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::google::protobuf::MethodOptions,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::google::protobuf::MethodOptions,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.options,
             &self._bitfield,
             4i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             3usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.client_streaming,
             &self._bitfield,
             5i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             4usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.server_streaming,
             &self._bitfield,
             6i32,
@@ -4374,32 +4314,32 @@ impl self::_puroro::Message for MethodDescriptorProto {
 impl ::std::clone::Clone for MethodDescriptorProto {
     fn clone(&self) -> Self {
         Self {
-            name: <self::_puroro::internal::field_type::OptionalUnsizedField::<
+            name: <self::_pinternal::field_type::OptionalUnsizedField::<
                 ::std::string::String,
-                self::_puroro::internal::tags::String,
+                self::_pinternal::tags::String,
                 0usize,
             > as ::std::clone::Clone>::clone(&self.name),
-            input_type: <self::_puroro::internal::field_type::OptionalUnsizedField::<
+            input_type: <self::_pinternal::field_type::OptionalUnsizedField::<
                 ::std::string::String,
-                self::_puroro::internal::tags::String,
+                self::_pinternal::tags::String,
                 1usize,
             > as ::std::clone::Clone>::clone(&self.input_type),
-            output_type: <self::_puroro::internal::field_type::OptionalUnsizedField::<
+            output_type: <self::_pinternal::field_type::OptionalUnsizedField::<
                 ::std::string::String,
-                self::_puroro::internal::tags::String,
+                self::_pinternal::tags::String,
                 2usize,
             > as ::std::clone::Clone>::clone(&self.output_type),
-            options: <self::_puroro::internal::field_type::SingularHeapMessageField::<
-                self::_puroro_root::google::protobuf::MethodOptions,
+            options: <self::_pinternal::field_type::SingularHeapMessageField::<
+                self::_root::google::protobuf::MethodOptions,
             > as ::std::clone::Clone>::clone(&self.options),
-            client_streaming: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            client_streaming: <self::_pinternal::field_type::OptionalNumericalField::<
                 bool,
-                self::_puroro::internal::tags::Bool,
+                self::_pinternal::tags::Bool,
                 3usize,
             > as ::std::clone::Clone>::clone(&self.client_streaming),
-            server_streaming: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            server_streaming: <self::_pinternal::field_type::OptionalNumericalField::<
                 bool,
-                self::_puroro::internal::tags::Bool,
+                self::_pinternal::tags::Bool,
                 4usize,
             > as ::std::clone::Clone>::clone(&self.server_streaming),
             _bitfield: ::std::clone::Clone::clone(&self._bitfield),
@@ -4409,7 +4349,7 @@ impl ::std::clone::Clone for MethodDescriptorProto {
 impl ::std::ops::Drop for MethodDescriptorProto {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for MethodDescriptorProto {
@@ -4430,7 +4370,7 @@ impl ::std::fmt::Debug for MethodDescriptorProto {
 impl ::std::cmp::PartialEq for MethodDescriptorProto {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         true && self.name_opt() == rhs.name_opt()
             && self.input_type_opt() == rhs.input_type_opt()
             && self.output_type_opt() == rhs.output_type_opt()
@@ -4441,119 +4381,119 @@ impl ::std::cmp::PartialEq for MethodDescriptorProto {
 }
 #[derive(::std::default::Default)]
 pub struct FileOptions {
-    java_package: self::_puroro::internal::field_type::OptionalUnsizedField::<
+    java_package: self::_pinternal::field_type::OptionalUnsizedField::<
         ::std::string::String,
-        self::_puroro::internal::tags::String,
+        self::_pinternal::tags::String,
         0usize,
     >,
-    java_outer_classname: self::_puroro::internal::field_type::OptionalUnsizedField::<
+    java_outer_classname: self::_pinternal::field_type::OptionalUnsizedField::<
         ::std::string::String,
-        self::_puroro::internal::tags::String,
+        self::_pinternal::tags::String,
         1usize,
     >,
-    java_multiple_files: self::_puroro::internal::field_type::OptionalNumericalField::<
+    java_multiple_files: self::_pinternal::field_type::OptionalNumericalField::<
         bool,
-        self::_puroro::internal::tags::Bool,
+        self::_pinternal::tags::Bool,
         2usize,
     >,
-    java_generate_equals_and_hash: self::_puroro::internal::field_type::OptionalNumericalField::<
+    java_generate_equals_and_hash: self::_pinternal::field_type::OptionalNumericalField::<
         bool,
-        self::_puroro::internal::tags::Bool,
+        self::_pinternal::tags::Bool,
         3usize,
     >,
-    java_string_check_utf8: self::_puroro::internal::field_type::OptionalNumericalField::<
+    java_string_check_utf8: self::_pinternal::field_type::OptionalNumericalField::<
         bool,
-        self::_puroro::internal::tags::Bool,
+        self::_pinternal::tags::Bool,
         4usize,
     >,
-    optimize_for: self::_puroro::internal::field_type::OptionalNumericalField::<
-        self::_puroro_root::google::protobuf::file_options::OptimizeMode,
-        self::_puroro::internal::tags::Enum2::<
-            self::_puroro_root::google::protobuf::file_options::OptimizeMode,
+    optimize_for: self::_pinternal::field_type::OptionalNumericalField::<
+        self::_root::google::protobuf::file_options::OptimizeMode,
+        self::_pinternal::tags::Enum2::<
+            self::_root::google::protobuf::file_options::OptimizeMode,
         >,
         5usize,
     >,
-    go_package: self::_puroro::internal::field_type::OptionalUnsizedField::<
+    go_package: self::_pinternal::field_type::OptionalUnsizedField::<
         ::std::string::String,
-        self::_puroro::internal::tags::String,
+        self::_pinternal::tags::String,
         6usize,
     >,
-    cc_generic_services: self::_puroro::internal::field_type::OptionalNumericalField::<
+    cc_generic_services: self::_pinternal::field_type::OptionalNumericalField::<
         bool,
-        self::_puroro::internal::tags::Bool,
+        self::_pinternal::tags::Bool,
         7usize,
     >,
-    java_generic_services: self::_puroro::internal::field_type::OptionalNumericalField::<
+    java_generic_services: self::_pinternal::field_type::OptionalNumericalField::<
         bool,
-        self::_puroro::internal::tags::Bool,
+        self::_pinternal::tags::Bool,
         8usize,
     >,
-    py_generic_services: self::_puroro::internal::field_type::OptionalNumericalField::<
+    py_generic_services: self::_pinternal::field_type::OptionalNumericalField::<
         bool,
-        self::_puroro::internal::tags::Bool,
+        self::_pinternal::tags::Bool,
         9usize,
     >,
-    php_generic_services: self::_puroro::internal::field_type::OptionalNumericalField::<
+    php_generic_services: self::_pinternal::field_type::OptionalNumericalField::<
         bool,
-        self::_puroro::internal::tags::Bool,
+        self::_pinternal::tags::Bool,
         10usize,
     >,
-    deprecated: self::_puroro::internal::field_type::OptionalNumericalField::<
+    deprecated: self::_pinternal::field_type::OptionalNumericalField::<
         bool,
-        self::_puroro::internal::tags::Bool,
+        self::_pinternal::tags::Bool,
         11usize,
     >,
-    cc_enable_arenas: self::_puroro::internal::field_type::OptionalNumericalField::<
+    cc_enable_arenas: self::_pinternal::field_type::OptionalNumericalField::<
         bool,
-        self::_puroro::internal::tags::Bool,
+        self::_pinternal::tags::Bool,
         12usize,
     >,
-    objc_class_prefix: self::_puroro::internal::field_type::OptionalUnsizedField::<
+    objc_class_prefix: self::_pinternal::field_type::OptionalUnsizedField::<
         ::std::string::String,
-        self::_puroro::internal::tags::String,
+        self::_pinternal::tags::String,
         13usize,
     >,
-    csharp_namespace: self::_puroro::internal::field_type::OptionalUnsizedField::<
+    csharp_namespace: self::_pinternal::field_type::OptionalUnsizedField::<
         ::std::string::String,
-        self::_puroro::internal::tags::String,
+        self::_pinternal::tags::String,
         14usize,
     >,
-    swift_prefix: self::_puroro::internal::field_type::OptionalUnsizedField::<
+    swift_prefix: self::_pinternal::field_type::OptionalUnsizedField::<
         ::std::string::String,
-        self::_puroro::internal::tags::String,
+        self::_pinternal::tags::String,
         15usize,
     >,
-    php_class_prefix: self::_puroro::internal::field_type::OptionalUnsizedField::<
+    php_class_prefix: self::_pinternal::field_type::OptionalUnsizedField::<
         ::std::string::String,
-        self::_puroro::internal::tags::String,
+        self::_pinternal::tags::String,
         16usize,
     >,
-    php_namespace: self::_puroro::internal::field_type::OptionalUnsizedField::<
+    php_namespace: self::_pinternal::field_type::OptionalUnsizedField::<
         ::std::string::String,
-        self::_puroro::internal::tags::String,
+        self::_pinternal::tags::String,
         17usize,
     >,
-    php_metadata_namespace: self::_puroro::internal::field_type::OptionalUnsizedField::<
+    php_metadata_namespace: self::_pinternal::field_type::OptionalUnsizedField::<
         ::std::string::String,
-        self::_puroro::internal::tags::String,
+        self::_pinternal::tags::String,
         18usize,
     >,
-    ruby_package: self::_puroro::internal::field_type::OptionalUnsizedField::<
+    ruby_package: self::_pinternal::field_type::OptionalUnsizedField::<
         ::std::string::String,
-        self::_puroro::internal::tags::String,
+        self::_pinternal::tags::String,
         19usize,
     >,
-    uninterpreted_option: self::_puroro::internal::field_type::RepeatedMessageField::<
-        self::_puroro_root::google::protobuf::UninterpretedOption,
+    uninterpreted_option: self::_pinternal::field_type::RepeatedMessageField::<
+        self::_root::google::protobuf::UninterpretedOption,
     >,
-    _bitfield: self::_puroro::internal::bitvec::BitArray<1usize>,
+    _bitfield: self::_pinternal::bitvec::BitArray<1usize>,
 }
 impl FileOptions {
     pub fn java_package(&self) -> &str {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.java_package,
@@ -4562,18 +4502,18 @@ impl FileOptions {
         )
     }
     pub fn java_package_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.java_package, &self._bitfield)
     }
     pub fn java_package_mut(&mut self) -> &mut ::std::string::String {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.java_package,
@@ -4582,27 +4522,27 @@ impl FileOptions {
         )
     }
     pub fn has_java_package(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.java_package, &self._bitfield)
             .is_some()
     }
     pub fn clear_java_package(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::clear(&mut self.java_package, &mut self._bitfield)
     }
     pub fn java_outer_classname(&self) -> &str {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             1usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.java_outer_classname,
@@ -4611,10 +4551,10 @@ impl FileOptions {
         )
     }
     pub fn java_outer_classname_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             1usize,
         > as NonRepeatedFieldType>::get_field_opt(
             &self.java_outer_classname,
@@ -4622,10 +4562,10 @@ impl FileOptions {
         )
     }
     pub fn java_outer_classname_mut(&mut self) -> &mut ::std::string::String {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             1usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.java_outer_classname,
@@ -4634,10 +4574,10 @@ impl FileOptions {
         )
     }
     pub fn has_java_outer_classname(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             1usize,
         > as NonRepeatedFieldType>::get_field_opt(
                 &self.java_outer_classname,
@@ -4646,10 +4586,10 @@ impl FileOptions {
             .is_some()
     }
     pub fn clear_java_outer_classname(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             1usize,
         > as NonRepeatedFieldType>::clear(
             &mut self.java_outer_classname,
@@ -4657,10 +4597,10 @@ impl FileOptions {
         )
     }
     pub fn java_multiple_files(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             2usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.java_multiple_files,
@@ -4669,10 +4609,10 @@ impl FileOptions {
         )
     }
     pub fn java_multiple_files_opt(&self) -> ::std::option::Option::<bool> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             2usize,
         > as NonRepeatedFieldType>::get_field_opt(
             &self.java_multiple_files,
@@ -4680,10 +4620,10 @@ impl FileOptions {
         )
     }
     pub fn java_multiple_files_mut(&mut self) -> &mut bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             2usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.java_multiple_files,
@@ -4692,10 +4632,10 @@ impl FileOptions {
         )
     }
     pub fn has_java_multiple_files(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             2usize,
         > as NonRepeatedFieldType>::get_field_opt(
                 &self.java_multiple_files,
@@ -4704,10 +4644,10 @@ impl FileOptions {
             .is_some()
     }
     pub fn clear_java_multiple_files(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             2usize,
         > as NonRepeatedFieldType>::clear(
             &mut self.java_multiple_files,
@@ -4715,10 +4655,10 @@ impl FileOptions {
         )
     }
     pub fn java_generate_equals_and_hash(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             3usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.java_generate_equals_and_hash,
@@ -4727,10 +4667,10 @@ impl FileOptions {
         )
     }
     pub fn java_generate_equals_and_hash_opt(&self) -> ::std::option::Option::<bool> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             3usize,
         > as NonRepeatedFieldType>::get_field_opt(
             &self.java_generate_equals_and_hash,
@@ -4738,10 +4678,10 @@ impl FileOptions {
         )
     }
     pub fn java_generate_equals_and_hash_mut(&mut self) -> &mut bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             3usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.java_generate_equals_and_hash,
@@ -4750,10 +4690,10 @@ impl FileOptions {
         )
     }
     pub fn has_java_generate_equals_and_hash(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             3usize,
         > as NonRepeatedFieldType>::get_field_opt(
                 &self.java_generate_equals_and_hash,
@@ -4762,10 +4702,10 @@ impl FileOptions {
             .is_some()
     }
     pub fn clear_java_generate_equals_and_hash(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             3usize,
         > as NonRepeatedFieldType>::clear(
             &mut self.java_generate_equals_and_hash,
@@ -4773,10 +4713,10 @@ impl FileOptions {
         )
     }
     pub fn java_string_check_utf8(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             4usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.java_string_check_utf8,
@@ -4785,10 +4725,10 @@ impl FileOptions {
         )
     }
     pub fn java_string_check_utf8_opt(&self) -> ::std::option::Option::<bool> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             4usize,
         > as NonRepeatedFieldType>::get_field_opt(
             &self.java_string_check_utf8,
@@ -4796,10 +4736,10 @@ impl FileOptions {
         )
     }
     pub fn java_string_check_utf8_mut(&mut self) -> &mut bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             4usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.java_string_check_utf8,
@@ -4808,10 +4748,10 @@ impl FileOptions {
         )
     }
     pub fn has_java_string_check_utf8(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             4usize,
         > as NonRepeatedFieldType>::get_field_opt(
                 &self.java_string_check_utf8,
@@ -4820,10 +4760,10 @@ impl FileOptions {
             .is_some()
     }
     pub fn clear_java_string_check_utf8(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             4usize,
         > as NonRepeatedFieldType>::clear(
             &mut self.java_string_check_utf8,
@@ -4832,76 +4772,76 @@ impl FileOptions {
     }
     pub fn optimize_for(
         &self,
-    ) -> self::_puroro_root::google::protobuf::file_options::OptimizeMode {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
-            self::_puroro_root::google::protobuf::file_options::OptimizeMode,
-            self::_puroro::internal::tags::Enum2::<
-                self::_puroro_root::google::protobuf::file_options::OptimizeMode,
+    ) -> self::_root::google::protobuf::file_options::OptimizeMode {
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
+            self::_root::google::protobuf::file_options::OptimizeMode,
+            self::_pinternal::tags::Enum2::<
+                self::_root::google::protobuf::file_options::OptimizeMode,
             >,
             5usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.optimize_for,
             &self._bitfield,
-            || self::_puroro_root::google::protobuf::file_options::OptimizeMode::Speed,
+            || self::_root::google::protobuf::file_options::OptimizeMode::Speed,
         )
     }
     pub fn optimize_for_opt(
         &self,
     ) -> ::std::option::Option::<
-        self::_puroro_root::google::protobuf::file_options::OptimizeMode,
+        self::_root::google::protobuf::file_options::OptimizeMode,
     > {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
-            self::_puroro_root::google::protobuf::file_options::OptimizeMode,
-            self::_puroro::internal::tags::Enum2::<
-                self::_puroro_root::google::protobuf::file_options::OptimizeMode,
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
+            self::_root::google::protobuf::file_options::OptimizeMode,
+            self::_pinternal::tags::Enum2::<
+                self::_root::google::protobuf::file_options::OptimizeMode,
             >,
             5usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.optimize_for, &self._bitfield)
     }
     pub fn optimize_for_mut(
         &mut self,
-    ) -> &mut self::_puroro_root::google::protobuf::file_options::OptimizeMode {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
-            self::_puroro_root::google::protobuf::file_options::OptimizeMode,
-            self::_puroro::internal::tags::Enum2::<
-                self::_puroro_root::google::protobuf::file_options::OptimizeMode,
+    ) -> &mut self::_root::google::protobuf::file_options::OptimizeMode {
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
+            self::_root::google::protobuf::file_options::OptimizeMode,
+            self::_pinternal::tags::Enum2::<
+                self::_root::google::protobuf::file_options::OptimizeMode,
             >,
             5usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.optimize_for,
             &mut self._bitfield,
-            || self::_puroro_root::google::protobuf::file_options::OptimizeMode::Speed,
+            || self::_root::google::protobuf::file_options::OptimizeMode::Speed,
         )
     }
     pub fn has_optimize_for(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
-            self::_puroro_root::google::protobuf::file_options::OptimizeMode,
-            self::_puroro::internal::tags::Enum2::<
-                self::_puroro_root::google::protobuf::file_options::OptimizeMode,
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
+            self::_root::google::protobuf::file_options::OptimizeMode,
+            self::_pinternal::tags::Enum2::<
+                self::_root::google::protobuf::file_options::OptimizeMode,
             >,
             5usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.optimize_for, &self._bitfield)
             .is_some()
     }
     pub fn clear_optimize_for(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
-            self::_puroro_root::google::protobuf::file_options::OptimizeMode,
-            self::_puroro::internal::tags::Enum2::<
-                self::_puroro_root::google::protobuf::file_options::OptimizeMode,
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
+            self::_root::google::protobuf::file_options::OptimizeMode,
+            self::_pinternal::tags::Enum2::<
+                self::_root::google::protobuf::file_options::OptimizeMode,
             >,
             5usize,
         > as NonRepeatedFieldType>::clear(&mut self.optimize_for, &mut self._bitfield)
     }
     pub fn go_package(&self) -> &str {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             6usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.go_package,
@@ -4910,18 +4850,18 @@ impl FileOptions {
         )
     }
     pub fn go_package_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             6usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.go_package, &self._bitfield)
     }
     pub fn go_package_mut(&mut self) -> &mut ::std::string::String {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             6usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.go_package,
@@ -4930,27 +4870,27 @@ impl FileOptions {
         )
     }
     pub fn has_go_package(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             6usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.go_package, &self._bitfield)
             .is_some()
     }
     pub fn clear_go_package(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             6usize,
         > as NonRepeatedFieldType>::clear(&mut self.go_package, &mut self._bitfield)
     }
     pub fn cc_generic_services(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             7usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.cc_generic_services,
@@ -4959,10 +4899,10 @@ impl FileOptions {
         )
     }
     pub fn cc_generic_services_opt(&self) -> ::std::option::Option::<bool> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             7usize,
         > as NonRepeatedFieldType>::get_field_opt(
             &self.cc_generic_services,
@@ -4970,10 +4910,10 @@ impl FileOptions {
         )
     }
     pub fn cc_generic_services_mut(&mut self) -> &mut bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             7usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.cc_generic_services,
@@ -4982,10 +4922,10 @@ impl FileOptions {
         )
     }
     pub fn has_cc_generic_services(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             7usize,
         > as NonRepeatedFieldType>::get_field_opt(
                 &self.cc_generic_services,
@@ -4994,10 +4934,10 @@ impl FileOptions {
             .is_some()
     }
     pub fn clear_cc_generic_services(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             7usize,
         > as NonRepeatedFieldType>::clear(
             &mut self.cc_generic_services,
@@ -5005,10 +4945,10 @@ impl FileOptions {
         )
     }
     pub fn java_generic_services(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             8usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.java_generic_services,
@@ -5017,10 +4957,10 @@ impl FileOptions {
         )
     }
     pub fn java_generic_services_opt(&self) -> ::std::option::Option::<bool> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             8usize,
         > as NonRepeatedFieldType>::get_field_opt(
             &self.java_generic_services,
@@ -5028,10 +4968,10 @@ impl FileOptions {
         )
     }
     pub fn java_generic_services_mut(&mut self) -> &mut bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             8usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.java_generic_services,
@@ -5040,10 +4980,10 @@ impl FileOptions {
         )
     }
     pub fn has_java_generic_services(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             8usize,
         > as NonRepeatedFieldType>::get_field_opt(
                 &self.java_generic_services,
@@ -5052,10 +4992,10 @@ impl FileOptions {
             .is_some()
     }
     pub fn clear_java_generic_services(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             8usize,
         > as NonRepeatedFieldType>::clear(
             &mut self.java_generic_services,
@@ -5063,10 +5003,10 @@ impl FileOptions {
         )
     }
     pub fn py_generic_services(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             9usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.py_generic_services,
@@ -5075,10 +5015,10 @@ impl FileOptions {
         )
     }
     pub fn py_generic_services_opt(&self) -> ::std::option::Option::<bool> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             9usize,
         > as NonRepeatedFieldType>::get_field_opt(
             &self.py_generic_services,
@@ -5086,10 +5026,10 @@ impl FileOptions {
         )
     }
     pub fn py_generic_services_mut(&mut self) -> &mut bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             9usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.py_generic_services,
@@ -5098,10 +5038,10 @@ impl FileOptions {
         )
     }
     pub fn has_py_generic_services(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             9usize,
         > as NonRepeatedFieldType>::get_field_opt(
                 &self.py_generic_services,
@@ -5110,10 +5050,10 @@ impl FileOptions {
             .is_some()
     }
     pub fn clear_py_generic_services(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             9usize,
         > as NonRepeatedFieldType>::clear(
             &mut self.py_generic_services,
@@ -5121,10 +5061,10 @@ impl FileOptions {
         )
     }
     pub fn php_generic_services(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             10usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.php_generic_services,
@@ -5133,10 +5073,10 @@ impl FileOptions {
         )
     }
     pub fn php_generic_services_opt(&self) -> ::std::option::Option::<bool> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             10usize,
         > as NonRepeatedFieldType>::get_field_opt(
             &self.php_generic_services,
@@ -5144,10 +5084,10 @@ impl FileOptions {
         )
     }
     pub fn php_generic_services_mut(&mut self) -> &mut bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             10usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.php_generic_services,
@@ -5156,10 +5096,10 @@ impl FileOptions {
         )
     }
     pub fn has_php_generic_services(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             10usize,
         > as NonRepeatedFieldType>::get_field_opt(
                 &self.php_generic_services,
@@ -5168,10 +5108,10 @@ impl FileOptions {
             .is_some()
     }
     pub fn clear_php_generic_services(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             10usize,
         > as NonRepeatedFieldType>::clear(
             &mut self.php_generic_services,
@@ -5179,10 +5119,10 @@ impl FileOptions {
         )
     }
     pub fn deprecated(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             11usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.deprecated,
@@ -5191,18 +5131,18 @@ impl FileOptions {
         )
     }
     pub fn deprecated_opt(&self) -> ::std::option::Option::<bool> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             11usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.deprecated, &self._bitfield)
     }
     pub fn deprecated_mut(&mut self) -> &mut bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             11usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.deprecated,
@@ -5211,27 +5151,27 @@ impl FileOptions {
         )
     }
     pub fn has_deprecated(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             11usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.deprecated, &self._bitfield)
             .is_some()
     }
     pub fn clear_deprecated(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             11usize,
         > as NonRepeatedFieldType>::clear(&mut self.deprecated, &mut self._bitfield)
     }
     pub fn cc_enable_arenas(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             12usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.cc_enable_arenas,
@@ -5240,10 +5180,10 @@ impl FileOptions {
         )
     }
     pub fn cc_enable_arenas_opt(&self) -> ::std::option::Option::<bool> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             12usize,
         > as NonRepeatedFieldType>::get_field_opt(
             &self.cc_enable_arenas,
@@ -5251,10 +5191,10 @@ impl FileOptions {
         )
     }
     pub fn cc_enable_arenas_mut(&mut self) -> &mut bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             12usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.cc_enable_arenas,
@@ -5263,10 +5203,10 @@ impl FileOptions {
         )
     }
     pub fn has_cc_enable_arenas(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             12usize,
         > as NonRepeatedFieldType>::get_field_opt(
                 &self.cc_enable_arenas,
@@ -5275,10 +5215,10 @@ impl FileOptions {
             .is_some()
     }
     pub fn clear_cc_enable_arenas(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             12usize,
         > as NonRepeatedFieldType>::clear(
             &mut self.cc_enable_arenas,
@@ -5286,10 +5226,10 @@ impl FileOptions {
         )
     }
     pub fn objc_class_prefix(&self) -> &str {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             13usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.objc_class_prefix,
@@ -5298,10 +5238,10 @@ impl FileOptions {
         )
     }
     pub fn objc_class_prefix_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             13usize,
         > as NonRepeatedFieldType>::get_field_opt(
             &self.objc_class_prefix,
@@ -5309,10 +5249,10 @@ impl FileOptions {
         )
     }
     pub fn objc_class_prefix_mut(&mut self) -> &mut ::std::string::String {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             13usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.objc_class_prefix,
@@ -5321,10 +5261,10 @@ impl FileOptions {
         )
     }
     pub fn has_objc_class_prefix(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             13usize,
         > as NonRepeatedFieldType>::get_field_opt(
                 &self.objc_class_prefix,
@@ -5333,10 +5273,10 @@ impl FileOptions {
             .is_some()
     }
     pub fn clear_objc_class_prefix(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             13usize,
         > as NonRepeatedFieldType>::clear(
             &mut self.objc_class_prefix,
@@ -5344,10 +5284,10 @@ impl FileOptions {
         )
     }
     pub fn csharp_namespace(&self) -> &str {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             14usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.csharp_namespace,
@@ -5356,10 +5296,10 @@ impl FileOptions {
         )
     }
     pub fn csharp_namespace_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             14usize,
         > as NonRepeatedFieldType>::get_field_opt(
             &self.csharp_namespace,
@@ -5367,10 +5307,10 @@ impl FileOptions {
         )
     }
     pub fn csharp_namespace_mut(&mut self) -> &mut ::std::string::String {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             14usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.csharp_namespace,
@@ -5379,10 +5319,10 @@ impl FileOptions {
         )
     }
     pub fn has_csharp_namespace(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             14usize,
         > as NonRepeatedFieldType>::get_field_opt(
                 &self.csharp_namespace,
@@ -5391,10 +5331,10 @@ impl FileOptions {
             .is_some()
     }
     pub fn clear_csharp_namespace(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             14usize,
         > as NonRepeatedFieldType>::clear(
             &mut self.csharp_namespace,
@@ -5402,10 +5342,10 @@ impl FileOptions {
         )
     }
     pub fn swift_prefix(&self) -> &str {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             15usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.swift_prefix,
@@ -5414,18 +5354,18 @@ impl FileOptions {
         )
     }
     pub fn swift_prefix_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             15usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.swift_prefix, &self._bitfield)
     }
     pub fn swift_prefix_mut(&mut self) -> &mut ::std::string::String {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             15usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.swift_prefix,
@@ -5434,27 +5374,27 @@ impl FileOptions {
         )
     }
     pub fn has_swift_prefix(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             15usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.swift_prefix, &self._bitfield)
             .is_some()
     }
     pub fn clear_swift_prefix(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             15usize,
         > as NonRepeatedFieldType>::clear(&mut self.swift_prefix, &mut self._bitfield)
     }
     pub fn php_class_prefix(&self) -> &str {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             16usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.php_class_prefix,
@@ -5463,10 +5403,10 @@ impl FileOptions {
         )
     }
     pub fn php_class_prefix_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             16usize,
         > as NonRepeatedFieldType>::get_field_opt(
             &self.php_class_prefix,
@@ -5474,10 +5414,10 @@ impl FileOptions {
         )
     }
     pub fn php_class_prefix_mut(&mut self) -> &mut ::std::string::String {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             16usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.php_class_prefix,
@@ -5486,10 +5426,10 @@ impl FileOptions {
         )
     }
     pub fn has_php_class_prefix(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             16usize,
         > as NonRepeatedFieldType>::get_field_opt(
                 &self.php_class_prefix,
@@ -5498,10 +5438,10 @@ impl FileOptions {
             .is_some()
     }
     pub fn clear_php_class_prefix(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             16usize,
         > as NonRepeatedFieldType>::clear(
             &mut self.php_class_prefix,
@@ -5509,10 +5449,10 @@ impl FileOptions {
         )
     }
     pub fn php_namespace(&self) -> &str {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             17usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.php_namespace,
@@ -5521,18 +5461,18 @@ impl FileOptions {
         )
     }
     pub fn php_namespace_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             17usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.php_namespace, &self._bitfield)
     }
     pub fn php_namespace_mut(&mut self) -> &mut ::std::string::String {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             17usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.php_namespace,
@@ -5541,27 +5481,27 @@ impl FileOptions {
         )
     }
     pub fn has_php_namespace(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             17usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.php_namespace, &self._bitfield)
             .is_some()
     }
     pub fn clear_php_namespace(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             17usize,
         > as NonRepeatedFieldType>::clear(&mut self.php_namespace, &mut self._bitfield)
     }
     pub fn php_metadata_namespace(&self) -> &str {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             18usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.php_metadata_namespace,
@@ -5570,10 +5510,10 @@ impl FileOptions {
         )
     }
     pub fn php_metadata_namespace_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             18usize,
         > as NonRepeatedFieldType>::get_field_opt(
             &self.php_metadata_namespace,
@@ -5581,10 +5521,10 @@ impl FileOptions {
         )
     }
     pub fn php_metadata_namespace_mut(&mut self) -> &mut ::std::string::String {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             18usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.php_metadata_namespace,
@@ -5593,10 +5533,10 @@ impl FileOptions {
         )
     }
     pub fn has_php_metadata_namespace(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             18usize,
         > as NonRepeatedFieldType>::get_field_opt(
                 &self.php_metadata_namespace,
@@ -5605,10 +5545,10 @@ impl FileOptions {
             .is_some()
     }
     pub fn clear_php_metadata_namespace(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             18usize,
         > as NonRepeatedFieldType>::clear(
             &mut self.php_metadata_namespace,
@@ -5616,10 +5556,10 @@ impl FileOptions {
         )
     }
     pub fn ruby_package(&self) -> &str {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             19usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.ruby_package,
@@ -5628,18 +5568,18 @@ impl FileOptions {
         )
     }
     pub fn ruby_package_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             19usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.ruby_package, &self._bitfield)
     }
     pub fn ruby_package_mut(&mut self) -> &mut ::std::string::String {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             19usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.ruby_package,
@@ -5648,47 +5588,45 @@ impl FileOptions {
         )
     }
     pub fn has_ruby_package(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             19usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.ruby_package, &self._bitfield)
             .is_some()
     }
     pub fn clear_ruby_package(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             19usize,
         > as NonRepeatedFieldType>::clear(&mut self.ruby_package, &mut self._bitfield)
     }
     pub fn uninterpreted_option(
         &self,
-    ) -> &[self::_puroro_root::google::protobuf::UninterpretedOption] {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::UninterpretedOption,
+    ) -> &[self::_root::google::protobuf::UninterpretedOption] {
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::UninterpretedOption,
         > as RepeatedFieldType>::get_field(&self.uninterpreted_option, &self._bitfield)
     }
     pub fn uninterpreted_option_mut(
         &mut self,
-    ) -> &mut ::std::vec::Vec::<
-        self::_puroro_root::google::protobuf::UninterpretedOption,
-    > {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::UninterpretedOption,
+    ) -> &mut ::std::vec::Vec::<self::_root::google::protobuf::UninterpretedOption> {
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::UninterpretedOption,
         > as RepeatedFieldType>::get_field_mut(
             &mut self.uninterpreted_option,
             &mut self._bitfield,
         )
     }
     pub fn clear_uninterpreted_option(&mut self) {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::UninterpretedOption,
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::UninterpretedOption,
         > as RepeatedFieldType>::clear(
             &mut self.uninterpreted_option,
             &mut self._bitfield,
@@ -5707,238 +5645,238 @@ impl self::_puroro::Message for FileOptions {
         &mut self,
         mut iter: I,
     ) -> self::_puroro::Result<()> {
-        use self::_puroro::internal::ser::FieldData;
+        use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 1i32 => {
-                    <self::_puroro::internal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::field_type::OptionalUnsizedField::<
                         ::std::string::String,
-                        self::_puroro::internal::tags::String,
+                        self::_pinternal::tags::String,
                         0usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.java_package,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 8i32 => {
-                    <self::_puroro::internal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::field_type::OptionalUnsizedField::<
                         ::std::string::String,
-                        self::_puroro::internal::tags::String,
+                        self::_pinternal::tags::String,
                         1usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.java_outer_classname,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 10i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         bool,
-                        self::_puroro::internal::tags::Bool,
+                        self::_pinternal::tags::Bool,
                         2usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.java_multiple_files,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 20i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         bool,
-                        self::_puroro::internal::tags::Bool,
+                        self::_pinternal::tags::Bool,
                         3usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.java_generate_equals_and_hash,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 27i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         bool,
-                        self::_puroro::internal::tags::Bool,
+                        self::_pinternal::tags::Bool,
                         4usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.java_string_check_utf8,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 9i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
-                        self::_puroro_root::google::protobuf::file_options::OptimizeMode,
-                        self::_puroro::internal::tags::Enum2::<
-                            self::_puroro_root::google::protobuf::file_options::OptimizeMode,
+                    <self::_pinternal::field_type::OptionalNumericalField::<
+                        self::_root::google::protobuf::file_options::OptimizeMode,
+                        self::_pinternal::tags::Enum2::<
+                            self::_root::google::protobuf::file_options::OptimizeMode,
                         >,
                         5usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.optimize_for,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 11i32 => {
-                    <self::_puroro::internal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::field_type::OptionalUnsizedField::<
                         ::std::string::String,
-                        self::_puroro::internal::tags::String,
+                        self::_pinternal::tags::String,
                         6usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.go_package,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 16i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         bool,
-                        self::_puroro::internal::tags::Bool,
+                        self::_pinternal::tags::Bool,
                         7usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.cc_generic_services,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 17i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         bool,
-                        self::_puroro::internal::tags::Bool,
+                        self::_pinternal::tags::Bool,
                         8usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.java_generic_services,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 18i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         bool,
-                        self::_puroro::internal::tags::Bool,
+                        self::_pinternal::tags::Bool,
                         9usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.py_generic_services,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 42i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         bool,
-                        self::_puroro::internal::tags::Bool,
+                        self::_pinternal::tags::Bool,
                         10usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.php_generic_services,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 23i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         bool,
-                        self::_puroro::internal::tags::Bool,
+                        self::_pinternal::tags::Bool,
                         11usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.deprecated,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 31i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         bool,
-                        self::_puroro::internal::tags::Bool,
+                        self::_pinternal::tags::Bool,
                         12usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.cc_enable_arenas,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 36i32 => {
-                    <self::_puroro::internal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::field_type::OptionalUnsizedField::<
                         ::std::string::String,
-                        self::_puroro::internal::tags::String,
+                        self::_pinternal::tags::String,
                         13usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.objc_class_prefix,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 37i32 => {
-                    <self::_puroro::internal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::field_type::OptionalUnsizedField::<
                         ::std::string::String,
-                        self::_puroro::internal::tags::String,
+                        self::_pinternal::tags::String,
                         14usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.csharp_namespace,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 39i32 => {
-                    <self::_puroro::internal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::field_type::OptionalUnsizedField::<
                         ::std::string::String,
-                        self::_puroro::internal::tags::String,
+                        self::_pinternal::tags::String,
                         15usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.swift_prefix,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 40i32 => {
-                    <self::_puroro::internal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::field_type::OptionalUnsizedField::<
                         ::std::string::String,
-                        self::_puroro::internal::tags::String,
+                        self::_pinternal::tags::String,
                         16usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.php_class_prefix,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 41i32 => {
-                    <self::_puroro::internal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::field_type::OptionalUnsizedField::<
                         ::std::string::String,
-                        self::_puroro::internal::tags::String,
+                        self::_pinternal::tags::String,
                         17usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.php_namespace,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 44i32 => {
-                    <self::_puroro::internal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::field_type::OptionalUnsizedField::<
                         ::std::string::String,
-                        self::_puroro::internal::tags::String,
+                        self::_pinternal::tags::String,
                         18usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.php_metadata_namespace,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 45i32 => {
-                    <self::_puroro::internal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::field_type::OptionalUnsizedField::<
                         ::std::string::String,
-                        self::_puroro::internal::tags::String,
+                        self::_pinternal::tags::String,
                         19usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.ruby_package,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 999i32 => {
-                    <self::_puroro::internal::field_type::RepeatedMessageField::<
-                        self::_puroro_root::google::protobuf::UninterpretedOption,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    <self::_pinternal::field_type::RepeatedMessageField::<
+                        self::_root::google::protobuf::UninterpretedOption,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.uninterpreted_option,
                         &mut self._bitfield,
                         field_data,
@@ -5955,212 +5893,212 @@ impl self::_puroro::Message for FileOptions {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::oneof_type::OneofUnion as _;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.java_package,
             &self._bitfield,
             1i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             1usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.java_outer_classname,
             &self._bitfield,
             8i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             2usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.java_multiple_files,
             &self._bitfield,
             10i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             3usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.java_generate_equals_and_hash,
             &self._bitfield,
             20i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             4usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.java_string_check_utf8,
             &self._bitfield,
             27i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
-            self::_puroro_root::google::protobuf::file_options::OptimizeMode,
-            self::_puroro::internal::tags::Enum2::<
-                self::_puroro_root::google::protobuf::file_options::OptimizeMode,
+        <self::_pinternal::field_type::OptionalNumericalField::<
+            self::_root::google::protobuf::file_options::OptimizeMode,
+            self::_pinternal::tags::Enum2::<
+                self::_root::google::protobuf::file_options::OptimizeMode,
             >,
             5usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.optimize_for,
             &self._bitfield,
             9i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             6usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.go_package,
             &self._bitfield,
             11i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             7usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.cc_generic_services,
             &self._bitfield,
             16i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             8usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.java_generic_services,
             &self._bitfield,
             17i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             9usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.py_generic_services,
             &self._bitfield,
             18i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             10usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.php_generic_services,
             &self._bitfield,
             42i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             11usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.deprecated,
             &self._bitfield,
             23i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             12usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.cc_enable_arenas,
             &self._bitfield,
             31i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             13usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.objc_class_prefix,
             &self._bitfield,
             36i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             14usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.csharp_namespace,
             &self._bitfield,
             37i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             15usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.swift_prefix,
             &self._bitfield,
             39i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             16usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.php_class_prefix,
             &self._bitfield,
             40i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             17usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.php_namespace,
             &self._bitfield,
             41i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             18usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.php_metadata_namespace,
             &self._bitfield,
             44i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             19usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.ruby_package,
             &self._bitfield,
             45i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::UninterpretedOption,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::UninterpretedOption,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.uninterpreted_option,
             &self._bitfield,
             999i32,
@@ -6172,110 +6110,110 @@ impl self::_puroro::Message for FileOptions {
 impl ::std::clone::Clone for FileOptions {
     fn clone(&self) -> Self {
         Self {
-            java_package: <self::_puroro::internal::field_type::OptionalUnsizedField::<
+            java_package: <self::_pinternal::field_type::OptionalUnsizedField::<
                 ::std::string::String,
-                self::_puroro::internal::tags::String,
+                self::_pinternal::tags::String,
                 0usize,
             > as ::std::clone::Clone>::clone(&self.java_package),
-            java_outer_classname: <self::_puroro::internal::field_type::OptionalUnsizedField::<
+            java_outer_classname: <self::_pinternal::field_type::OptionalUnsizedField::<
                 ::std::string::String,
-                self::_puroro::internal::tags::String,
+                self::_pinternal::tags::String,
                 1usize,
             > as ::std::clone::Clone>::clone(&self.java_outer_classname),
-            java_multiple_files: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            java_multiple_files: <self::_pinternal::field_type::OptionalNumericalField::<
                 bool,
-                self::_puroro::internal::tags::Bool,
+                self::_pinternal::tags::Bool,
                 2usize,
             > as ::std::clone::Clone>::clone(&self.java_multiple_files),
-            java_generate_equals_and_hash: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            java_generate_equals_and_hash: <self::_pinternal::field_type::OptionalNumericalField::<
                 bool,
-                self::_puroro::internal::tags::Bool,
+                self::_pinternal::tags::Bool,
                 3usize,
             > as ::std::clone::Clone>::clone(&self.java_generate_equals_and_hash),
-            java_string_check_utf8: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            java_string_check_utf8: <self::_pinternal::field_type::OptionalNumericalField::<
                 bool,
-                self::_puroro::internal::tags::Bool,
+                self::_pinternal::tags::Bool,
                 4usize,
             > as ::std::clone::Clone>::clone(&self.java_string_check_utf8),
-            optimize_for: <self::_puroro::internal::field_type::OptionalNumericalField::<
-                self::_puroro_root::google::protobuf::file_options::OptimizeMode,
-                self::_puroro::internal::tags::Enum2::<
-                    self::_puroro_root::google::protobuf::file_options::OptimizeMode,
+            optimize_for: <self::_pinternal::field_type::OptionalNumericalField::<
+                self::_root::google::protobuf::file_options::OptimizeMode,
+                self::_pinternal::tags::Enum2::<
+                    self::_root::google::protobuf::file_options::OptimizeMode,
                 >,
                 5usize,
             > as ::std::clone::Clone>::clone(&self.optimize_for),
-            go_package: <self::_puroro::internal::field_type::OptionalUnsizedField::<
+            go_package: <self::_pinternal::field_type::OptionalUnsizedField::<
                 ::std::string::String,
-                self::_puroro::internal::tags::String,
+                self::_pinternal::tags::String,
                 6usize,
             > as ::std::clone::Clone>::clone(&self.go_package),
-            cc_generic_services: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            cc_generic_services: <self::_pinternal::field_type::OptionalNumericalField::<
                 bool,
-                self::_puroro::internal::tags::Bool,
+                self::_pinternal::tags::Bool,
                 7usize,
             > as ::std::clone::Clone>::clone(&self.cc_generic_services),
-            java_generic_services: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            java_generic_services: <self::_pinternal::field_type::OptionalNumericalField::<
                 bool,
-                self::_puroro::internal::tags::Bool,
+                self::_pinternal::tags::Bool,
                 8usize,
             > as ::std::clone::Clone>::clone(&self.java_generic_services),
-            py_generic_services: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            py_generic_services: <self::_pinternal::field_type::OptionalNumericalField::<
                 bool,
-                self::_puroro::internal::tags::Bool,
+                self::_pinternal::tags::Bool,
                 9usize,
             > as ::std::clone::Clone>::clone(&self.py_generic_services),
-            php_generic_services: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            php_generic_services: <self::_pinternal::field_type::OptionalNumericalField::<
                 bool,
-                self::_puroro::internal::tags::Bool,
+                self::_pinternal::tags::Bool,
                 10usize,
             > as ::std::clone::Clone>::clone(&self.php_generic_services),
-            deprecated: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            deprecated: <self::_pinternal::field_type::OptionalNumericalField::<
                 bool,
-                self::_puroro::internal::tags::Bool,
+                self::_pinternal::tags::Bool,
                 11usize,
             > as ::std::clone::Clone>::clone(&self.deprecated),
-            cc_enable_arenas: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            cc_enable_arenas: <self::_pinternal::field_type::OptionalNumericalField::<
                 bool,
-                self::_puroro::internal::tags::Bool,
+                self::_pinternal::tags::Bool,
                 12usize,
             > as ::std::clone::Clone>::clone(&self.cc_enable_arenas),
-            objc_class_prefix: <self::_puroro::internal::field_type::OptionalUnsizedField::<
+            objc_class_prefix: <self::_pinternal::field_type::OptionalUnsizedField::<
                 ::std::string::String,
-                self::_puroro::internal::tags::String,
+                self::_pinternal::tags::String,
                 13usize,
             > as ::std::clone::Clone>::clone(&self.objc_class_prefix),
-            csharp_namespace: <self::_puroro::internal::field_type::OptionalUnsizedField::<
+            csharp_namespace: <self::_pinternal::field_type::OptionalUnsizedField::<
                 ::std::string::String,
-                self::_puroro::internal::tags::String,
+                self::_pinternal::tags::String,
                 14usize,
             > as ::std::clone::Clone>::clone(&self.csharp_namespace),
-            swift_prefix: <self::_puroro::internal::field_type::OptionalUnsizedField::<
+            swift_prefix: <self::_pinternal::field_type::OptionalUnsizedField::<
                 ::std::string::String,
-                self::_puroro::internal::tags::String,
+                self::_pinternal::tags::String,
                 15usize,
             > as ::std::clone::Clone>::clone(&self.swift_prefix),
-            php_class_prefix: <self::_puroro::internal::field_type::OptionalUnsizedField::<
+            php_class_prefix: <self::_pinternal::field_type::OptionalUnsizedField::<
                 ::std::string::String,
-                self::_puroro::internal::tags::String,
+                self::_pinternal::tags::String,
                 16usize,
             > as ::std::clone::Clone>::clone(&self.php_class_prefix),
-            php_namespace: <self::_puroro::internal::field_type::OptionalUnsizedField::<
+            php_namespace: <self::_pinternal::field_type::OptionalUnsizedField::<
                 ::std::string::String,
-                self::_puroro::internal::tags::String,
+                self::_pinternal::tags::String,
                 17usize,
             > as ::std::clone::Clone>::clone(&self.php_namespace),
-            php_metadata_namespace: <self::_puroro::internal::field_type::OptionalUnsizedField::<
+            php_metadata_namespace: <self::_pinternal::field_type::OptionalUnsizedField::<
                 ::std::string::String,
-                self::_puroro::internal::tags::String,
+                self::_pinternal::tags::String,
                 18usize,
             > as ::std::clone::Clone>::clone(&self.php_metadata_namespace),
-            ruby_package: <self::_puroro::internal::field_type::OptionalUnsizedField::<
+            ruby_package: <self::_pinternal::field_type::OptionalUnsizedField::<
                 ::std::string::String,
-                self::_puroro::internal::tags::String,
+                self::_pinternal::tags::String,
                 19usize,
             > as ::std::clone::Clone>::clone(&self.ruby_package),
-            uninterpreted_option: <self::_puroro::internal::field_type::RepeatedMessageField::<
-                self::_puroro_root::google::protobuf::UninterpretedOption,
+            uninterpreted_option: <self::_pinternal::field_type::RepeatedMessageField::<
+                self::_root::google::protobuf::UninterpretedOption,
             > as ::std::clone::Clone>::clone(&self.uninterpreted_option),
             _bitfield: ::std::clone::Clone::clone(&self._bitfield),
         }
@@ -6284,7 +6222,7 @@ impl ::std::clone::Clone for FileOptions {
 impl ::std::ops::Drop for FileOptions {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for FileOptions {
@@ -6329,7 +6267,7 @@ impl ::std::fmt::Debug for FileOptions {
 impl ::std::cmp::PartialEq for FileOptions {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         true && self.java_package_opt() == rhs.java_package_opt()
             && self.java_outer_classname_opt() == rhs.java_outer_classname_opt()
             && self.java_multiple_files_opt() == rhs.java_multiple_files_opt()
@@ -6356,37 +6294,37 @@ impl ::std::cmp::PartialEq for FileOptions {
 }
 #[derive(::std::default::Default)]
 pub struct MessageOptions {
-    message_set_wire_format: self::_puroro::internal::field_type::OptionalNumericalField::<
+    message_set_wire_format: self::_pinternal::field_type::OptionalNumericalField::<
         bool,
-        self::_puroro::internal::tags::Bool,
+        self::_pinternal::tags::Bool,
         0usize,
     >,
-    no_standard_descriptor_accessor: self::_puroro::internal::field_type::OptionalNumericalField::<
+    no_standard_descriptor_accessor: self::_pinternal::field_type::OptionalNumericalField::<
         bool,
-        self::_puroro::internal::tags::Bool,
+        self::_pinternal::tags::Bool,
         1usize,
     >,
-    deprecated: self::_puroro::internal::field_type::OptionalNumericalField::<
+    deprecated: self::_pinternal::field_type::OptionalNumericalField::<
         bool,
-        self::_puroro::internal::tags::Bool,
+        self::_pinternal::tags::Bool,
         2usize,
     >,
-    map_entry: self::_puroro::internal::field_type::OptionalNumericalField::<
+    map_entry: self::_pinternal::field_type::OptionalNumericalField::<
         bool,
-        self::_puroro::internal::tags::Bool,
+        self::_pinternal::tags::Bool,
         3usize,
     >,
-    uninterpreted_option: self::_puroro::internal::field_type::RepeatedMessageField::<
-        self::_puroro_root::google::protobuf::UninterpretedOption,
+    uninterpreted_option: self::_pinternal::field_type::RepeatedMessageField::<
+        self::_root::google::protobuf::UninterpretedOption,
     >,
-    _bitfield: self::_puroro::internal::bitvec::BitArray<1usize>,
+    _bitfield: self::_pinternal::bitvec::BitArray<1usize>,
 }
 impl MessageOptions {
     pub fn message_set_wire_format(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             0usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.message_set_wire_format,
@@ -6395,10 +6333,10 @@ impl MessageOptions {
         )
     }
     pub fn message_set_wire_format_opt(&self) -> ::std::option::Option::<bool> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(
             &self.message_set_wire_format,
@@ -6406,10 +6344,10 @@ impl MessageOptions {
         )
     }
     pub fn message_set_wire_format_mut(&mut self) -> &mut bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             0usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.message_set_wire_format,
@@ -6418,10 +6356,10 @@ impl MessageOptions {
         )
     }
     pub fn has_message_set_wire_format(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(
                 &self.message_set_wire_format,
@@ -6430,10 +6368,10 @@ impl MessageOptions {
             .is_some()
     }
     pub fn clear_message_set_wire_format(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             0usize,
         > as NonRepeatedFieldType>::clear(
             &mut self.message_set_wire_format,
@@ -6441,10 +6379,10 @@ impl MessageOptions {
         )
     }
     pub fn no_standard_descriptor_accessor(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             1usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.no_standard_descriptor_accessor,
@@ -6453,10 +6391,10 @@ impl MessageOptions {
         )
     }
     pub fn no_standard_descriptor_accessor_opt(&self) -> ::std::option::Option::<bool> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             1usize,
         > as NonRepeatedFieldType>::get_field_opt(
             &self.no_standard_descriptor_accessor,
@@ -6464,10 +6402,10 @@ impl MessageOptions {
         )
     }
     pub fn no_standard_descriptor_accessor_mut(&mut self) -> &mut bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             1usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.no_standard_descriptor_accessor,
@@ -6476,10 +6414,10 @@ impl MessageOptions {
         )
     }
     pub fn has_no_standard_descriptor_accessor(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             1usize,
         > as NonRepeatedFieldType>::get_field_opt(
                 &self.no_standard_descriptor_accessor,
@@ -6488,10 +6426,10 @@ impl MessageOptions {
             .is_some()
     }
     pub fn clear_no_standard_descriptor_accessor(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             1usize,
         > as NonRepeatedFieldType>::clear(
             &mut self.no_standard_descriptor_accessor,
@@ -6499,10 +6437,10 @@ impl MessageOptions {
         )
     }
     pub fn deprecated(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             2usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.deprecated,
@@ -6511,18 +6449,18 @@ impl MessageOptions {
         )
     }
     pub fn deprecated_opt(&self) -> ::std::option::Option::<bool> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             2usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.deprecated, &self._bitfield)
     }
     pub fn deprecated_mut(&mut self) -> &mut bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             2usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.deprecated,
@@ -6531,27 +6469,27 @@ impl MessageOptions {
         )
     }
     pub fn has_deprecated(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             2usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.deprecated, &self._bitfield)
             .is_some()
     }
     pub fn clear_deprecated(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             2usize,
         > as NonRepeatedFieldType>::clear(&mut self.deprecated, &mut self._bitfield)
     }
     pub fn map_entry(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             3usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.map_entry,
@@ -6560,18 +6498,18 @@ impl MessageOptions {
         )
     }
     pub fn map_entry_opt(&self) -> ::std::option::Option::<bool> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             3usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.map_entry, &self._bitfield)
     }
     pub fn map_entry_mut(&mut self) -> &mut bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             3usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.map_entry,
@@ -6580,47 +6518,45 @@ impl MessageOptions {
         )
     }
     pub fn has_map_entry(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             3usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.map_entry, &self._bitfield)
             .is_some()
     }
     pub fn clear_map_entry(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             3usize,
         > as NonRepeatedFieldType>::clear(&mut self.map_entry, &mut self._bitfield)
     }
     pub fn uninterpreted_option(
         &self,
-    ) -> &[self::_puroro_root::google::protobuf::UninterpretedOption] {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::UninterpretedOption,
+    ) -> &[self::_root::google::protobuf::UninterpretedOption] {
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::UninterpretedOption,
         > as RepeatedFieldType>::get_field(&self.uninterpreted_option, &self._bitfield)
     }
     pub fn uninterpreted_option_mut(
         &mut self,
-    ) -> &mut ::std::vec::Vec::<
-        self::_puroro_root::google::protobuf::UninterpretedOption,
-    > {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::UninterpretedOption,
+    ) -> &mut ::std::vec::Vec::<self::_root::google::protobuf::UninterpretedOption> {
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::UninterpretedOption,
         > as RepeatedFieldType>::get_field_mut(
             &mut self.uninterpreted_option,
             &mut self._bitfield,
         )
     }
     pub fn clear_uninterpreted_option(&mut self) {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::UninterpretedOption,
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::UninterpretedOption,
         > as RepeatedFieldType>::clear(
             &mut self.uninterpreted_option,
             &mut self._bitfield,
@@ -6639,60 +6575,60 @@ impl self::_puroro::Message for MessageOptions {
         &mut self,
         mut iter: I,
     ) -> self::_puroro::Result<()> {
-        use self::_puroro::internal::ser::FieldData;
+        use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 1i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         bool,
-                        self::_puroro::internal::tags::Bool,
+                        self::_pinternal::tags::Bool,
                         0usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.message_set_wire_format,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 2i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         bool,
-                        self::_puroro::internal::tags::Bool,
+                        self::_pinternal::tags::Bool,
                         1usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.no_standard_descriptor_accessor,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 3i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         bool,
-                        self::_puroro::internal::tags::Bool,
+                        self::_pinternal::tags::Bool,
                         2usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.deprecated,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 7i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         bool,
-                        self::_puroro::internal::tags::Bool,
+                        self::_pinternal::tags::Bool,
                         3usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.map_entry,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 999i32 => {
-                    <self::_puroro::internal::field_type::RepeatedMessageField::<
-                        self::_puroro_root::google::protobuf::UninterpretedOption,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    <self::_pinternal::field_type::RepeatedMessageField::<
+                        self::_root::google::protobuf::UninterpretedOption,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.uninterpreted_option,
                         &mut self._bitfield,
                         field_data,
@@ -6709,50 +6645,50 @@ impl self::_puroro::Message for MessageOptions {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::oneof_type::OneofUnion as _;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             0usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.message_set_wire_format,
             &self._bitfield,
             1i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             1usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.no_standard_descriptor_accessor,
             &self._bitfield,
             2i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             2usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.deprecated,
             &self._bitfield,
             3i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             3usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.map_entry,
             &self._bitfield,
             7i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::UninterpretedOption,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::UninterpretedOption,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.uninterpreted_option,
             &self._bitfield,
             999i32,
@@ -6764,28 +6700,28 @@ impl self::_puroro::Message for MessageOptions {
 impl ::std::clone::Clone for MessageOptions {
     fn clone(&self) -> Self {
         Self {
-            message_set_wire_format: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            message_set_wire_format: <self::_pinternal::field_type::OptionalNumericalField::<
                 bool,
-                self::_puroro::internal::tags::Bool,
+                self::_pinternal::tags::Bool,
                 0usize,
             > as ::std::clone::Clone>::clone(&self.message_set_wire_format),
-            no_standard_descriptor_accessor: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            no_standard_descriptor_accessor: <self::_pinternal::field_type::OptionalNumericalField::<
                 bool,
-                self::_puroro::internal::tags::Bool,
+                self::_pinternal::tags::Bool,
                 1usize,
             > as ::std::clone::Clone>::clone(&self.no_standard_descriptor_accessor),
-            deprecated: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            deprecated: <self::_pinternal::field_type::OptionalNumericalField::<
                 bool,
-                self::_puroro::internal::tags::Bool,
+                self::_pinternal::tags::Bool,
                 2usize,
             > as ::std::clone::Clone>::clone(&self.deprecated),
-            map_entry: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            map_entry: <self::_pinternal::field_type::OptionalNumericalField::<
                 bool,
-                self::_puroro::internal::tags::Bool,
+                self::_pinternal::tags::Bool,
                 3usize,
             > as ::std::clone::Clone>::clone(&self.map_entry),
-            uninterpreted_option: <self::_puroro::internal::field_type::RepeatedMessageField::<
-                self::_puroro_root::google::protobuf::UninterpretedOption,
+            uninterpreted_option: <self::_pinternal::field_type::RepeatedMessageField::<
+                self::_root::google::protobuf::UninterpretedOption,
             > as ::std::clone::Clone>::clone(&self.uninterpreted_option),
             _bitfield: ::std::clone::Clone::clone(&self._bitfield),
         }
@@ -6794,7 +6730,7 @@ impl ::std::clone::Clone for MessageOptions {
 impl ::std::ops::Drop for MessageOptions {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for MessageOptions {
@@ -6820,7 +6756,7 @@ impl ::std::fmt::Debug for MessageOptions {
 impl ::std::cmp::PartialEq for MessageOptions {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         true && self.message_set_wire_format_opt() == rhs.message_set_wire_format_opt()
             && self.no_standard_descriptor_accessor_opt()
                 == rhs.no_standard_descriptor_accessor_opt()
@@ -6831,116 +6767,114 @@ impl ::std::cmp::PartialEq for MessageOptions {
 }
 #[derive(::std::default::Default)]
 pub struct FieldOptions {
-    ctype: self::_puroro::internal::field_type::OptionalNumericalField::<
-        self::_puroro_root::google::protobuf::field_options::CType,
-        self::_puroro::internal::tags::Enum2::<
-            self::_puroro_root::google::protobuf::field_options::CType,
+    ctype: self::_pinternal::field_type::OptionalNumericalField::<
+        self::_root::google::protobuf::field_options::CType,
+        self::_pinternal::tags::Enum2::<
+            self::_root::google::protobuf::field_options::CType,
         >,
         0usize,
     >,
-    packed: self::_puroro::internal::field_type::OptionalNumericalField::<
+    packed: self::_pinternal::field_type::OptionalNumericalField::<
         bool,
-        self::_puroro::internal::tags::Bool,
+        self::_pinternal::tags::Bool,
         1usize,
     >,
-    jstype: self::_puroro::internal::field_type::OptionalNumericalField::<
-        self::_puroro_root::google::protobuf::field_options::JSType,
-        self::_puroro::internal::tags::Enum2::<
-            self::_puroro_root::google::protobuf::field_options::JSType,
+    jstype: self::_pinternal::field_type::OptionalNumericalField::<
+        self::_root::google::protobuf::field_options::JSType,
+        self::_pinternal::tags::Enum2::<
+            self::_root::google::protobuf::field_options::JSType,
         >,
         2usize,
     >,
-    lazy: self::_puroro::internal::field_type::OptionalNumericalField::<
+    lazy: self::_pinternal::field_type::OptionalNumericalField::<
         bool,
-        self::_puroro::internal::tags::Bool,
+        self::_pinternal::tags::Bool,
         3usize,
     >,
-    deprecated: self::_puroro::internal::field_type::OptionalNumericalField::<
+    deprecated: self::_pinternal::field_type::OptionalNumericalField::<
         bool,
-        self::_puroro::internal::tags::Bool,
+        self::_pinternal::tags::Bool,
         4usize,
     >,
-    weak: self::_puroro::internal::field_type::OptionalNumericalField::<
+    weak: self::_pinternal::field_type::OptionalNumericalField::<
         bool,
-        self::_puroro::internal::tags::Bool,
+        self::_pinternal::tags::Bool,
         5usize,
     >,
-    uninterpreted_option: self::_puroro::internal::field_type::RepeatedMessageField::<
-        self::_puroro_root::google::protobuf::UninterpretedOption,
+    uninterpreted_option: self::_pinternal::field_type::RepeatedMessageField::<
+        self::_root::google::protobuf::UninterpretedOption,
     >,
-    _bitfield: self::_puroro::internal::bitvec::BitArray<1usize>,
+    _bitfield: self::_pinternal::bitvec::BitArray<1usize>,
 }
 impl FieldOptions {
-    pub fn ctype(&self) -> self::_puroro_root::google::protobuf::field_options::CType {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
-            self::_puroro_root::google::protobuf::field_options::CType,
-            self::_puroro::internal::tags::Enum2::<
-                self::_puroro_root::google::protobuf::field_options::CType,
+    pub fn ctype(&self) -> self::_root::google::protobuf::field_options::CType {
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
+            self::_root::google::protobuf::field_options::CType,
+            self::_pinternal::tags::Enum2::<
+                self::_root::google::protobuf::field_options::CType,
             >,
             0usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.ctype,
             &self._bitfield,
-            || self::_puroro_root::google::protobuf::field_options::CType::String,
+            || self::_root::google::protobuf::field_options::CType::String,
         )
     }
     pub fn ctype_opt(
         &self,
-    ) -> ::std::option::Option::<
-        self::_puroro_root::google::protobuf::field_options::CType,
-    > {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
-            self::_puroro_root::google::protobuf::field_options::CType,
-            self::_puroro::internal::tags::Enum2::<
-                self::_puroro_root::google::protobuf::field_options::CType,
+    ) -> ::std::option::Option::<self::_root::google::protobuf::field_options::CType> {
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
+            self::_root::google::protobuf::field_options::CType,
+            self::_pinternal::tags::Enum2::<
+                self::_root::google::protobuf::field_options::CType,
             >,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.ctype, &self._bitfield)
     }
     pub fn ctype_mut(
         &mut self,
-    ) -> &mut self::_puroro_root::google::protobuf::field_options::CType {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
-            self::_puroro_root::google::protobuf::field_options::CType,
-            self::_puroro::internal::tags::Enum2::<
-                self::_puroro_root::google::protobuf::field_options::CType,
+    ) -> &mut self::_root::google::protobuf::field_options::CType {
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
+            self::_root::google::protobuf::field_options::CType,
+            self::_pinternal::tags::Enum2::<
+                self::_root::google::protobuf::field_options::CType,
             >,
             0usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.ctype,
             &mut self._bitfield,
-            || self::_puroro_root::google::protobuf::field_options::CType::String,
+            || self::_root::google::protobuf::field_options::CType::String,
         )
     }
     pub fn has_ctype(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
-            self::_puroro_root::google::protobuf::field_options::CType,
-            self::_puroro::internal::tags::Enum2::<
-                self::_puroro_root::google::protobuf::field_options::CType,
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
+            self::_root::google::protobuf::field_options::CType,
+            self::_pinternal::tags::Enum2::<
+                self::_root::google::protobuf::field_options::CType,
             >,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.ctype, &self._bitfield)
             .is_some()
     }
     pub fn clear_ctype(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
-            self::_puroro_root::google::protobuf::field_options::CType,
-            self::_puroro::internal::tags::Enum2::<
-                self::_puroro_root::google::protobuf::field_options::CType,
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
+            self::_root::google::protobuf::field_options::CType,
+            self::_pinternal::tags::Enum2::<
+                self::_root::google::protobuf::field_options::CType,
             >,
             0usize,
         > as NonRepeatedFieldType>::clear(&mut self.ctype, &mut self._bitfield)
     }
     pub fn packed(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             1usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.packed,
@@ -6949,18 +6883,18 @@ impl FieldOptions {
         )
     }
     pub fn packed_opt(&self) -> ::std::option::Option::<bool> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             1usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.packed, &self._bitfield)
     }
     pub fn packed_mut(&mut self) -> &mut bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             1usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.packed,
@@ -6969,92 +6903,90 @@ impl FieldOptions {
         )
     }
     pub fn has_packed(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             1usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.packed, &self._bitfield)
             .is_some()
     }
     pub fn clear_packed(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             1usize,
         > as NonRepeatedFieldType>::clear(&mut self.packed, &mut self._bitfield)
     }
-    pub fn jstype(&self) -> self::_puroro_root::google::protobuf::field_options::JSType {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
-            self::_puroro_root::google::protobuf::field_options::JSType,
-            self::_puroro::internal::tags::Enum2::<
-                self::_puroro_root::google::protobuf::field_options::JSType,
+    pub fn jstype(&self) -> self::_root::google::protobuf::field_options::JSType {
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
+            self::_root::google::protobuf::field_options::JSType,
+            self::_pinternal::tags::Enum2::<
+                self::_root::google::protobuf::field_options::JSType,
             >,
             2usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.jstype,
             &self._bitfield,
-            || self::_puroro_root::google::protobuf::field_options::JSType::JsNormal,
+            || self::_root::google::protobuf::field_options::JSType::JsNormal,
         )
     }
     pub fn jstype_opt(
         &self,
-    ) -> ::std::option::Option::<
-        self::_puroro_root::google::protobuf::field_options::JSType,
-    > {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
-            self::_puroro_root::google::protobuf::field_options::JSType,
-            self::_puroro::internal::tags::Enum2::<
-                self::_puroro_root::google::protobuf::field_options::JSType,
+    ) -> ::std::option::Option::<self::_root::google::protobuf::field_options::JSType> {
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
+            self::_root::google::protobuf::field_options::JSType,
+            self::_pinternal::tags::Enum2::<
+                self::_root::google::protobuf::field_options::JSType,
             >,
             2usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.jstype, &self._bitfield)
     }
     pub fn jstype_mut(
         &mut self,
-    ) -> &mut self::_puroro_root::google::protobuf::field_options::JSType {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
-            self::_puroro_root::google::protobuf::field_options::JSType,
-            self::_puroro::internal::tags::Enum2::<
-                self::_puroro_root::google::protobuf::field_options::JSType,
+    ) -> &mut self::_root::google::protobuf::field_options::JSType {
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
+            self::_root::google::protobuf::field_options::JSType,
+            self::_pinternal::tags::Enum2::<
+                self::_root::google::protobuf::field_options::JSType,
             >,
             2usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.jstype,
             &mut self._bitfield,
-            || self::_puroro_root::google::protobuf::field_options::JSType::JsNormal,
+            || self::_root::google::protobuf::field_options::JSType::JsNormal,
         )
     }
     pub fn has_jstype(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
-            self::_puroro_root::google::protobuf::field_options::JSType,
-            self::_puroro::internal::tags::Enum2::<
-                self::_puroro_root::google::protobuf::field_options::JSType,
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
+            self::_root::google::protobuf::field_options::JSType,
+            self::_pinternal::tags::Enum2::<
+                self::_root::google::protobuf::field_options::JSType,
             >,
             2usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.jstype, &self._bitfield)
             .is_some()
     }
     pub fn clear_jstype(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
-            self::_puroro_root::google::protobuf::field_options::JSType,
-            self::_puroro::internal::tags::Enum2::<
-                self::_puroro_root::google::protobuf::field_options::JSType,
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
+            self::_root::google::protobuf::field_options::JSType,
+            self::_pinternal::tags::Enum2::<
+                self::_root::google::protobuf::field_options::JSType,
             >,
             2usize,
         > as NonRepeatedFieldType>::clear(&mut self.jstype, &mut self._bitfield)
     }
     pub fn lazy(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             3usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.lazy,
@@ -7063,18 +6995,18 @@ impl FieldOptions {
         )
     }
     pub fn lazy_opt(&self) -> ::std::option::Option::<bool> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             3usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.lazy, &self._bitfield)
     }
     pub fn lazy_mut(&mut self) -> &mut bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             3usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.lazy,
@@ -7083,27 +7015,27 @@ impl FieldOptions {
         )
     }
     pub fn has_lazy(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             3usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.lazy, &self._bitfield)
             .is_some()
     }
     pub fn clear_lazy(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             3usize,
         > as NonRepeatedFieldType>::clear(&mut self.lazy, &mut self._bitfield)
     }
     pub fn deprecated(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             4usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.deprecated,
@@ -7112,18 +7044,18 @@ impl FieldOptions {
         )
     }
     pub fn deprecated_opt(&self) -> ::std::option::Option::<bool> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             4usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.deprecated, &self._bitfield)
     }
     pub fn deprecated_mut(&mut self) -> &mut bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             4usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.deprecated,
@@ -7132,27 +7064,27 @@ impl FieldOptions {
         )
     }
     pub fn has_deprecated(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             4usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.deprecated, &self._bitfield)
             .is_some()
     }
     pub fn clear_deprecated(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             4usize,
         > as NonRepeatedFieldType>::clear(&mut self.deprecated, &mut self._bitfield)
     }
     pub fn weak(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             5usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.weak,
@@ -7161,18 +7093,18 @@ impl FieldOptions {
         )
     }
     pub fn weak_opt(&self) -> ::std::option::Option::<bool> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             5usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.weak, &self._bitfield)
     }
     pub fn weak_mut(&mut self) -> &mut bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             5usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.weak,
@@ -7181,47 +7113,45 @@ impl FieldOptions {
         )
     }
     pub fn has_weak(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             5usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.weak, &self._bitfield)
             .is_some()
     }
     pub fn clear_weak(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             5usize,
         > as NonRepeatedFieldType>::clear(&mut self.weak, &mut self._bitfield)
     }
     pub fn uninterpreted_option(
         &self,
-    ) -> &[self::_puroro_root::google::protobuf::UninterpretedOption] {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::UninterpretedOption,
+    ) -> &[self::_root::google::protobuf::UninterpretedOption] {
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::UninterpretedOption,
         > as RepeatedFieldType>::get_field(&self.uninterpreted_option, &self._bitfield)
     }
     pub fn uninterpreted_option_mut(
         &mut self,
-    ) -> &mut ::std::vec::Vec::<
-        self::_puroro_root::google::protobuf::UninterpretedOption,
-    > {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::UninterpretedOption,
+    ) -> &mut ::std::vec::Vec::<self::_root::google::protobuf::UninterpretedOption> {
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::UninterpretedOption,
         > as RepeatedFieldType>::get_field_mut(
             &mut self.uninterpreted_option,
             &mut self._bitfield,
         )
     }
     pub fn clear_uninterpreted_option(&mut self) {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::UninterpretedOption,
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::UninterpretedOption,
         > as RepeatedFieldType>::clear(
             &mut self.uninterpreted_option,
             &mut self._bitfield,
@@ -7240,86 +7170,86 @@ impl self::_puroro::Message for FieldOptions {
         &mut self,
         mut iter: I,
     ) -> self::_puroro::Result<()> {
-        use self::_puroro::internal::ser::FieldData;
+        use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 1i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
-                        self::_puroro_root::google::protobuf::field_options::CType,
-                        self::_puroro::internal::tags::Enum2::<
-                            self::_puroro_root::google::protobuf::field_options::CType,
+                    <self::_pinternal::field_type::OptionalNumericalField::<
+                        self::_root::google::protobuf::field_options::CType,
+                        self::_pinternal::tags::Enum2::<
+                            self::_root::google::protobuf::field_options::CType,
                         >,
                         0usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.ctype,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 2i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         bool,
-                        self::_puroro::internal::tags::Bool,
+                        self::_pinternal::tags::Bool,
                         1usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.packed,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 6i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
-                        self::_puroro_root::google::protobuf::field_options::JSType,
-                        self::_puroro::internal::tags::Enum2::<
-                            self::_puroro_root::google::protobuf::field_options::JSType,
+                    <self::_pinternal::field_type::OptionalNumericalField::<
+                        self::_root::google::protobuf::field_options::JSType,
+                        self::_pinternal::tags::Enum2::<
+                            self::_root::google::protobuf::field_options::JSType,
                         >,
                         2usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.jstype,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 5i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         bool,
-                        self::_puroro::internal::tags::Bool,
+                        self::_pinternal::tags::Bool,
                         3usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.lazy,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 3i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         bool,
-                        self::_puroro::internal::tags::Bool,
+                        self::_pinternal::tags::Bool,
                         4usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.deprecated,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 10i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         bool,
-                        self::_puroro::internal::tags::Bool,
+                        self::_pinternal::tags::Bool,
                         5usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.weak,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 999i32 => {
-                    <self::_puroro::internal::field_type::RepeatedMessageField::<
-                        self::_puroro_root::google::protobuf::UninterpretedOption,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    <self::_pinternal::field_type::RepeatedMessageField::<
+                        self::_root::google::protobuf::UninterpretedOption,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.uninterpreted_option,
                         &mut self._bitfield,
                         field_data,
@@ -7336,74 +7266,74 @@ impl self::_puroro::Message for FieldOptions {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
-            self::_puroro_root::google::protobuf::field_options::CType,
-            self::_puroro::internal::tags::Enum2::<
-                self::_puroro_root::google::protobuf::field_options::CType,
+        use self::_pinternal::oneof_type::OneofUnion as _;
+        <self::_pinternal::field_type::OptionalNumericalField::<
+            self::_root::google::protobuf::field_options::CType,
+            self::_pinternal::tags::Enum2::<
+                self::_root::google::protobuf::field_options::CType,
             >,
             0usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.ctype,
             &self._bitfield,
             1i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             1usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.packed,
             &self._bitfield,
             2i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
-            self::_puroro_root::google::protobuf::field_options::JSType,
-            self::_puroro::internal::tags::Enum2::<
-                self::_puroro_root::google::protobuf::field_options::JSType,
+        <self::_pinternal::field_type::OptionalNumericalField::<
+            self::_root::google::protobuf::field_options::JSType,
+            self::_pinternal::tags::Enum2::<
+                self::_root::google::protobuf::field_options::JSType,
             >,
             2usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.jstype,
             &self._bitfield,
             6i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             3usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.lazy,
             &self._bitfield,
             5i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             4usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.deprecated,
             &self._bitfield,
             3i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             5usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.weak,
             &self._bitfield,
             10i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::UninterpretedOption,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::UninterpretedOption,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.uninterpreted_option,
             &self._bitfield,
             999i32,
@@ -7415,42 +7345,42 @@ impl self::_puroro::Message for FieldOptions {
 impl ::std::clone::Clone for FieldOptions {
     fn clone(&self) -> Self {
         Self {
-            ctype: <self::_puroro::internal::field_type::OptionalNumericalField::<
-                self::_puroro_root::google::protobuf::field_options::CType,
-                self::_puroro::internal::tags::Enum2::<
-                    self::_puroro_root::google::protobuf::field_options::CType,
+            ctype: <self::_pinternal::field_type::OptionalNumericalField::<
+                self::_root::google::protobuf::field_options::CType,
+                self::_pinternal::tags::Enum2::<
+                    self::_root::google::protobuf::field_options::CType,
                 >,
                 0usize,
             > as ::std::clone::Clone>::clone(&self.ctype),
-            packed: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            packed: <self::_pinternal::field_type::OptionalNumericalField::<
                 bool,
-                self::_puroro::internal::tags::Bool,
+                self::_pinternal::tags::Bool,
                 1usize,
             > as ::std::clone::Clone>::clone(&self.packed),
-            jstype: <self::_puroro::internal::field_type::OptionalNumericalField::<
-                self::_puroro_root::google::protobuf::field_options::JSType,
-                self::_puroro::internal::tags::Enum2::<
-                    self::_puroro_root::google::protobuf::field_options::JSType,
+            jstype: <self::_pinternal::field_type::OptionalNumericalField::<
+                self::_root::google::protobuf::field_options::JSType,
+                self::_pinternal::tags::Enum2::<
+                    self::_root::google::protobuf::field_options::JSType,
                 >,
                 2usize,
             > as ::std::clone::Clone>::clone(&self.jstype),
-            lazy: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            lazy: <self::_pinternal::field_type::OptionalNumericalField::<
                 bool,
-                self::_puroro::internal::tags::Bool,
+                self::_pinternal::tags::Bool,
                 3usize,
             > as ::std::clone::Clone>::clone(&self.lazy),
-            deprecated: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            deprecated: <self::_pinternal::field_type::OptionalNumericalField::<
                 bool,
-                self::_puroro::internal::tags::Bool,
+                self::_pinternal::tags::Bool,
                 4usize,
             > as ::std::clone::Clone>::clone(&self.deprecated),
-            weak: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            weak: <self::_pinternal::field_type::OptionalNumericalField::<
                 bool,
-                self::_puroro::internal::tags::Bool,
+                self::_pinternal::tags::Bool,
                 5usize,
             > as ::std::clone::Clone>::clone(&self.weak),
-            uninterpreted_option: <self::_puroro::internal::field_type::RepeatedMessageField::<
-                self::_puroro_root::google::protobuf::UninterpretedOption,
+            uninterpreted_option: <self::_pinternal::field_type::RepeatedMessageField::<
+                self::_root::google::protobuf::UninterpretedOption,
             > as ::std::clone::Clone>::clone(&self.uninterpreted_option),
             _bitfield: ::std::clone::Clone::clone(&self._bitfield),
         }
@@ -7459,7 +7389,7 @@ impl ::std::clone::Clone for FieldOptions {
 impl ::std::ops::Drop for FieldOptions {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for FieldOptions {
@@ -7481,7 +7411,7 @@ impl ::std::fmt::Debug for FieldOptions {
 impl ::std::cmp::PartialEq for FieldOptions {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         true && self.ctype_opt() == rhs.ctype_opt()
             && self.packed_opt() == rhs.packed_opt()
             && self.jstype_opt() == rhs.jstype_opt() && self.lazy_opt() == rhs.lazy_opt()
@@ -7492,37 +7422,35 @@ impl ::std::cmp::PartialEq for FieldOptions {
 }
 #[derive(::std::default::Default)]
 pub struct OneofOptions {
-    uninterpreted_option: self::_puroro::internal::field_type::RepeatedMessageField::<
-        self::_puroro_root::google::protobuf::UninterpretedOption,
+    uninterpreted_option: self::_pinternal::field_type::RepeatedMessageField::<
+        self::_root::google::protobuf::UninterpretedOption,
     >,
-    _bitfield: self::_puroro::internal::bitvec::BitArray<0usize>,
+    _bitfield: self::_pinternal::bitvec::BitArray<0usize>,
 }
 impl OneofOptions {
     pub fn uninterpreted_option(
         &self,
-    ) -> &[self::_puroro_root::google::protobuf::UninterpretedOption] {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::UninterpretedOption,
+    ) -> &[self::_root::google::protobuf::UninterpretedOption] {
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::UninterpretedOption,
         > as RepeatedFieldType>::get_field(&self.uninterpreted_option, &self._bitfield)
     }
     pub fn uninterpreted_option_mut(
         &mut self,
-    ) -> &mut ::std::vec::Vec::<
-        self::_puroro_root::google::protobuf::UninterpretedOption,
-    > {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::UninterpretedOption,
+    ) -> &mut ::std::vec::Vec::<self::_root::google::protobuf::UninterpretedOption> {
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::UninterpretedOption,
         > as RepeatedFieldType>::get_field_mut(
             &mut self.uninterpreted_option,
             &mut self._bitfield,
         )
     }
     pub fn clear_uninterpreted_option(&mut self) {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::UninterpretedOption,
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::UninterpretedOption,
         > as RepeatedFieldType>::clear(
             &mut self.uninterpreted_option,
             &mut self._bitfield,
@@ -7541,16 +7469,16 @@ impl self::_puroro::Message for OneofOptions {
         &mut self,
         mut iter: I,
     ) -> self::_puroro::Result<()> {
-        use self::_puroro::internal::ser::FieldData;
+        use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 999i32 => {
-                    <self::_puroro::internal::field_type::RepeatedMessageField::<
-                        self::_puroro_root::google::protobuf::UninterpretedOption,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    <self::_pinternal::field_type::RepeatedMessageField::<
+                        self::_root::google::protobuf::UninterpretedOption,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.uninterpreted_option,
                         &mut self._bitfield,
                         field_data,
@@ -7567,10 +7495,10 @@ impl self::_puroro::Message for OneofOptions {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::UninterpretedOption,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        use self::_pinternal::oneof_type::OneofUnion as _;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::UninterpretedOption,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.uninterpreted_option,
             &self._bitfield,
             999i32,
@@ -7582,8 +7510,8 @@ impl self::_puroro::Message for OneofOptions {
 impl ::std::clone::Clone for OneofOptions {
     fn clone(&self) -> Self {
         Self {
-            uninterpreted_option: <self::_puroro::internal::field_type::RepeatedMessageField::<
-                self::_puroro_root::google::protobuf::UninterpretedOption,
+            uninterpreted_option: <self::_pinternal::field_type::RepeatedMessageField::<
+                self::_root::google::protobuf::UninterpretedOption,
             > as ::std::clone::Clone>::clone(&self.uninterpreted_option),
             _bitfield: ::std::clone::Clone::clone(&self._bitfield),
         }
@@ -7592,7 +7520,7 @@ impl ::std::clone::Clone for OneofOptions {
 impl ::std::ops::Drop for OneofOptions {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for OneofOptions {
@@ -7608,33 +7536,33 @@ impl ::std::fmt::Debug for OneofOptions {
 impl ::std::cmp::PartialEq for OneofOptions {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         true && self.uninterpreted_option() == rhs.uninterpreted_option()
     }
 }
 #[derive(::std::default::Default)]
 pub struct EnumOptions {
-    allow_alias: self::_puroro::internal::field_type::OptionalNumericalField::<
+    allow_alias: self::_pinternal::field_type::OptionalNumericalField::<
         bool,
-        self::_puroro::internal::tags::Bool,
+        self::_pinternal::tags::Bool,
         0usize,
     >,
-    deprecated: self::_puroro::internal::field_type::OptionalNumericalField::<
+    deprecated: self::_pinternal::field_type::OptionalNumericalField::<
         bool,
-        self::_puroro::internal::tags::Bool,
+        self::_pinternal::tags::Bool,
         1usize,
     >,
-    uninterpreted_option: self::_puroro::internal::field_type::RepeatedMessageField::<
-        self::_puroro_root::google::protobuf::UninterpretedOption,
+    uninterpreted_option: self::_pinternal::field_type::RepeatedMessageField::<
+        self::_root::google::protobuf::UninterpretedOption,
     >,
-    _bitfield: self::_puroro::internal::bitvec::BitArray<1usize>,
+    _bitfield: self::_pinternal::bitvec::BitArray<1usize>,
 }
 impl EnumOptions {
     pub fn allow_alias(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             0usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.allow_alias,
@@ -7643,18 +7571,18 @@ impl EnumOptions {
         )
     }
     pub fn allow_alias_opt(&self) -> ::std::option::Option::<bool> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.allow_alias, &self._bitfield)
     }
     pub fn allow_alias_mut(&mut self) -> &mut bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             0usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.allow_alias,
@@ -7663,27 +7591,27 @@ impl EnumOptions {
         )
     }
     pub fn has_allow_alias(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.allow_alias, &self._bitfield)
             .is_some()
     }
     pub fn clear_allow_alias(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             0usize,
         > as NonRepeatedFieldType>::clear(&mut self.allow_alias, &mut self._bitfield)
     }
     pub fn deprecated(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             1usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.deprecated,
@@ -7692,18 +7620,18 @@ impl EnumOptions {
         )
     }
     pub fn deprecated_opt(&self) -> ::std::option::Option::<bool> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             1usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.deprecated, &self._bitfield)
     }
     pub fn deprecated_mut(&mut self) -> &mut bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             1usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.deprecated,
@@ -7712,47 +7640,45 @@ impl EnumOptions {
         )
     }
     pub fn has_deprecated(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             1usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.deprecated, &self._bitfield)
             .is_some()
     }
     pub fn clear_deprecated(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             1usize,
         > as NonRepeatedFieldType>::clear(&mut self.deprecated, &mut self._bitfield)
     }
     pub fn uninterpreted_option(
         &self,
-    ) -> &[self::_puroro_root::google::protobuf::UninterpretedOption] {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::UninterpretedOption,
+    ) -> &[self::_root::google::protobuf::UninterpretedOption] {
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::UninterpretedOption,
         > as RepeatedFieldType>::get_field(&self.uninterpreted_option, &self._bitfield)
     }
     pub fn uninterpreted_option_mut(
         &mut self,
-    ) -> &mut ::std::vec::Vec::<
-        self::_puroro_root::google::protobuf::UninterpretedOption,
-    > {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::UninterpretedOption,
+    ) -> &mut ::std::vec::Vec::<self::_root::google::protobuf::UninterpretedOption> {
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::UninterpretedOption,
         > as RepeatedFieldType>::get_field_mut(
             &mut self.uninterpreted_option,
             &mut self._bitfield,
         )
     }
     pub fn clear_uninterpreted_option(&mut self) {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::UninterpretedOption,
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::UninterpretedOption,
         > as RepeatedFieldType>::clear(
             &mut self.uninterpreted_option,
             &mut self._bitfield,
@@ -7771,38 +7697,38 @@ impl self::_puroro::Message for EnumOptions {
         &mut self,
         mut iter: I,
     ) -> self::_puroro::Result<()> {
-        use self::_puroro::internal::ser::FieldData;
+        use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 2i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         bool,
-                        self::_puroro::internal::tags::Bool,
+                        self::_pinternal::tags::Bool,
                         0usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.allow_alias,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 3i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         bool,
-                        self::_puroro::internal::tags::Bool,
+                        self::_pinternal::tags::Bool,
                         1usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.deprecated,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 999i32 => {
-                    <self::_puroro::internal::field_type::RepeatedMessageField::<
-                        self::_puroro_root::google::protobuf::UninterpretedOption,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    <self::_pinternal::field_type::RepeatedMessageField::<
+                        self::_root::google::protobuf::UninterpretedOption,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.uninterpreted_option,
                         &mut self._bitfield,
                         field_data,
@@ -7819,30 +7745,30 @@ impl self::_puroro::Message for EnumOptions {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::oneof_type::OneofUnion as _;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             0usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.allow_alias,
             &self._bitfield,
             2i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             1usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.deprecated,
             &self._bitfield,
             3i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::UninterpretedOption,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::UninterpretedOption,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.uninterpreted_option,
             &self._bitfield,
             999i32,
@@ -7854,18 +7780,18 @@ impl self::_puroro::Message for EnumOptions {
 impl ::std::clone::Clone for EnumOptions {
     fn clone(&self) -> Self {
         Self {
-            allow_alias: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            allow_alias: <self::_pinternal::field_type::OptionalNumericalField::<
                 bool,
-                self::_puroro::internal::tags::Bool,
+                self::_pinternal::tags::Bool,
                 0usize,
             > as ::std::clone::Clone>::clone(&self.allow_alias),
-            deprecated: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            deprecated: <self::_pinternal::field_type::OptionalNumericalField::<
                 bool,
-                self::_puroro::internal::tags::Bool,
+                self::_pinternal::tags::Bool,
                 1usize,
             > as ::std::clone::Clone>::clone(&self.deprecated),
-            uninterpreted_option: <self::_puroro::internal::field_type::RepeatedMessageField::<
-                self::_puroro_root::google::protobuf::UninterpretedOption,
+            uninterpreted_option: <self::_pinternal::field_type::RepeatedMessageField::<
+                self::_root::google::protobuf::UninterpretedOption,
             > as ::std::clone::Clone>::clone(&self.uninterpreted_option),
             _bitfield: ::std::clone::Clone::clone(&self._bitfield),
         }
@@ -7874,7 +7800,7 @@ impl ::std::clone::Clone for EnumOptions {
 impl ::std::ops::Drop for EnumOptions {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for EnumOptions {
@@ -7892,7 +7818,7 @@ impl ::std::fmt::Debug for EnumOptions {
 impl ::std::cmp::PartialEq for EnumOptions {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         true && self.allow_alias_opt() == rhs.allow_alias_opt()
             && self.deprecated_opt() == rhs.deprecated_opt()
             && self.uninterpreted_option() == rhs.uninterpreted_option()
@@ -7900,22 +7826,22 @@ impl ::std::cmp::PartialEq for EnumOptions {
 }
 #[derive(::std::default::Default)]
 pub struct EnumValueOptions {
-    deprecated: self::_puroro::internal::field_type::OptionalNumericalField::<
+    deprecated: self::_pinternal::field_type::OptionalNumericalField::<
         bool,
-        self::_puroro::internal::tags::Bool,
+        self::_pinternal::tags::Bool,
         0usize,
     >,
-    uninterpreted_option: self::_puroro::internal::field_type::RepeatedMessageField::<
-        self::_puroro_root::google::protobuf::UninterpretedOption,
+    uninterpreted_option: self::_pinternal::field_type::RepeatedMessageField::<
+        self::_root::google::protobuf::UninterpretedOption,
     >,
-    _bitfield: self::_puroro::internal::bitvec::BitArray<1usize>,
+    _bitfield: self::_pinternal::bitvec::BitArray<1usize>,
 }
 impl EnumValueOptions {
     pub fn deprecated(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             0usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.deprecated,
@@ -7924,18 +7850,18 @@ impl EnumValueOptions {
         )
     }
     pub fn deprecated_opt(&self) -> ::std::option::Option::<bool> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.deprecated, &self._bitfield)
     }
     pub fn deprecated_mut(&mut self) -> &mut bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             0usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.deprecated,
@@ -7944,47 +7870,45 @@ impl EnumValueOptions {
         )
     }
     pub fn has_deprecated(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.deprecated, &self._bitfield)
             .is_some()
     }
     pub fn clear_deprecated(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             0usize,
         > as NonRepeatedFieldType>::clear(&mut self.deprecated, &mut self._bitfield)
     }
     pub fn uninterpreted_option(
         &self,
-    ) -> &[self::_puroro_root::google::protobuf::UninterpretedOption] {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::UninterpretedOption,
+    ) -> &[self::_root::google::protobuf::UninterpretedOption] {
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::UninterpretedOption,
         > as RepeatedFieldType>::get_field(&self.uninterpreted_option, &self._bitfield)
     }
     pub fn uninterpreted_option_mut(
         &mut self,
-    ) -> &mut ::std::vec::Vec::<
-        self::_puroro_root::google::protobuf::UninterpretedOption,
-    > {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::UninterpretedOption,
+    ) -> &mut ::std::vec::Vec::<self::_root::google::protobuf::UninterpretedOption> {
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::UninterpretedOption,
         > as RepeatedFieldType>::get_field_mut(
             &mut self.uninterpreted_option,
             &mut self._bitfield,
         )
     }
     pub fn clear_uninterpreted_option(&mut self) {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::UninterpretedOption,
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::UninterpretedOption,
         > as RepeatedFieldType>::clear(
             &mut self.uninterpreted_option,
             &mut self._bitfield,
@@ -8003,27 +7927,27 @@ impl self::_puroro::Message for EnumValueOptions {
         &mut self,
         mut iter: I,
     ) -> self::_puroro::Result<()> {
-        use self::_puroro::internal::ser::FieldData;
+        use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 1i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         bool,
-                        self::_puroro::internal::tags::Bool,
+                        self::_pinternal::tags::Bool,
                         0usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.deprecated,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 999i32 => {
-                    <self::_puroro::internal::field_type::RepeatedMessageField::<
-                        self::_puroro_root::google::protobuf::UninterpretedOption,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    <self::_pinternal::field_type::RepeatedMessageField::<
+                        self::_root::google::protobuf::UninterpretedOption,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.uninterpreted_option,
                         &mut self._bitfield,
                         field_data,
@@ -8040,20 +7964,20 @@ impl self::_puroro::Message for EnumValueOptions {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::oneof_type::OneofUnion as _;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             0usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.deprecated,
             &self._bitfield,
             1i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::UninterpretedOption,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::UninterpretedOption,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.uninterpreted_option,
             &self._bitfield,
             999i32,
@@ -8065,13 +7989,13 @@ impl self::_puroro::Message for EnumValueOptions {
 impl ::std::clone::Clone for EnumValueOptions {
     fn clone(&self) -> Self {
         Self {
-            deprecated: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            deprecated: <self::_pinternal::field_type::OptionalNumericalField::<
                 bool,
-                self::_puroro::internal::tags::Bool,
+                self::_pinternal::tags::Bool,
                 0usize,
             > as ::std::clone::Clone>::clone(&self.deprecated),
-            uninterpreted_option: <self::_puroro::internal::field_type::RepeatedMessageField::<
-                self::_puroro_root::google::protobuf::UninterpretedOption,
+            uninterpreted_option: <self::_pinternal::field_type::RepeatedMessageField::<
+                self::_root::google::protobuf::UninterpretedOption,
             > as ::std::clone::Clone>::clone(&self.uninterpreted_option),
             _bitfield: ::std::clone::Clone::clone(&self._bitfield),
         }
@@ -8080,7 +8004,7 @@ impl ::std::clone::Clone for EnumValueOptions {
 impl ::std::ops::Drop for EnumValueOptions {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for EnumValueOptions {
@@ -8097,29 +8021,29 @@ impl ::std::fmt::Debug for EnumValueOptions {
 impl ::std::cmp::PartialEq for EnumValueOptions {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         true && self.deprecated_opt() == rhs.deprecated_opt()
             && self.uninterpreted_option() == rhs.uninterpreted_option()
     }
 }
 #[derive(::std::default::Default)]
 pub struct ServiceOptions {
-    deprecated: self::_puroro::internal::field_type::OptionalNumericalField::<
+    deprecated: self::_pinternal::field_type::OptionalNumericalField::<
         bool,
-        self::_puroro::internal::tags::Bool,
+        self::_pinternal::tags::Bool,
         0usize,
     >,
-    uninterpreted_option: self::_puroro::internal::field_type::RepeatedMessageField::<
-        self::_puroro_root::google::protobuf::UninterpretedOption,
+    uninterpreted_option: self::_pinternal::field_type::RepeatedMessageField::<
+        self::_root::google::protobuf::UninterpretedOption,
     >,
-    _bitfield: self::_puroro::internal::bitvec::BitArray<1usize>,
+    _bitfield: self::_pinternal::bitvec::BitArray<1usize>,
 }
 impl ServiceOptions {
     pub fn deprecated(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             0usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.deprecated,
@@ -8128,18 +8052,18 @@ impl ServiceOptions {
         )
     }
     pub fn deprecated_opt(&self) -> ::std::option::Option::<bool> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.deprecated, &self._bitfield)
     }
     pub fn deprecated_mut(&mut self) -> &mut bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             0usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.deprecated,
@@ -8148,47 +8072,45 @@ impl ServiceOptions {
         )
     }
     pub fn has_deprecated(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.deprecated, &self._bitfield)
             .is_some()
     }
     pub fn clear_deprecated(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             0usize,
         > as NonRepeatedFieldType>::clear(&mut self.deprecated, &mut self._bitfield)
     }
     pub fn uninterpreted_option(
         &self,
-    ) -> &[self::_puroro_root::google::protobuf::UninterpretedOption] {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::UninterpretedOption,
+    ) -> &[self::_root::google::protobuf::UninterpretedOption] {
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::UninterpretedOption,
         > as RepeatedFieldType>::get_field(&self.uninterpreted_option, &self._bitfield)
     }
     pub fn uninterpreted_option_mut(
         &mut self,
-    ) -> &mut ::std::vec::Vec::<
-        self::_puroro_root::google::protobuf::UninterpretedOption,
-    > {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::UninterpretedOption,
+    ) -> &mut ::std::vec::Vec::<self::_root::google::protobuf::UninterpretedOption> {
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::UninterpretedOption,
         > as RepeatedFieldType>::get_field_mut(
             &mut self.uninterpreted_option,
             &mut self._bitfield,
         )
     }
     pub fn clear_uninterpreted_option(&mut self) {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::UninterpretedOption,
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::UninterpretedOption,
         > as RepeatedFieldType>::clear(
             &mut self.uninterpreted_option,
             &mut self._bitfield,
@@ -8207,27 +8129,27 @@ impl self::_puroro::Message for ServiceOptions {
         &mut self,
         mut iter: I,
     ) -> self::_puroro::Result<()> {
-        use self::_puroro::internal::ser::FieldData;
+        use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 33i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         bool,
-                        self::_puroro::internal::tags::Bool,
+                        self::_pinternal::tags::Bool,
                         0usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.deprecated,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 999i32 => {
-                    <self::_puroro::internal::field_type::RepeatedMessageField::<
-                        self::_puroro_root::google::protobuf::UninterpretedOption,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    <self::_pinternal::field_type::RepeatedMessageField::<
+                        self::_root::google::protobuf::UninterpretedOption,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.uninterpreted_option,
                         &mut self._bitfield,
                         field_data,
@@ -8244,20 +8166,20 @@ impl self::_puroro::Message for ServiceOptions {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::oneof_type::OneofUnion as _;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             0usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.deprecated,
             &self._bitfield,
             33i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::UninterpretedOption,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::UninterpretedOption,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.uninterpreted_option,
             &self._bitfield,
             999i32,
@@ -8269,13 +8191,13 @@ impl self::_puroro::Message for ServiceOptions {
 impl ::std::clone::Clone for ServiceOptions {
     fn clone(&self) -> Self {
         Self {
-            deprecated: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            deprecated: <self::_pinternal::field_type::OptionalNumericalField::<
                 bool,
-                self::_puroro::internal::tags::Bool,
+                self::_pinternal::tags::Bool,
                 0usize,
             > as ::std::clone::Clone>::clone(&self.deprecated),
-            uninterpreted_option: <self::_puroro::internal::field_type::RepeatedMessageField::<
-                self::_puroro_root::google::protobuf::UninterpretedOption,
+            uninterpreted_option: <self::_pinternal::field_type::RepeatedMessageField::<
+                self::_root::google::protobuf::UninterpretedOption,
             > as ::std::clone::Clone>::clone(&self.uninterpreted_option),
             _bitfield: ::std::clone::Clone::clone(&self._bitfield),
         }
@@ -8284,7 +8206,7 @@ impl ::std::clone::Clone for ServiceOptions {
 impl ::std::ops::Drop for ServiceOptions {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for ServiceOptions {
@@ -8301,36 +8223,36 @@ impl ::std::fmt::Debug for ServiceOptions {
 impl ::std::cmp::PartialEq for ServiceOptions {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         true && self.deprecated_opt() == rhs.deprecated_opt()
             && self.uninterpreted_option() == rhs.uninterpreted_option()
     }
 }
 #[derive(::std::default::Default)]
 pub struct MethodOptions {
-    deprecated: self::_puroro::internal::field_type::OptionalNumericalField::<
+    deprecated: self::_pinternal::field_type::OptionalNumericalField::<
         bool,
-        self::_puroro::internal::tags::Bool,
+        self::_pinternal::tags::Bool,
         0usize,
     >,
-    idempotency_level: self::_puroro::internal::field_type::OptionalNumericalField::<
-        self::_puroro_root::google::protobuf::method_options::IdempotencyLevel,
-        self::_puroro::internal::tags::Enum2::<
-            self::_puroro_root::google::protobuf::method_options::IdempotencyLevel,
+    idempotency_level: self::_pinternal::field_type::OptionalNumericalField::<
+        self::_root::google::protobuf::method_options::IdempotencyLevel,
+        self::_pinternal::tags::Enum2::<
+            self::_root::google::protobuf::method_options::IdempotencyLevel,
         >,
         1usize,
     >,
-    uninterpreted_option: self::_puroro::internal::field_type::RepeatedMessageField::<
-        self::_puroro_root::google::protobuf::UninterpretedOption,
+    uninterpreted_option: self::_pinternal::field_type::RepeatedMessageField::<
+        self::_root::google::protobuf::UninterpretedOption,
     >,
-    _bitfield: self::_puroro::internal::bitvec::BitArray<1usize>,
+    _bitfield: self::_pinternal::bitvec::BitArray<1usize>,
 }
 impl MethodOptions {
     pub fn deprecated(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             0usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.deprecated,
@@ -8339,18 +8261,18 @@ impl MethodOptions {
         )
     }
     pub fn deprecated_opt(&self) -> ::std::option::Option::<bool> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.deprecated, &self._bitfield)
     }
     pub fn deprecated_mut(&mut self) -> &mut bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             0usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.deprecated,
@@ -8359,50 +8281,50 @@ impl MethodOptions {
         )
     }
     pub fn has_deprecated(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.deprecated, &self._bitfield)
             .is_some()
     }
     pub fn clear_deprecated(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             0usize,
         > as NonRepeatedFieldType>::clear(&mut self.deprecated, &mut self._bitfield)
     }
     pub fn idempotency_level(
         &self,
-    ) -> self::_puroro_root::google::protobuf::method_options::IdempotencyLevel {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
-            self::_puroro_root::google::protobuf::method_options::IdempotencyLevel,
-            self::_puroro::internal::tags::Enum2::<
-                self::_puroro_root::google::protobuf::method_options::IdempotencyLevel,
+    ) -> self::_root::google::protobuf::method_options::IdempotencyLevel {
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
+            self::_root::google::protobuf::method_options::IdempotencyLevel,
+            self::_pinternal::tags::Enum2::<
+                self::_root::google::protobuf::method_options::IdempotencyLevel,
             >,
             1usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.idempotency_level,
             &self._bitfield,
             || {
-                self::_puroro_root::google::protobuf::method_options::IdempotencyLevel::IdempotencyUnknown
+                self::_root::google::protobuf::method_options::IdempotencyLevel::IdempotencyUnknown
             },
         )
     }
     pub fn idempotency_level_opt(
         &self,
     ) -> ::std::option::Option::<
-        self::_puroro_root::google::protobuf::method_options::IdempotencyLevel,
+        self::_root::google::protobuf::method_options::IdempotencyLevel,
     > {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
-            self::_puroro_root::google::protobuf::method_options::IdempotencyLevel,
-            self::_puroro::internal::tags::Enum2::<
-                self::_puroro_root::google::protobuf::method_options::IdempotencyLevel,
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
+            self::_root::google::protobuf::method_options::IdempotencyLevel,
+            self::_pinternal::tags::Enum2::<
+                self::_root::google::protobuf::method_options::IdempotencyLevel,
             >,
             1usize,
         > as NonRepeatedFieldType>::get_field_opt(
@@ -8412,28 +8334,28 @@ impl MethodOptions {
     }
     pub fn idempotency_level_mut(
         &mut self,
-    ) -> &mut self::_puroro_root::google::protobuf::method_options::IdempotencyLevel {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
-            self::_puroro_root::google::protobuf::method_options::IdempotencyLevel,
-            self::_puroro::internal::tags::Enum2::<
-                self::_puroro_root::google::protobuf::method_options::IdempotencyLevel,
+    ) -> &mut self::_root::google::protobuf::method_options::IdempotencyLevel {
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
+            self::_root::google::protobuf::method_options::IdempotencyLevel,
+            self::_pinternal::tags::Enum2::<
+                self::_root::google::protobuf::method_options::IdempotencyLevel,
             >,
             1usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.idempotency_level,
             &mut self._bitfield,
             || {
-                self::_puroro_root::google::protobuf::method_options::IdempotencyLevel::IdempotencyUnknown
+                self::_root::google::protobuf::method_options::IdempotencyLevel::IdempotencyUnknown
             },
         )
     }
     pub fn has_idempotency_level(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
-            self::_puroro_root::google::protobuf::method_options::IdempotencyLevel,
-            self::_puroro::internal::tags::Enum2::<
-                self::_puroro_root::google::protobuf::method_options::IdempotencyLevel,
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
+            self::_root::google::protobuf::method_options::IdempotencyLevel,
+            self::_pinternal::tags::Enum2::<
+                self::_root::google::protobuf::method_options::IdempotencyLevel,
             >,
             1usize,
         > as NonRepeatedFieldType>::get_field_opt(
@@ -8443,11 +8365,11 @@ impl MethodOptions {
             .is_some()
     }
     pub fn clear_idempotency_level(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
-            self::_puroro_root::google::protobuf::method_options::IdempotencyLevel,
-            self::_puroro::internal::tags::Enum2::<
-                self::_puroro_root::google::protobuf::method_options::IdempotencyLevel,
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
+            self::_root::google::protobuf::method_options::IdempotencyLevel,
+            self::_pinternal::tags::Enum2::<
+                self::_root::google::protobuf::method_options::IdempotencyLevel,
             >,
             1usize,
         > as NonRepeatedFieldType>::clear(
@@ -8457,29 +8379,27 @@ impl MethodOptions {
     }
     pub fn uninterpreted_option(
         &self,
-    ) -> &[self::_puroro_root::google::protobuf::UninterpretedOption] {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::UninterpretedOption,
+    ) -> &[self::_root::google::protobuf::UninterpretedOption] {
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::UninterpretedOption,
         > as RepeatedFieldType>::get_field(&self.uninterpreted_option, &self._bitfield)
     }
     pub fn uninterpreted_option_mut(
         &mut self,
-    ) -> &mut ::std::vec::Vec::<
-        self::_puroro_root::google::protobuf::UninterpretedOption,
-    > {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::UninterpretedOption,
+    ) -> &mut ::std::vec::Vec::<self::_root::google::protobuf::UninterpretedOption> {
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::UninterpretedOption,
         > as RepeatedFieldType>::get_field_mut(
             &mut self.uninterpreted_option,
             &mut self._bitfield,
         )
     }
     pub fn clear_uninterpreted_option(&mut self) {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::UninterpretedOption,
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::UninterpretedOption,
         > as RepeatedFieldType>::clear(
             &mut self.uninterpreted_option,
             &mut self._bitfield,
@@ -8498,40 +8418,40 @@ impl self::_puroro::Message for MethodOptions {
         &mut self,
         mut iter: I,
     ) -> self::_puroro::Result<()> {
-        use self::_puroro::internal::ser::FieldData;
+        use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 33i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         bool,
-                        self::_puroro::internal::tags::Bool,
+                        self::_pinternal::tags::Bool,
                         0usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.deprecated,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 34i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
-                        self::_puroro_root::google::protobuf::method_options::IdempotencyLevel,
-                        self::_puroro::internal::tags::Enum2::<
-                            self::_puroro_root::google::protobuf::method_options::IdempotencyLevel,
+                    <self::_pinternal::field_type::OptionalNumericalField::<
+                        self::_root::google::protobuf::method_options::IdempotencyLevel,
+                        self::_pinternal::tags::Enum2::<
+                            self::_root::google::protobuf::method_options::IdempotencyLevel,
                         >,
                         1usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.idempotency_level,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 999i32 => {
-                    <self::_puroro::internal::field_type::RepeatedMessageField::<
-                        self::_puroro_root::google::protobuf::UninterpretedOption,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    <self::_pinternal::field_type::RepeatedMessageField::<
+                        self::_root::google::protobuf::UninterpretedOption,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.uninterpreted_option,
                         &mut self._bitfield,
                         field_data,
@@ -8548,32 +8468,32 @@ impl self::_puroro::Message for MethodOptions {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::oneof_type::OneofUnion as _;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             0usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.deprecated,
             &self._bitfield,
             33i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
-            self::_puroro_root::google::protobuf::method_options::IdempotencyLevel,
-            self::_puroro::internal::tags::Enum2::<
-                self::_puroro_root::google::protobuf::method_options::IdempotencyLevel,
+        <self::_pinternal::field_type::OptionalNumericalField::<
+            self::_root::google::protobuf::method_options::IdempotencyLevel,
+            self::_pinternal::tags::Enum2::<
+                self::_root::google::protobuf::method_options::IdempotencyLevel,
             >,
             1usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.idempotency_level,
             &self._bitfield,
             34i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::UninterpretedOption,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::UninterpretedOption,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.uninterpreted_option,
             &self._bitfield,
             999i32,
@@ -8585,20 +8505,20 @@ impl self::_puroro::Message for MethodOptions {
 impl ::std::clone::Clone for MethodOptions {
     fn clone(&self) -> Self {
         Self {
-            deprecated: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            deprecated: <self::_pinternal::field_type::OptionalNumericalField::<
                 bool,
-                self::_puroro::internal::tags::Bool,
+                self::_pinternal::tags::Bool,
                 0usize,
             > as ::std::clone::Clone>::clone(&self.deprecated),
-            idempotency_level: <self::_puroro::internal::field_type::OptionalNumericalField::<
-                self::_puroro_root::google::protobuf::method_options::IdempotencyLevel,
-                self::_puroro::internal::tags::Enum2::<
-                    self::_puroro_root::google::protobuf::method_options::IdempotencyLevel,
+            idempotency_level: <self::_pinternal::field_type::OptionalNumericalField::<
+                self::_root::google::protobuf::method_options::IdempotencyLevel,
+                self::_pinternal::tags::Enum2::<
+                    self::_root::google::protobuf::method_options::IdempotencyLevel,
                 >,
                 1usize,
             > as ::std::clone::Clone>::clone(&self.idempotency_level),
-            uninterpreted_option: <self::_puroro::internal::field_type::RepeatedMessageField::<
-                self::_puroro_root::google::protobuf::UninterpretedOption,
+            uninterpreted_option: <self::_pinternal::field_type::RepeatedMessageField::<
+                self::_root::google::protobuf::UninterpretedOption,
             > as ::std::clone::Clone>::clone(&self.uninterpreted_option),
             _bitfield: ::std::clone::Clone::clone(&self._bitfield),
         }
@@ -8607,7 +8527,7 @@ impl ::std::clone::Clone for MethodOptions {
 impl ::std::ops::Drop for MethodOptions {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for MethodOptions {
@@ -8625,7 +8545,7 @@ impl ::std::fmt::Debug for MethodOptions {
 impl ::std::cmp::PartialEq for MethodOptions {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         true && self.deprecated_opt() == rhs.deprecated_opt()
             && self.idempotency_level_opt() == rhs.idempotency_level_opt()
             && self.uninterpreted_option() == rhs.uninterpreted_option()
@@ -8633,71 +8553,71 @@ impl ::std::cmp::PartialEq for MethodOptions {
 }
 #[derive(::std::default::Default)]
 pub struct UninterpretedOption {
-    name: self::_puroro::internal::field_type::RepeatedMessageField::<
-        self::_puroro_root::google::protobuf::uninterpreted_option::NamePart,
+    name: self::_pinternal::field_type::RepeatedMessageField::<
+        self::_root::google::protobuf::uninterpreted_option::NamePart,
     >,
-    identifier_value: self::_puroro::internal::field_type::OptionalUnsizedField::<
+    identifier_value: self::_pinternal::field_type::OptionalUnsizedField::<
         ::std::string::String,
-        self::_puroro::internal::tags::String,
+        self::_pinternal::tags::String,
         0usize,
     >,
-    positive_int_value: self::_puroro::internal::field_type::OptionalNumericalField::<
+    positive_int_value: self::_pinternal::field_type::OptionalNumericalField::<
         u64,
-        self::_puroro::internal::tags::UInt64,
+        self::_pinternal::tags::UInt64,
         1usize,
     >,
-    negative_int_value: self::_puroro::internal::field_type::OptionalNumericalField::<
+    negative_int_value: self::_pinternal::field_type::OptionalNumericalField::<
         i64,
-        self::_puroro::internal::tags::Int64,
+        self::_pinternal::tags::Int64,
         2usize,
     >,
-    double_value: self::_puroro::internal::field_type::OptionalNumericalField::<
+    double_value: self::_pinternal::field_type::OptionalNumericalField::<
         f64,
-        self::_puroro::internal::tags::Double,
+        self::_pinternal::tags::Double,
         3usize,
     >,
-    string_value: self::_puroro::internal::field_type::OptionalUnsizedField::<
+    string_value: self::_pinternal::field_type::OptionalUnsizedField::<
         ::std::vec::Vec<u8>,
-        self::_puroro::internal::tags::Bytes,
+        self::_pinternal::tags::Bytes,
         4usize,
     >,
-    aggregate_value: self::_puroro::internal::field_type::OptionalUnsizedField::<
+    aggregate_value: self::_pinternal::field_type::OptionalUnsizedField::<
         ::std::string::String,
-        self::_puroro::internal::tags::String,
+        self::_pinternal::tags::String,
         5usize,
     >,
-    _bitfield: self::_puroro::internal::bitvec::BitArray<1usize>,
+    _bitfield: self::_pinternal::bitvec::BitArray<1usize>,
 }
 impl UninterpretedOption {
     pub fn name(
         &self,
-    ) -> &[self::_puroro_root::google::protobuf::uninterpreted_option::NamePart] {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::uninterpreted_option::NamePart,
+    ) -> &[self::_root::google::protobuf::uninterpreted_option::NamePart] {
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::uninterpreted_option::NamePart,
         > as RepeatedFieldType>::get_field(&self.name, &self._bitfield)
     }
     pub fn name_mut(
         &mut self,
     ) -> &mut ::std::vec::Vec::<
-        self::_puroro_root::google::protobuf::uninterpreted_option::NamePart,
+        self::_root::google::protobuf::uninterpreted_option::NamePart,
     > {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::uninterpreted_option::NamePart,
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::uninterpreted_option::NamePart,
         > as RepeatedFieldType>::get_field_mut(&mut self.name, &mut self._bitfield)
     }
     pub fn clear_name(&mut self) {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::uninterpreted_option::NamePart,
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::uninterpreted_option::NamePart,
         > as RepeatedFieldType>::clear(&mut self.name, &mut self._bitfield)
     }
     pub fn identifier_value(&self) -> &str {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.identifier_value,
@@ -8706,10 +8626,10 @@ impl UninterpretedOption {
         )
     }
     pub fn identifier_value_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(
             &self.identifier_value,
@@ -8717,10 +8637,10 @@ impl UninterpretedOption {
         )
     }
     pub fn identifier_value_mut(&mut self) -> &mut ::std::string::String {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.identifier_value,
@@ -8729,10 +8649,10 @@ impl UninterpretedOption {
         )
     }
     pub fn has_identifier_value(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(
                 &self.identifier_value,
@@ -8741,10 +8661,10 @@ impl UninterpretedOption {
             .is_some()
     }
     pub fn clear_identifier_value(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::clear(
             &mut self.identifier_value,
@@ -8752,10 +8672,10 @@ impl UninterpretedOption {
         )
     }
     pub fn positive_int_value(&self) -> u64 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u64,
-            self::_puroro::internal::tags::UInt64,
+            self::_pinternal::tags::UInt64,
             1usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.positive_int_value,
@@ -8764,10 +8684,10 @@ impl UninterpretedOption {
         )
     }
     pub fn positive_int_value_opt(&self) -> ::std::option::Option::<u64> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u64,
-            self::_puroro::internal::tags::UInt64,
+            self::_pinternal::tags::UInt64,
             1usize,
         > as NonRepeatedFieldType>::get_field_opt(
             &self.positive_int_value,
@@ -8775,10 +8695,10 @@ impl UninterpretedOption {
         )
     }
     pub fn positive_int_value_mut(&mut self) -> &mut u64 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u64,
-            self::_puroro::internal::tags::UInt64,
+            self::_pinternal::tags::UInt64,
             1usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.positive_int_value,
@@ -8787,10 +8707,10 @@ impl UninterpretedOption {
         )
     }
     pub fn has_positive_int_value(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u64,
-            self::_puroro::internal::tags::UInt64,
+            self::_pinternal::tags::UInt64,
             1usize,
         > as NonRepeatedFieldType>::get_field_opt(
                 &self.positive_int_value,
@@ -8799,10 +8719,10 @@ impl UninterpretedOption {
             .is_some()
     }
     pub fn clear_positive_int_value(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u64,
-            self::_puroro::internal::tags::UInt64,
+            self::_pinternal::tags::UInt64,
             1usize,
         > as NonRepeatedFieldType>::clear(
             &mut self.positive_int_value,
@@ -8810,10 +8730,10 @@ impl UninterpretedOption {
         )
     }
     pub fn negative_int_value(&self) -> i64 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i64,
-            self::_puroro::internal::tags::Int64,
+            self::_pinternal::tags::Int64,
             2usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.negative_int_value,
@@ -8822,10 +8742,10 @@ impl UninterpretedOption {
         )
     }
     pub fn negative_int_value_opt(&self) -> ::std::option::Option::<i64> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i64,
-            self::_puroro::internal::tags::Int64,
+            self::_pinternal::tags::Int64,
             2usize,
         > as NonRepeatedFieldType>::get_field_opt(
             &self.negative_int_value,
@@ -8833,10 +8753,10 @@ impl UninterpretedOption {
         )
     }
     pub fn negative_int_value_mut(&mut self) -> &mut i64 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i64,
-            self::_puroro::internal::tags::Int64,
+            self::_pinternal::tags::Int64,
             2usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.negative_int_value,
@@ -8845,10 +8765,10 @@ impl UninterpretedOption {
         )
     }
     pub fn has_negative_int_value(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i64,
-            self::_puroro::internal::tags::Int64,
+            self::_pinternal::tags::Int64,
             2usize,
         > as NonRepeatedFieldType>::get_field_opt(
                 &self.negative_int_value,
@@ -8857,10 +8777,10 @@ impl UninterpretedOption {
             .is_some()
     }
     pub fn clear_negative_int_value(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i64,
-            self::_puroro::internal::tags::Int64,
+            self::_pinternal::tags::Int64,
             2usize,
         > as NonRepeatedFieldType>::clear(
             &mut self.negative_int_value,
@@ -8868,10 +8788,10 @@ impl UninterpretedOption {
         )
     }
     pub fn double_value(&self) -> f64 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             f64,
-            self::_puroro::internal::tags::Double,
+            self::_pinternal::tags::Double,
             3usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.double_value,
@@ -8880,18 +8800,18 @@ impl UninterpretedOption {
         )
     }
     pub fn double_value_opt(&self) -> ::std::option::Option::<f64> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             f64,
-            self::_puroro::internal::tags::Double,
+            self::_pinternal::tags::Double,
             3usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.double_value, &self._bitfield)
     }
     pub fn double_value_mut(&mut self) -> &mut f64 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             f64,
-            self::_puroro::internal::tags::Double,
+            self::_pinternal::tags::Double,
             3usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.double_value,
@@ -8900,27 +8820,27 @@ impl UninterpretedOption {
         )
     }
     pub fn has_double_value(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             f64,
-            self::_puroro::internal::tags::Double,
+            self::_pinternal::tags::Double,
             3usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.double_value, &self._bitfield)
             .is_some()
     }
     pub fn clear_double_value(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             f64,
-            self::_puroro::internal::tags::Double,
+            self::_pinternal::tags::Double,
             3usize,
         > as NonRepeatedFieldType>::clear(&mut self.double_value, &mut self._bitfield)
     }
     pub fn string_value(&self) -> &[u8] {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::vec::Vec<u8>,
-            self::_puroro::internal::tags::Bytes,
+            self::_pinternal::tags::Bytes,
             4usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.string_value,
@@ -8929,18 +8849,18 @@ impl UninterpretedOption {
         )
     }
     pub fn string_value_opt(&self) -> ::std::option::Option::<&[u8]> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::vec::Vec<u8>,
-            self::_puroro::internal::tags::Bytes,
+            self::_pinternal::tags::Bytes,
             4usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.string_value, &self._bitfield)
     }
     pub fn string_value_mut(&mut self) -> &mut ::std::vec::Vec::<u8> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::vec::Vec<u8>,
-            self::_puroro::internal::tags::Bytes,
+            self::_pinternal::tags::Bytes,
             4usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.string_value,
@@ -8949,27 +8869,27 @@ impl UninterpretedOption {
         )
     }
     pub fn has_string_value(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::vec::Vec<u8>,
-            self::_puroro::internal::tags::Bytes,
+            self::_pinternal::tags::Bytes,
             4usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.string_value, &self._bitfield)
             .is_some()
     }
     pub fn clear_string_value(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::vec::Vec<u8>,
-            self::_puroro::internal::tags::Bytes,
+            self::_pinternal::tags::Bytes,
             4usize,
         > as NonRepeatedFieldType>::clear(&mut self.string_value, &mut self._bitfield)
     }
     pub fn aggregate_value(&self) -> &str {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             5usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.aggregate_value,
@@ -8978,18 +8898,18 @@ impl UninterpretedOption {
         )
     }
     pub fn aggregate_value_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             5usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.aggregate_value, &self._bitfield)
     }
     pub fn aggregate_value_mut(&mut self) -> &mut ::std::string::String {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             5usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.aggregate_value,
@@ -8998,19 +8918,19 @@ impl UninterpretedOption {
         )
     }
     pub fn has_aggregate_value(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             5usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.aggregate_value, &self._bitfield)
             .is_some()
     }
     pub fn clear_aggregate_value(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             5usize,
         > as NonRepeatedFieldType>::clear(&mut self.aggregate_value, &mut self._bitfield)
     }
@@ -9027,82 +8947,82 @@ impl self::_puroro::Message for UninterpretedOption {
         &mut self,
         mut iter: I,
     ) -> self::_puroro::Result<()> {
-        use self::_puroro::internal::ser::FieldData;
+        use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 2i32 => {
-                    <self::_puroro::internal::field_type::RepeatedMessageField::<
-                        self::_puroro_root::google::protobuf::uninterpreted_option::NamePart,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    <self::_pinternal::field_type::RepeatedMessageField::<
+                        self::_root::google::protobuf::uninterpreted_option::NamePart,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.name,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 3i32 => {
-                    <self::_puroro::internal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::field_type::OptionalUnsizedField::<
                         ::std::string::String,
-                        self::_puroro::internal::tags::String,
+                        self::_pinternal::tags::String,
                         0usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.identifier_value,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 4i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         u64,
-                        self::_puroro::internal::tags::UInt64,
+                        self::_pinternal::tags::UInt64,
                         1usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.positive_int_value,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 5i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         i64,
-                        self::_puroro::internal::tags::Int64,
+                        self::_pinternal::tags::Int64,
                         2usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.negative_int_value,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 6i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         f64,
-                        self::_puroro::internal::tags::Double,
+                        self::_pinternal::tags::Double,
                         3usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.double_value,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 7i32 => {
-                    <self::_puroro::internal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::field_type::OptionalUnsizedField::<
                         ::std::vec::Vec<u8>,
-                        self::_puroro::internal::tags::Bytes,
+                        self::_pinternal::tags::Bytes,
                         4usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.string_value,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 8i32 => {
-                    <self::_puroro::internal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::field_type::OptionalUnsizedField::<
                         ::std::string::String,
-                        self::_puroro::internal::tags::String,
+                        self::_pinternal::tags::String,
                         5usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.aggregate_value,
                         &mut self._bitfield,
                         field_data,
@@ -9119,70 +9039,70 @@ impl self::_puroro::Message for UninterpretedOption {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::uninterpreted_option::NamePart,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        use self::_pinternal::oneof_type::OneofUnion as _;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::uninterpreted_option::NamePart,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.name,
             &self._bitfield,
             2i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.identifier_value,
             &self._bitfield,
             3i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u64,
-            self::_puroro::internal::tags::UInt64,
+            self::_pinternal::tags::UInt64,
             1usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.positive_int_value,
             &self._bitfield,
             4i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i64,
-            self::_puroro::internal::tags::Int64,
+            self::_pinternal::tags::Int64,
             2usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.negative_int_value,
             &self._bitfield,
             5i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        <self::_pinternal::field_type::OptionalNumericalField::<
             f64,
-            self::_puroro::internal::tags::Double,
+            self::_pinternal::tags::Double,
             3usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.double_value,
             &self._bitfield,
             6i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::vec::Vec<u8>,
-            self::_puroro::internal::tags::Bytes,
+            self::_pinternal::tags::Bytes,
             4usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.string_value,
             &self._bitfield,
             7i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             5usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.aggregate_value,
             &self._bitfield,
             8i32,
@@ -9194,37 +9114,37 @@ impl self::_puroro::Message for UninterpretedOption {
 impl ::std::clone::Clone for UninterpretedOption {
     fn clone(&self) -> Self {
         Self {
-            name: <self::_puroro::internal::field_type::RepeatedMessageField::<
-                self::_puroro_root::google::protobuf::uninterpreted_option::NamePart,
+            name: <self::_pinternal::field_type::RepeatedMessageField::<
+                self::_root::google::protobuf::uninterpreted_option::NamePart,
             > as ::std::clone::Clone>::clone(&self.name),
-            identifier_value: <self::_puroro::internal::field_type::OptionalUnsizedField::<
+            identifier_value: <self::_pinternal::field_type::OptionalUnsizedField::<
                 ::std::string::String,
-                self::_puroro::internal::tags::String,
+                self::_pinternal::tags::String,
                 0usize,
             > as ::std::clone::Clone>::clone(&self.identifier_value),
-            positive_int_value: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            positive_int_value: <self::_pinternal::field_type::OptionalNumericalField::<
                 u64,
-                self::_puroro::internal::tags::UInt64,
+                self::_pinternal::tags::UInt64,
                 1usize,
             > as ::std::clone::Clone>::clone(&self.positive_int_value),
-            negative_int_value: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            negative_int_value: <self::_pinternal::field_type::OptionalNumericalField::<
                 i64,
-                self::_puroro::internal::tags::Int64,
+                self::_pinternal::tags::Int64,
                 2usize,
             > as ::std::clone::Clone>::clone(&self.negative_int_value),
-            double_value: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            double_value: <self::_pinternal::field_type::OptionalNumericalField::<
                 f64,
-                self::_puroro::internal::tags::Double,
+                self::_pinternal::tags::Double,
                 3usize,
             > as ::std::clone::Clone>::clone(&self.double_value),
-            string_value: <self::_puroro::internal::field_type::OptionalUnsizedField::<
+            string_value: <self::_pinternal::field_type::OptionalUnsizedField::<
                 ::std::vec::Vec<u8>,
-                self::_puroro::internal::tags::Bytes,
+                self::_pinternal::tags::Bytes,
                 4usize,
             > as ::std::clone::Clone>::clone(&self.string_value),
-            aggregate_value: <self::_puroro::internal::field_type::OptionalUnsizedField::<
+            aggregate_value: <self::_pinternal::field_type::OptionalUnsizedField::<
                 ::std::string::String,
-                self::_puroro::internal::tags::String,
+                self::_pinternal::tags::String,
                 5usize,
             > as ::std::clone::Clone>::clone(&self.aggregate_value),
             _bitfield: ::std::clone::Clone::clone(&self._bitfield),
@@ -9234,7 +9154,7 @@ impl ::std::clone::Clone for UninterpretedOption {
 impl ::std::ops::Drop for UninterpretedOption {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for UninterpretedOption {
@@ -9256,7 +9176,7 @@ impl ::std::fmt::Debug for UninterpretedOption {
 impl ::std::cmp::PartialEq for UninterpretedOption {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         true && self.name() == rhs.name()
             && self.identifier_value_opt() == rhs.identifier_value_opt()
             && self.positive_int_value_opt() == rhs.positive_int_value_opt()
@@ -9268,34 +9188,34 @@ impl ::std::cmp::PartialEq for UninterpretedOption {
 }
 #[derive(::std::default::Default)]
 pub struct SourceCodeInfo {
-    location: self::_puroro::internal::field_type::RepeatedMessageField::<
-        self::_puroro_root::google::protobuf::source_code_info::Location,
+    location: self::_pinternal::field_type::RepeatedMessageField::<
+        self::_root::google::protobuf::source_code_info::Location,
     >,
-    _bitfield: self::_puroro::internal::bitvec::BitArray<0usize>,
+    _bitfield: self::_pinternal::bitvec::BitArray<0usize>,
 }
 impl SourceCodeInfo {
     pub fn location(
         &self,
-    ) -> &[self::_puroro_root::google::protobuf::source_code_info::Location] {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::source_code_info::Location,
+    ) -> &[self::_root::google::protobuf::source_code_info::Location] {
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::source_code_info::Location,
         > as RepeatedFieldType>::get_field(&self.location, &self._bitfield)
     }
     pub fn location_mut(
         &mut self,
     ) -> &mut ::std::vec::Vec::<
-        self::_puroro_root::google::protobuf::source_code_info::Location,
+        self::_root::google::protobuf::source_code_info::Location,
     > {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::source_code_info::Location,
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::source_code_info::Location,
         > as RepeatedFieldType>::get_field_mut(&mut self.location, &mut self._bitfield)
     }
     pub fn clear_location(&mut self) {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::source_code_info::Location,
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::source_code_info::Location,
         > as RepeatedFieldType>::clear(&mut self.location, &mut self._bitfield)
     }
 }
@@ -9311,16 +9231,16 @@ impl self::_puroro::Message for SourceCodeInfo {
         &mut self,
         mut iter: I,
     ) -> self::_puroro::Result<()> {
-        use self::_puroro::internal::ser::FieldData;
+        use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 1i32 => {
-                    <self::_puroro::internal::field_type::RepeatedMessageField::<
-                        self::_puroro_root::google::protobuf::source_code_info::Location,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    <self::_pinternal::field_type::RepeatedMessageField::<
+                        self::_root::google::protobuf::source_code_info::Location,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.location,
                         &mut self._bitfield,
                         field_data,
@@ -9337,10 +9257,10 @@ impl self::_puroro::Message for SourceCodeInfo {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::source_code_info::Location,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        use self::_pinternal::oneof_type::OneofUnion as _;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::source_code_info::Location,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.location,
             &self._bitfield,
             1i32,
@@ -9352,8 +9272,8 @@ impl self::_puroro::Message for SourceCodeInfo {
 impl ::std::clone::Clone for SourceCodeInfo {
     fn clone(&self) -> Self {
         Self {
-            location: <self::_puroro::internal::field_type::RepeatedMessageField::<
-                self::_puroro_root::google::protobuf::source_code_info::Location,
+            location: <self::_pinternal::field_type::RepeatedMessageField::<
+                self::_root::google::protobuf::source_code_info::Location,
             > as ::std::clone::Clone>::clone(&self.location),
             _bitfield: ::std::clone::Clone::clone(&self._bitfield),
         }
@@ -9362,7 +9282,7 @@ impl ::std::clone::Clone for SourceCodeInfo {
 impl ::std::ops::Drop for SourceCodeInfo {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for SourceCodeInfo {
@@ -9378,40 +9298,40 @@ impl ::std::fmt::Debug for SourceCodeInfo {
 impl ::std::cmp::PartialEq for SourceCodeInfo {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         true && self.location() == rhs.location()
     }
 }
 #[derive(::std::default::Default)]
 pub struct GeneratedCodeInfo {
-    annotation: self::_puroro::internal::field_type::RepeatedMessageField::<
-        self::_puroro_root::google::protobuf::generated_code_info::Annotation,
+    annotation: self::_pinternal::field_type::RepeatedMessageField::<
+        self::_root::google::protobuf::generated_code_info::Annotation,
     >,
-    _bitfield: self::_puroro::internal::bitvec::BitArray<0usize>,
+    _bitfield: self::_pinternal::bitvec::BitArray<0usize>,
 }
 impl GeneratedCodeInfo {
     pub fn annotation(
         &self,
-    ) -> &[self::_puroro_root::google::protobuf::generated_code_info::Annotation] {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::generated_code_info::Annotation,
+    ) -> &[self::_root::google::protobuf::generated_code_info::Annotation] {
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::generated_code_info::Annotation,
         > as RepeatedFieldType>::get_field(&self.annotation, &self._bitfield)
     }
     pub fn annotation_mut(
         &mut self,
     ) -> &mut ::std::vec::Vec::<
-        self::_puroro_root::google::protobuf::generated_code_info::Annotation,
+        self::_root::google::protobuf::generated_code_info::Annotation,
     > {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::generated_code_info::Annotation,
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::generated_code_info::Annotation,
         > as RepeatedFieldType>::get_field_mut(&mut self.annotation, &mut self._bitfield)
     }
     pub fn clear_annotation(&mut self) {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::generated_code_info::Annotation,
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::generated_code_info::Annotation,
         > as RepeatedFieldType>::clear(&mut self.annotation, &mut self._bitfield)
     }
 }
@@ -9427,16 +9347,16 @@ impl self::_puroro::Message for GeneratedCodeInfo {
         &mut self,
         mut iter: I,
     ) -> self::_puroro::Result<()> {
-        use self::_puroro::internal::ser::FieldData;
+        use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 1i32 => {
-                    <self::_puroro::internal::field_type::RepeatedMessageField::<
-                        self::_puroro_root::google::protobuf::generated_code_info::Annotation,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    <self::_pinternal::field_type::RepeatedMessageField::<
+                        self::_root::google::protobuf::generated_code_info::Annotation,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.annotation,
                         &mut self._bitfield,
                         field_data,
@@ -9453,10 +9373,10 @@ impl self::_puroro::Message for GeneratedCodeInfo {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::generated_code_info::Annotation,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        use self::_pinternal::oneof_type::OneofUnion as _;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::generated_code_info::Annotation,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.annotation,
             &self._bitfield,
             1i32,
@@ -9468,8 +9388,8 @@ impl self::_puroro::Message for GeneratedCodeInfo {
 impl ::std::clone::Clone for GeneratedCodeInfo {
     fn clone(&self) -> Self {
         Self {
-            annotation: <self::_puroro::internal::field_type::RepeatedMessageField::<
-                self::_puroro_root::google::protobuf::generated_code_info::Annotation,
+            annotation: <self::_pinternal::field_type::RepeatedMessageField::<
+                self::_root::google::protobuf::generated_code_info::Annotation,
             > as ::std::clone::Clone>::clone(&self.annotation),
             _bitfield: ::std::clone::Clone::clone(&self._bitfield),
         }
@@ -9478,7 +9398,7 @@ impl ::std::clone::Clone for GeneratedCodeInfo {
 impl ::std::ops::Drop for GeneratedCodeInfo {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for GeneratedCodeInfo {
@@ -9494,7 +9414,7 @@ impl ::std::fmt::Debug for GeneratedCodeInfo {
 impl ::std::cmp::PartialEq for GeneratedCodeInfo {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         true && self.annotation() == rhs.annotation()
     }
 }

--- a/puroro-protobuf-compiled/src/google/protobuf.rs
+++ b/puroro-protobuf-compiled/src/google/protobuf.rs
@@ -22,29 +22,29 @@ pub mod source_code_info;
 pub mod uninterpreted_option;
 #[derive(::std::default::Default)]
 pub struct FileDescriptorSet {
-    file: self::_pinternal::field_type::RepeatedMessageField::<
+    file: self::_pinternal::RepeatedMessageField::<
         self::_root::google::protobuf::FileDescriptorProto,
     >,
-    _bitfield: self::_pinternal::bitvec::BitArray<0usize>,
+    _bitfield: self::_pinternal::BitArray<0usize>,
 }
 impl FileDescriptorSet {
     pub fn file(&self) -> &[self::_root::google::protobuf::FileDescriptorProto] {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::FileDescriptorProto,
         > as RepeatedFieldType>::get_field(&self.file, &self._bitfield)
     }
     pub fn file_mut(
         &mut self,
     ) -> &mut ::std::vec::Vec::<self::_root::google::protobuf::FileDescriptorProto> {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::FileDescriptorProto,
         > as RepeatedFieldType>::get_field_mut(&mut self.file, &mut self._bitfield)
     }
     pub fn clear_file(&mut self) {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::FileDescriptorProto,
         > as RepeatedFieldType>::clear(&mut self.file, &mut self._bitfield)
     }
@@ -63,14 +63,14 @@ impl self::_puroro::Message for FileDescriptorSet {
     ) -> self::_puroro::Result<()> {
         use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 1i32 => {
-                    <self::_pinternal::field_type::RepeatedMessageField::<
+                    <self::_pinternal::RepeatedMessageField::<
                         self::_root::google::protobuf::FileDescriptorProto,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.file,
                         &mut self._bitfield,
                         field_data,
@@ -87,10 +87,10 @@ impl self::_puroro::Message for FileDescriptorSet {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::OneofUnion as _;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::FileDescriptorProto,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.file,
             &self._bitfield,
             1i32,
@@ -102,7 +102,7 @@ impl self::_puroro::Message for FileDescriptorSet {
 impl ::std::clone::Clone for FileDescriptorSet {
     fn clone(&self) -> Self {
         Self {
-            file: <self::_pinternal::field_type::RepeatedMessageField::<
+            file: <self::_pinternal::RepeatedMessageField::<
                 self::_root::google::protobuf::FileDescriptorProto,
             > as ::std::clone::Clone>::clone(&self.file),
             _bitfield: ::std::clone::Clone::clone(&self._bitfield),
@@ -112,7 +112,7 @@ impl ::std::clone::Clone for FileDescriptorSet {
 impl ::std::ops::Drop for FileDescriptorSet {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for FileDescriptorSet {
@@ -128,63 +128,63 @@ impl ::std::fmt::Debug for FileDescriptorSet {
 impl ::std::cmp::PartialEq for FileDescriptorSet {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         true && self.file() == rhs.file()
     }
 }
 #[derive(::std::default::Default)]
 pub struct FileDescriptorProto {
-    name: self::_pinternal::field_type::OptionalUnsizedField::<
+    name: self::_pinternal::OptionalUnsizedField::<
         ::std::string::String,
         self::_pinternal::tags::String,
         0usize,
     >,
-    package: self::_pinternal::field_type::OptionalUnsizedField::<
+    package: self::_pinternal::OptionalUnsizedField::<
         ::std::string::String,
         self::_pinternal::tags::String,
         1usize,
     >,
-    dependency: self::_pinternal::field_type::RepeatedUnsizedField::<
+    dependency: self::_pinternal::RepeatedUnsizedField::<
         ::std::string::String,
         self::_pinternal::tags::String,
     >,
-    public_dependency: self::_pinternal::field_type::RepeatedNumericalField::<
+    public_dependency: self::_pinternal::RepeatedNumericalField::<
         i32,
         self::_pinternal::tags::Int32,
     >,
-    weak_dependency: self::_pinternal::field_type::RepeatedNumericalField::<
+    weak_dependency: self::_pinternal::RepeatedNumericalField::<
         i32,
         self::_pinternal::tags::Int32,
     >,
-    message_type: self::_pinternal::field_type::RepeatedMessageField::<
+    message_type: self::_pinternal::RepeatedMessageField::<
         self::_root::google::protobuf::DescriptorProto,
     >,
-    enum_type: self::_pinternal::field_type::RepeatedMessageField::<
+    enum_type: self::_pinternal::RepeatedMessageField::<
         self::_root::google::protobuf::EnumDescriptorProto,
     >,
-    service: self::_pinternal::field_type::RepeatedMessageField::<
+    service: self::_pinternal::RepeatedMessageField::<
         self::_root::google::protobuf::ServiceDescriptorProto,
     >,
-    extension: self::_pinternal::field_type::RepeatedMessageField::<
+    extension: self::_pinternal::RepeatedMessageField::<
         self::_root::google::protobuf::FieldDescriptorProto,
     >,
-    options: self::_pinternal::field_type::SingularHeapMessageField::<
+    options: self::_pinternal::SingularHeapMessageField::<
         self::_root::google::protobuf::FileOptions,
     >,
-    source_code_info: self::_pinternal::field_type::SingularHeapMessageField::<
+    source_code_info: self::_pinternal::SingularHeapMessageField::<
         self::_root::google::protobuf::SourceCodeInfo,
     >,
-    syntax: self::_pinternal::field_type::OptionalUnsizedField::<
+    syntax: self::_pinternal::OptionalUnsizedField::<
         ::std::string::String,
         self::_pinternal::tags::String,
         2usize,
     >,
-    _bitfield: self::_pinternal::bitvec::BitArray<1usize>,
+    _bitfield: self::_pinternal::BitArray<1usize>,
 }
 impl FileDescriptorProto {
     pub fn name(&self) -> &str {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
@@ -195,16 +195,16 @@ impl FileDescriptorProto {
         )
     }
     pub fn name_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.name, &self._bitfield)
     }
     pub fn name_mut(&mut self) -> &mut ::std::string::String {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
@@ -215,8 +215,8 @@ impl FileDescriptorProto {
         )
     }
     pub fn has_name(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
@@ -224,16 +224,16 @@ impl FileDescriptorProto {
             .is_some()
     }
     pub fn clear_name(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::clear(&mut self.name, &mut self._bitfield)
     }
     pub fn package(&self) -> &str {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             1usize,
@@ -244,16 +244,16 @@ impl FileDescriptorProto {
         )
     }
     pub fn package_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             1usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.package, &self._bitfield)
     }
     pub fn package_mut(&mut self) -> &mut ::std::string::String {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             1usize,
@@ -264,8 +264,8 @@ impl FileDescriptorProto {
         )
     }
     pub fn has_package(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             1usize,
@@ -273,8 +273,8 @@ impl FileDescriptorProto {
             .is_some()
     }
     pub fn clear_package(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             1usize,
@@ -285,36 +285,36 @@ impl FileDescriptorProto {
     ) -> &[impl ::std::ops::Deref::<
         Target = str,
     > + ::std::fmt::Debug + ::std::cmp::PartialEq] {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedUnsizedField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
         > as RepeatedFieldType>::get_field(&self.dependency, &self._bitfield)
     }
     pub fn dependency_mut(&mut self) -> &mut ::std::vec::Vec::<::std::string::String> {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedUnsizedField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
         > as RepeatedFieldType>::get_field_mut(&mut self.dependency, &mut self._bitfield)
     }
     pub fn clear_dependency(&mut self) {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedUnsizedField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
         > as RepeatedFieldType>::clear(&mut self.dependency, &mut self._bitfield)
     }
     pub fn public_dependency(&self) -> &[i32] {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
         > as RepeatedFieldType>::get_field(&self.public_dependency, &self._bitfield)
     }
     pub fn public_dependency_mut(&mut self) -> &mut ::std::vec::Vec::<i32> {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
         > as RepeatedFieldType>::get_field_mut(
@@ -323,22 +323,22 @@ impl FileDescriptorProto {
         )
     }
     pub fn clear_public_dependency(&mut self) {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
         > as RepeatedFieldType>::clear(&mut self.public_dependency, &mut self._bitfield)
     }
     pub fn weak_dependency(&self) -> &[i32] {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
         > as RepeatedFieldType>::get_field(&self.weak_dependency, &self._bitfield)
     }
     pub fn weak_dependency_mut(&mut self) -> &mut ::std::vec::Vec::<i32> {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
         > as RepeatedFieldType>::get_field_mut(
@@ -347,23 +347,23 @@ impl FileDescriptorProto {
         )
     }
     pub fn clear_weak_dependency(&mut self) {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
         > as RepeatedFieldType>::clear(&mut self.weak_dependency, &mut self._bitfield)
     }
     pub fn message_type(&self) -> &[self::_root::google::protobuf::DescriptorProto] {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::DescriptorProto,
         > as RepeatedFieldType>::get_field(&self.message_type, &self._bitfield)
     }
     pub fn message_type_mut(
         &mut self,
     ) -> &mut ::std::vec::Vec::<self::_root::google::protobuf::DescriptorProto> {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::DescriptorProto,
         > as RepeatedFieldType>::get_field_mut(
             &mut self.message_type,
@@ -371,76 +371,76 @@ impl FileDescriptorProto {
         )
     }
     pub fn clear_message_type(&mut self) {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::DescriptorProto,
         > as RepeatedFieldType>::clear(&mut self.message_type, &mut self._bitfield)
     }
     pub fn enum_type(&self) -> &[self::_root::google::protobuf::EnumDescriptorProto] {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::EnumDescriptorProto,
         > as RepeatedFieldType>::get_field(&self.enum_type, &self._bitfield)
     }
     pub fn enum_type_mut(
         &mut self,
     ) -> &mut ::std::vec::Vec::<self::_root::google::protobuf::EnumDescriptorProto> {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::EnumDescriptorProto,
         > as RepeatedFieldType>::get_field_mut(&mut self.enum_type, &mut self._bitfield)
     }
     pub fn clear_enum_type(&mut self) {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::EnumDescriptorProto,
         > as RepeatedFieldType>::clear(&mut self.enum_type, &mut self._bitfield)
     }
     pub fn service(&self) -> &[self::_root::google::protobuf::ServiceDescriptorProto] {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::ServiceDescriptorProto,
         > as RepeatedFieldType>::get_field(&self.service, &self._bitfield)
     }
     pub fn service_mut(
         &mut self,
     ) -> &mut ::std::vec::Vec::<self::_root::google::protobuf::ServiceDescriptorProto> {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::ServiceDescriptorProto,
         > as RepeatedFieldType>::get_field_mut(&mut self.service, &mut self._bitfield)
     }
     pub fn clear_service(&mut self) {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::ServiceDescriptorProto,
         > as RepeatedFieldType>::clear(&mut self.service, &mut self._bitfield)
     }
     pub fn extension(&self) -> &[self::_root::google::protobuf::FieldDescriptorProto] {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::FieldDescriptorProto,
         > as RepeatedFieldType>::get_field(&self.extension, &self._bitfield)
     }
     pub fn extension_mut(
         &mut self,
     ) -> &mut ::std::vec::Vec::<self::_root::google::protobuf::FieldDescriptorProto> {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::FieldDescriptorProto,
         > as RepeatedFieldType>::get_field_mut(&mut self.extension, &mut self._bitfield)
     }
     pub fn clear_extension(&mut self) {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::FieldDescriptorProto,
         > as RepeatedFieldType>::clear(&mut self.extension, &mut self._bitfield)
     }
     pub fn options(
         &self,
     ) -> ::std::option::Option::<&self::_root::google::protobuf::FileOptions> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::google::protobuf::FileOptions,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.options,
@@ -451,14 +451,14 @@ impl FileDescriptorProto {
     pub fn options_opt(
         &self,
     ) -> ::std::option::Option::<&self::_root::google::protobuf::FileOptions> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::google::protobuf::FileOptions,
         > as NonRepeatedFieldType>::get_field_opt(&self.options, &self._bitfield)
     }
     pub fn options_mut(&mut self) -> &mut self::_root::google::protobuf::FileOptions {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::google::protobuf::FileOptions,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.options,
@@ -467,23 +467,23 @@ impl FileDescriptorProto {
         )
     }
     pub fn has_options(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::google::protobuf::FileOptions,
         > as NonRepeatedFieldType>::get_field_opt(&self.options, &self._bitfield)
             .is_some()
     }
     pub fn clear_options(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::google::protobuf::FileOptions,
         > as NonRepeatedFieldType>::clear(&mut self.options, &mut self._bitfield)
     }
     pub fn source_code_info(
         &self,
     ) -> ::std::option::Option::<&self::_root::google::protobuf::SourceCodeInfo> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::google::protobuf::SourceCodeInfo,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.source_code_info,
@@ -494,8 +494,8 @@ impl FileDescriptorProto {
     pub fn source_code_info_opt(
         &self,
     ) -> ::std::option::Option::<&self::_root::google::protobuf::SourceCodeInfo> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::google::protobuf::SourceCodeInfo,
         > as NonRepeatedFieldType>::get_field_opt(
             &self.source_code_info,
@@ -505,8 +505,8 @@ impl FileDescriptorProto {
     pub fn source_code_info_mut(
         &mut self,
     ) -> &mut self::_root::google::protobuf::SourceCodeInfo {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::google::protobuf::SourceCodeInfo,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.source_code_info,
@@ -515,8 +515,8 @@ impl FileDescriptorProto {
         )
     }
     pub fn has_source_code_info(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::google::protobuf::SourceCodeInfo,
         > as NonRepeatedFieldType>::get_field_opt(
                 &self.source_code_info,
@@ -525,8 +525,8 @@ impl FileDescriptorProto {
             .is_some()
     }
     pub fn clear_source_code_info(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::google::protobuf::SourceCodeInfo,
         > as NonRepeatedFieldType>::clear(
             &mut self.source_code_info,
@@ -534,8 +534,8 @@ impl FileDescriptorProto {
         )
     }
     pub fn syntax(&self) -> &str {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             2usize,
@@ -546,16 +546,16 @@ impl FileDescriptorProto {
         )
     }
     pub fn syntax_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             2usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.syntax, &self._bitfield)
     }
     pub fn syntax_mut(&mut self) -> &mut ::std::string::String {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             2usize,
@@ -566,8 +566,8 @@ impl FileDescriptorProto {
         )
     }
     pub fn has_syntax(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             2usize,
@@ -575,8 +575,8 @@ impl FileDescriptorProto {
             .is_some()
     }
     pub fn clear_syntax(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             2usize,
@@ -597,122 +597,122 @@ impl self::_puroro::Message for FileDescriptorProto {
     ) -> self::_puroro::Result<()> {
         use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 1i32 => {
-                    <self::_pinternal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::OptionalUnsizedField::<
                         ::std::string::String,
                         self::_pinternal::tags::String,
                         0usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.name,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 2i32 => {
-                    <self::_pinternal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::OptionalUnsizedField::<
                         ::std::string::String,
                         self::_pinternal::tags::String,
                         1usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.package,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 3i32 => {
-                    <self::_pinternal::field_type::RepeatedUnsizedField::<
+                    <self::_pinternal::RepeatedUnsizedField::<
                         ::std::string::String,
                         self::_pinternal::tags::String,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.dependency,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 10i32 => {
-                    <self::_pinternal::field_type::RepeatedNumericalField::<
+                    <self::_pinternal::RepeatedNumericalField::<
                         i32,
                         self::_pinternal::tags::Int32,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.public_dependency,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 11i32 => {
-                    <self::_pinternal::field_type::RepeatedNumericalField::<
+                    <self::_pinternal::RepeatedNumericalField::<
                         i32,
                         self::_pinternal::tags::Int32,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.weak_dependency,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 4i32 => {
-                    <self::_pinternal::field_type::RepeatedMessageField::<
+                    <self::_pinternal::RepeatedMessageField::<
                         self::_root::google::protobuf::DescriptorProto,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.message_type,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 5i32 => {
-                    <self::_pinternal::field_type::RepeatedMessageField::<
+                    <self::_pinternal::RepeatedMessageField::<
                         self::_root::google::protobuf::EnumDescriptorProto,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.enum_type,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 6i32 => {
-                    <self::_pinternal::field_type::RepeatedMessageField::<
+                    <self::_pinternal::RepeatedMessageField::<
                         self::_root::google::protobuf::ServiceDescriptorProto,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.service,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 7i32 => {
-                    <self::_pinternal::field_type::RepeatedMessageField::<
+                    <self::_pinternal::RepeatedMessageField::<
                         self::_root::google::protobuf::FieldDescriptorProto,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.extension,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 8i32 => {
-                    <self::_pinternal::field_type::SingularHeapMessageField::<
+                    <self::_pinternal::SingularHeapMessageField::<
                         self::_root::google::protobuf::FileOptions,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.options,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 9i32 => {
-                    <self::_pinternal::field_type::SingularHeapMessageField::<
+                    <self::_pinternal::SingularHeapMessageField::<
                         self::_root::google::protobuf::SourceCodeInfo,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.source_code_info,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 12i32 => {
-                    <self::_pinternal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::OptionalUnsizedField::<
                         ::std::string::String,
                         self::_pinternal::tags::String,
                         2usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.syntax,
                         &mut self._bitfield,
                         field_data,
@@ -729,107 +729,107 @@ impl self::_puroro::Message for FileDescriptorProto {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::OneofUnion as _;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.name,
             &self._bitfield,
             1i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             1usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.package,
             &self._bitfield,
             2i32,
             out,
         )?;
-        <self::_pinternal::field_type::RepeatedUnsizedField::<
+        <self::_pinternal::RepeatedUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.dependency,
             &self._bitfield,
             3i32,
             out,
         )?;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        <self::_pinternal::RepeatedNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.public_dependency,
             &self._bitfield,
             10i32,
             out,
         )?;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        <self::_pinternal::RepeatedNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.weak_dependency,
             &self._bitfield,
             11i32,
             out,
         )?;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::DescriptorProto,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.message_type,
             &self._bitfield,
             4i32,
             out,
         )?;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::EnumDescriptorProto,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.enum_type,
             &self._bitfield,
             5i32,
             out,
         )?;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::ServiceDescriptorProto,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.service,
             &self._bitfield,
             6i32,
             out,
         )?;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::FieldDescriptorProto,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.extension,
             &self._bitfield,
             7i32,
             out,
         )?;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::google::protobuf::FileOptions,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.options,
             &self._bitfield,
             8i32,
             out,
         )?;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::google::protobuf::SourceCodeInfo,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.source_code_info,
             &self._bitfield,
             9i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             2usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.syntax,
             &self._bitfield,
             12i32,
@@ -841,47 +841,47 @@ impl self::_puroro::Message for FileDescriptorProto {
 impl ::std::clone::Clone for FileDescriptorProto {
     fn clone(&self) -> Self {
         Self {
-            name: <self::_pinternal::field_type::OptionalUnsizedField::<
+            name: <self::_pinternal::OptionalUnsizedField::<
                 ::std::string::String,
                 self::_pinternal::tags::String,
                 0usize,
             > as ::std::clone::Clone>::clone(&self.name),
-            package: <self::_pinternal::field_type::OptionalUnsizedField::<
+            package: <self::_pinternal::OptionalUnsizedField::<
                 ::std::string::String,
                 self::_pinternal::tags::String,
                 1usize,
             > as ::std::clone::Clone>::clone(&self.package),
-            dependency: <self::_pinternal::field_type::RepeatedUnsizedField::<
+            dependency: <self::_pinternal::RepeatedUnsizedField::<
                 ::std::string::String,
                 self::_pinternal::tags::String,
             > as ::std::clone::Clone>::clone(&self.dependency),
-            public_dependency: <self::_pinternal::field_type::RepeatedNumericalField::<
+            public_dependency: <self::_pinternal::RepeatedNumericalField::<
                 i32,
                 self::_pinternal::tags::Int32,
             > as ::std::clone::Clone>::clone(&self.public_dependency),
-            weak_dependency: <self::_pinternal::field_type::RepeatedNumericalField::<
+            weak_dependency: <self::_pinternal::RepeatedNumericalField::<
                 i32,
                 self::_pinternal::tags::Int32,
             > as ::std::clone::Clone>::clone(&self.weak_dependency),
-            message_type: <self::_pinternal::field_type::RepeatedMessageField::<
+            message_type: <self::_pinternal::RepeatedMessageField::<
                 self::_root::google::protobuf::DescriptorProto,
             > as ::std::clone::Clone>::clone(&self.message_type),
-            enum_type: <self::_pinternal::field_type::RepeatedMessageField::<
+            enum_type: <self::_pinternal::RepeatedMessageField::<
                 self::_root::google::protobuf::EnumDescriptorProto,
             > as ::std::clone::Clone>::clone(&self.enum_type),
-            service: <self::_pinternal::field_type::RepeatedMessageField::<
+            service: <self::_pinternal::RepeatedMessageField::<
                 self::_root::google::protobuf::ServiceDescriptorProto,
             > as ::std::clone::Clone>::clone(&self.service),
-            extension: <self::_pinternal::field_type::RepeatedMessageField::<
+            extension: <self::_pinternal::RepeatedMessageField::<
                 self::_root::google::protobuf::FieldDescriptorProto,
             > as ::std::clone::Clone>::clone(&self.extension),
-            options: <self::_pinternal::field_type::SingularHeapMessageField::<
+            options: <self::_pinternal::SingularHeapMessageField::<
                 self::_root::google::protobuf::FileOptions,
             > as ::std::clone::Clone>::clone(&self.options),
-            source_code_info: <self::_pinternal::field_type::SingularHeapMessageField::<
+            source_code_info: <self::_pinternal::SingularHeapMessageField::<
                 self::_root::google::protobuf::SourceCodeInfo,
             > as ::std::clone::Clone>::clone(&self.source_code_info),
-            syntax: <self::_pinternal::field_type::OptionalUnsizedField::<
+            syntax: <self::_pinternal::OptionalUnsizedField::<
                 ::std::string::String,
                 self::_pinternal::tags::String,
                 2usize,
@@ -893,7 +893,7 @@ impl ::std::clone::Clone for FileDescriptorProto {
 impl ::std::ops::Drop for FileDescriptorProto {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for FileDescriptorProto {
@@ -920,7 +920,7 @@ impl ::std::fmt::Debug for FileDescriptorProto {
 impl ::std::cmp::PartialEq for FileDescriptorProto {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         true && self.name_opt() == rhs.name_opt()
             && self.package_opt() == rhs.package_opt()
             && self.dependency() == rhs.dependency()
@@ -936,45 +936,45 @@ impl ::std::cmp::PartialEq for FileDescriptorProto {
 }
 #[derive(::std::default::Default)]
 pub struct DescriptorProto {
-    name: self::_pinternal::field_type::OptionalUnsizedField::<
+    name: self::_pinternal::OptionalUnsizedField::<
         ::std::string::String,
         self::_pinternal::tags::String,
         0usize,
     >,
-    field: self::_pinternal::field_type::RepeatedMessageField::<
+    field: self::_pinternal::RepeatedMessageField::<
         self::_root::google::protobuf::FieldDescriptorProto,
     >,
-    extension: self::_pinternal::field_type::RepeatedMessageField::<
+    extension: self::_pinternal::RepeatedMessageField::<
         self::_root::google::protobuf::FieldDescriptorProto,
     >,
-    nested_type: self::_pinternal::field_type::RepeatedMessageField::<
+    nested_type: self::_pinternal::RepeatedMessageField::<
         self::_root::google::protobuf::DescriptorProto,
     >,
-    enum_type: self::_pinternal::field_type::RepeatedMessageField::<
+    enum_type: self::_pinternal::RepeatedMessageField::<
         self::_root::google::protobuf::EnumDescriptorProto,
     >,
-    extension_range: self::_pinternal::field_type::RepeatedMessageField::<
+    extension_range: self::_pinternal::RepeatedMessageField::<
         self::_root::google::protobuf::descriptor_proto::ExtensionRange,
     >,
-    oneof_decl: self::_pinternal::field_type::RepeatedMessageField::<
+    oneof_decl: self::_pinternal::RepeatedMessageField::<
         self::_root::google::protobuf::OneofDescriptorProto,
     >,
-    options: self::_pinternal::field_type::SingularHeapMessageField::<
+    options: self::_pinternal::SingularHeapMessageField::<
         self::_root::google::protobuf::MessageOptions,
     >,
-    reserved_range: self::_pinternal::field_type::RepeatedMessageField::<
+    reserved_range: self::_pinternal::RepeatedMessageField::<
         self::_root::google::protobuf::descriptor_proto::ReservedRange,
     >,
-    reserved_name: self::_pinternal::field_type::RepeatedUnsizedField::<
+    reserved_name: self::_pinternal::RepeatedUnsizedField::<
         ::std::string::String,
         self::_pinternal::tags::String,
     >,
-    _bitfield: self::_pinternal::bitvec::BitArray<1usize>,
+    _bitfield: self::_pinternal::BitArray<1usize>,
 }
 impl DescriptorProto {
     pub fn name(&self) -> &str {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
@@ -985,16 +985,16 @@ impl DescriptorProto {
         )
     }
     pub fn name_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.name, &self._bitfield)
     }
     pub fn name_mut(&mut self) -> &mut ::std::string::String {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
@@ -1005,8 +1005,8 @@ impl DescriptorProto {
         )
     }
     pub fn has_name(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
@@ -1014,64 +1014,64 @@ impl DescriptorProto {
             .is_some()
     }
     pub fn clear_name(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::clear(&mut self.name, &mut self._bitfield)
     }
     pub fn field(&self) -> &[self::_root::google::protobuf::FieldDescriptorProto] {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::FieldDescriptorProto,
         > as RepeatedFieldType>::get_field(&self.field, &self._bitfield)
     }
     pub fn field_mut(
         &mut self,
     ) -> &mut ::std::vec::Vec::<self::_root::google::protobuf::FieldDescriptorProto> {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::FieldDescriptorProto,
         > as RepeatedFieldType>::get_field_mut(&mut self.field, &mut self._bitfield)
     }
     pub fn clear_field(&mut self) {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::FieldDescriptorProto,
         > as RepeatedFieldType>::clear(&mut self.field, &mut self._bitfield)
     }
     pub fn extension(&self) -> &[self::_root::google::protobuf::FieldDescriptorProto] {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::FieldDescriptorProto,
         > as RepeatedFieldType>::get_field(&self.extension, &self._bitfield)
     }
     pub fn extension_mut(
         &mut self,
     ) -> &mut ::std::vec::Vec::<self::_root::google::protobuf::FieldDescriptorProto> {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::FieldDescriptorProto,
         > as RepeatedFieldType>::get_field_mut(&mut self.extension, &mut self._bitfield)
     }
     pub fn clear_extension(&mut self) {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::FieldDescriptorProto,
         > as RepeatedFieldType>::clear(&mut self.extension, &mut self._bitfield)
     }
     pub fn nested_type(&self) -> &[self::_root::google::protobuf::DescriptorProto] {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::DescriptorProto,
         > as RepeatedFieldType>::get_field(&self.nested_type, &self._bitfield)
     }
     pub fn nested_type_mut(
         &mut self,
     ) -> &mut ::std::vec::Vec::<self::_root::google::protobuf::DescriptorProto> {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::DescriptorProto,
         > as RepeatedFieldType>::get_field_mut(
             &mut self.nested_type,
@@ -1079,36 +1079,36 @@ impl DescriptorProto {
         )
     }
     pub fn clear_nested_type(&mut self) {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::DescriptorProto,
         > as RepeatedFieldType>::clear(&mut self.nested_type, &mut self._bitfield)
     }
     pub fn enum_type(&self) -> &[self::_root::google::protobuf::EnumDescriptorProto] {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::EnumDescriptorProto,
         > as RepeatedFieldType>::get_field(&self.enum_type, &self._bitfield)
     }
     pub fn enum_type_mut(
         &mut self,
     ) -> &mut ::std::vec::Vec::<self::_root::google::protobuf::EnumDescriptorProto> {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::EnumDescriptorProto,
         > as RepeatedFieldType>::get_field_mut(&mut self.enum_type, &mut self._bitfield)
     }
     pub fn clear_enum_type(&mut self) {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::EnumDescriptorProto,
         > as RepeatedFieldType>::clear(&mut self.enum_type, &mut self._bitfield)
     }
     pub fn extension_range(
         &self,
     ) -> &[self::_root::google::protobuf::descriptor_proto::ExtensionRange] {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::descriptor_proto::ExtensionRange,
         > as RepeatedFieldType>::get_field(&self.extension_range, &self._bitfield)
     }
@@ -1117,8 +1117,8 @@ impl DescriptorProto {
     ) -> &mut ::std::vec::Vec::<
         self::_root::google::protobuf::descriptor_proto::ExtensionRange,
     > {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::descriptor_proto::ExtensionRange,
         > as RepeatedFieldType>::get_field_mut(
             &mut self.extension_range,
@@ -1126,36 +1126,36 @@ impl DescriptorProto {
         )
     }
     pub fn clear_extension_range(&mut self) {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::descriptor_proto::ExtensionRange,
         > as RepeatedFieldType>::clear(&mut self.extension_range, &mut self._bitfield)
     }
     pub fn oneof_decl(&self) -> &[self::_root::google::protobuf::OneofDescriptorProto] {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::OneofDescriptorProto,
         > as RepeatedFieldType>::get_field(&self.oneof_decl, &self._bitfield)
     }
     pub fn oneof_decl_mut(
         &mut self,
     ) -> &mut ::std::vec::Vec::<self::_root::google::protobuf::OneofDescriptorProto> {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::OneofDescriptorProto,
         > as RepeatedFieldType>::get_field_mut(&mut self.oneof_decl, &mut self._bitfield)
     }
     pub fn clear_oneof_decl(&mut self) {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::OneofDescriptorProto,
         > as RepeatedFieldType>::clear(&mut self.oneof_decl, &mut self._bitfield)
     }
     pub fn options(
         &self,
     ) -> ::std::option::Option::<&self::_root::google::protobuf::MessageOptions> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::google::protobuf::MessageOptions,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.options,
@@ -1166,14 +1166,14 @@ impl DescriptorProto {
     pub fn options_opt(
         &self,
     ) -> ::std::option::Option::<&self::_root::google::protobuf::MessageOptions> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::google::protobuf::MessageOptions,
         > as NonRepeatedFieldType>::get_field_opt(&self.options, &self._bitfield)
     }
     pub fn options_mut(&mut self) -> &mut self::_root::google::protobuf::MessageOptions {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::google::protobuf::MessageOptions,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.options,
@@ -1182,23 +1182,23 @@ impl DescriptorProto {
         )
     }
     pub fn has_options(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::google::protobuf::MessageOptions,
         > as NonRepeatedFieldType>::get_field_opt(&self.options, &self._bitfield)
             .is_some()
     }
     pub fn clear_options(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::google::protobuf::MessageOptions,
         > as NonRepeatedFieldType>::clear(&mut self.options, &mut self._bitfield)
     }
     pub fn reserved_range(
         &self,
     ) -> &[self::_root::google::protobuf::descriptor_proto::ReservedRange] {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::descriptor_proto::ReservedRange,
         > as RepeatedFieldType>::get_field(&self.reserved_range, &self._bitfield)
     }
@@ -1207,8 +1207,8 @@ impl DescriptorProto {
     ) -> &mut ::std::vec::Vec::<
         self::_root::google::protobuf::descriptor_proto::ReservedRange,
     > {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::descriptor_proto::ReservedRange,
         > as RepeatedFieldType>::get_field_mut(
             &mut self.reserved_range,
@@ -1216,8 +1216,8 @@ impl DescriptorProto {
         )
     }
     pub fn clear_reserved_range(&mut self) {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::descriptor_proto::ReservedRange,
         > as RepeatedFieldType>::clear(&mut self.reserved_range, &mut self._bitfield)
     }
@@ -1226,8 +1226,8 @@ impl DescriptorProto {
     ) -> &[impl ::std::ops::Deref::<
         Target = str,
     > + ::std::fmt::Debug + ::std::cmp::PartialEq] {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedUnsizedField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
         > as RepeatedFieldType>::get_field(&self.reserved_name, &self._bitfield)
@@ -1235,8 +1235,8 @@ impl DescriptorProto {
     pub fn reserved_name_mut(
         &mut self,
     ) -> &mut ::std::vec::Vec::<::std::string::String> {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedUnsizedField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
         > as RepeatedFieldType>::get_field_mut(
@@ -1245,8 +1245,8 @@ impl DescriptorProto {
         )
     }
     pub fn clear_reserved_name(&mut self) {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedUnsizedField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
         > as RepeatedFieldType>::clear(&mut self.reserved_name, &mut self._bitfield)
@@ -1266,98 +1266,98 @@ impl self::_puroro::Message for DescriptorProto {
     ) -> self::_puroro::Result<()> {
         use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 1i32 => {
-                    <self::_pinternal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::OptionalUnsizedField::<
                         ::std::string::String,
                         self::_pinternal::tags::String,
                         0usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.name,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 2i32 => {
-                    <self::_pinternal::field_type::RepeatedMessageField::<
+                    <self::_pinternal::RepeatedMessageField::<
                         self::_root::google::protobuf::FieldDescriptorProto,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.field,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 6i32 => {
-                    <self::_pinternal::field_type::RepeatedMessageField::<
+                    <self::_pinternal::RepeatedMessageField::<
                         self::_root::google::protobuf::FieldDescriptorProto,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.extension,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 3i32 => {
-                    <self::_pinternal::field_type::RepeatedMessageField::<
+                    <self::_pinternal::RepeatedMessageField::<
                         self::_root::google::protobuf::DescriptorProto,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.nested_type,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 4i32 => {
-                    <self::_pinternal::field_type::RepeatedMessageField::<
+                    <self::_pinternal::RepeatedMessageField::<
                         self::_root::google::protobuf::EnumDescriptorProto,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.enum_type,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 5i32 => {
-                    <self::_pinternal::field_type::RepeatedMessageField::<
+                    <self::_pinternal::RepeatedMessageField::<
                         self::_root::google::protobuf::descriptor_proto::ExtensionRange,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.extension_range,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 8i32 => {
-                    <self::_pinternal::field_type::RepeatedMessageField::<
+                    <self::_pinternal::RepeatedMessageField::<
                         self::_root::google::protobuf::OneofDescriptorProto,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.oneof_decl,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 7i32 => {
-                    <self::_pinternal::field_type::SingularHeapMessageField::<
+                    <self::_pinternal::SingularHeapMessageField::<
                         self::_root::google::protobuf::MessageOptions,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.options,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 9i32 => {
-                    <self::_pinternal::field_type::RepeatedMessageField::<
+                    <self::_pinternal::RepeatedMessageField::<
                         self::_root::google::protobuf::descriptor_proto::ReservedRange,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.reserved_range,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 10i32 => {
-                    <self::_pinternal::field_type::RepeatedUnsizedField::<
+                    <self::_pinternal::RepeatedUnsizedField::<
                         ::std::string::String,
                         self::_pinternal::tags::String,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.reserved_name,
                         &mut self._bitfield,
                         field_data,
@@ -1374,85 +1374,85 @@ impl self::_puroro::Message for DescriptorProto {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::OneofUnion as _;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.name,
             &self._bitfield,
             1i32,
             out,
         )?;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::FieldDescriptorProto,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.field,
             &self._bitfield,
             2i32,
             out,
         )?;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::FieldDescriptorProto,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.extension,
             &self._bitfield,
             6i32,
             out,
         )?;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::DescriptorProto,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.nested_type,
             &self._bitfield,
             3i32,
             out,
         )?;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::EnumDescriptorProto,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.enum_type,
             &self._bitfield,
             4i32,
             out,
         )?;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::descriptor_proto::ExtensionRange,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.extension_range,
             &self._bitfield,
             5i32,
             out,
         )?;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::OneofDescriptorProto,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.oneof_decl,
             &self._bitfield,
             8i32,
             out,
         )?;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::google::protobuf::MessageOptions,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.options,
             &self._bitfield,
             7i32,
             out,
         )?;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::descriptor_proto::ReservedRange,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.reserved_range,
             &self._bitfield,
             9i32,
             out,
         )?;
-        <self::_pinternal::field_type::RepeatedUnsizedField::<
+        <self::_pinternal::RepeatedUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.reserved_name,
             &self._bitfield,
             10i32,
@@ -1464,36 +1464,36 @@ impl self::_puroro::Message for DescriptorProto {
 impl ::std::clone::Clone for DescriptorProto {
     fn clone(&self) -> Self {
         Self {
-            name: <self::_pinternal::field_type::OptionalUnsizedField::<
+            name: <self::_pinternal::OptionalUnsizedField::<
                 ::std::string::String,
                 self::_pinternal::tags::String,
                 0usize,
             > as ::std::clone::Clone>::clone(&self.name),
-            field: <self::_pinternal::field_type::RepeatedMessageField::<
+            field: <self::_pinternal::RepeatedMessageField::<
                 self::_root::google::protobuf::FieldDescriptorProto,
             > as ::std::clone::Clone>::clone(&self.field),
-            extension: <self::_pinternal::field_type::RepeatedMessageField::<
+            extension: <self::_pinternal::RepeatedMessageField::<
                 self::_root::google::protobuf::FieldDescriptorProto,
             > as ::std::clone::Clone>::clone(&self.extension),
-            nested_type: <self::_pinternal::field_type::RepeatedMessageField::<
+            nested_type: <self::_pinternal::RepeatedMessageField::<
                 self::_root::google::protobuf::DescriptorProto,
             > as ::std::clone::Clone>::clone(&self.nested_type),
-            enum_type: <self::_pinternal::field_type::RepeatedMessageField::<
+            enum_type: <self::_pinternal::RepeatedMessageField::<
                 self::_root::google::protobuf::EnumDescriptorProto,
             > as ::std::clone::Clone>::clone(&self.enum_type),
-            extension_range: <self::_pinternal::field_type::RepeatedMessageField::<
+            extension_range: <self::_pinternal::RepeatedMessageField::<
                 self::_root::google::protobuf::descriptor_proto::ExtensionRange,
             > as ::std::clone::Clone>::clone(&self.extension_range),
-            oneof_decl: <self::_pinternal::field_type::RepeatedMessageField::<
+            oneof_decl: <self::_pinternal::RepeatedMessageField::<
                 self::_root::google::protobuf::OneofDescriptorProto,
             > as ::std::clone::Clone>::clone(&self.oneof_decl),
-            options: <self::_pinternal::field_type::SingularHeapMessageField::<
+            options: <self::_pinternal::SingularHeapMessageField::<
                 self::_root::google::protobuf::MessageOptions,
             > as ::std::clone::Clone>::clone(&self.options),
-            reserved_range: <self::_pinternal::field_type::RepeatedMessageField::<
+            reserved_range: <self::_pinternal::RepeatedMessageField::<
                 self::_root::google::protobuf::descriptor_proto::ReservedRange,
             > as ::std::clone::Clone>::clone(&self.reserved_range),
-            reserved_name: <self::_pinternal::field_type::RepeatedUnsizedField::<
+            reserved_name: <self::_pinternal::RepeatedUnsizedField::<
                 ::std::string::String,
                 self::_pinternal::tags::String,
             > as ::std::clone::Clone>::clone(&self.reserved_name),
@@ -1504,7 +1504,7 @@ impl ::std::clone::Clone for DescriptorProto {
 impl ::std::ops::Drop for DescriptorProto {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for DescriptorProto {
@@ -1529,7 +1529,7 @@ impl ::std::fmt::Debug for DescriptorProto {
 impl ::std::cmp::PartialEq for DescriptorProto {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         true && self.name_opt() == rhs.name_opt() && self.field() == rhs.field()
             && self.extension() == rhs.extension()
             && self.nested_type() == rhs.nested_type()
@@ -1543,25 +1543,25 @@ impl ::std::cmp::PartialEq for DescriptorProto {
 }
 #[derive(::std::default::Default)]
 pub struct ExtensionRangeOptions {
-    uninterpreted_option: self::_pinternal::field_type::RepeatedMessageField::<
+    uninterpreted_option: self::_pinternal::RepeatedMessageField::<
         self::_root::google::protobuf::UninterpretedOption,
     >,
-    _bitfield: self::_pinternal::bitvec::BitArray<0usize>,
+    _bitfield: self::_pinternal::BitArray<0usize>,
 }
 impl ExtensionRangeOptions {
     pub fn uninterpreted_option(
         &self,
     ) -> &[self::_root::google::protobuf::UninterpretedOption] {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::UninterpretedOption,
         > as RepeatedFieldType>::get_field(&self.uninterpreted_option, &self._bitfield)
     }
     pub fn uninterpreted_option_mut(
         &mut self,
     ) -> &mut ::std::vec::Vec::<self::_root::google::protobuf::UninterpretedOption> {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::UninterpretedOption,
         > as RepeatedFieldType>::get_field_mut(
             &mut self.uninterpreted_option,
@@ -1569,8 +1569,8 @@ impl ExtensionRangeOptions {
         )
     }
     pub fn clear_uninterpreted_option(&mut self) {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::UninterpretedOption,
         > as RepeatedFieldType>::clear(
             &mut self.uninterpreted_option,
@@ -1592,14 +1592,14 @@ impl self::_puroro::Message for ExtensionRangeOptions {
     ) -> self::_puroro::Result<()> {
         use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 999i32 => {
-                    <self::_pinternal::field_type::RepeatedMessageField::<
+                    <self::_pinternal::RepeatedMessageField::<
                         self::_root::google::protobuf::UninterpretedOption,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.uninterpreted_option,
                         &mut self._bitfield,
                         field_data,
@@ -1616,10 +1616,10 @@ impl self::_puroro::Message for ExtensionRangeOptions {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::OneofUnion as _;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::UninterpretedOption,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.uninterpreted_option,
             &self._bitfield,
             999i32,
@@ -1631,7 +1631,7 @@ impl self::_puroro::Message for ExtensionRangeOptions {
 impl ::std::clone::Clone for ExtensionRangeOptions {
     fn clone(&self) -> Self {
         Self {
-            uninterpreted_option: <self::_pinternal::field_type::RepeatedMessageField::<
+            uninterpreted_option: <self::_pinternal::RepeatedMessageField::<
                 self::_root::google::protobuf::UninterpretedOption,
             > as ::std::clone::Clone>::clone(&self.uninterpreted_option),
             _bitfield: ::std::clone::Clone::clone(&self._bitfield),
@@ -1641,7 +1641,7 @@ impl ::std::clone::Clone for ExtensionRangeOptions {
 impl ::std::ops::Drop for ExtensionRangeOptions {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for ExtensionRangeOptions {
@@ -1657,75 +1657,75 @@ impl ::std::fmt::Debug for ExtensionRangeOptions {
 impl ::std::cmp::PartialEq for ExtensionRangeOptions {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         true && self.uninterpreted_option() == rhs.uninterpreted_option()
     }
 }
 #[derive(::std::default::Default)]
 pub struct FieldDescriptorProto {
-    name: self::_pinternal::field_type::OptionalUnsizedField::<
+    name: self::_pinternal::OptionalUnsizedField::<
         ::std::string::String,
         self::_pinternal::tags::String,
         0usize,
     >,
-    number: self::_pinternal::field_type::OptionalNumericalField::<
+    number: self::_pinternal::OptionalNumericalField::<
         i32,
         self::_pinternal::tags::Int32,
         1usize,
     >,
-    label: self::_pinternal::field_type::OptionalNumericalField::<
+    label: self::_pinternal::OptionalNumericalField::<
         self::_root::google::protobuf::field_descriptor_proto::Label,
         self::_pinternal::tags::Enum2::<
             self::_root::google::protobuf::field_descriptor_proto::Label,
         >,
         2usize,
     >,
-    r#type: self::_pinternal::field_type::OptionalNumericalField::<
+    r#type: self::_pinternal::OptionalNumericalField::<
         self::_root::google::protobuf::field_descriptor_proto::Type,
         self::_pinternal::tags::Enum2::<
             self::_root::google::protobuf::field_descriptor_proto::Type,
         >,
         3usize,
     >,
-    type_name: self::_pinternal::field_type::OptionalUnsizedField::<
+    type_name: self::_pinternal::OptionalUnsizedField::<
         ::std::string::String,
         self::_pinternal::tags::String,
         4usize,
     >,
-    extendee: self::_pinternal::field_type::OptionalUnsizedField::<
+    extendee: self::_pinternal::OptionalUnsizedField::<
         ::std::string::String,
         self::_pinternal::tags::String,
         5usize,
     >,
-    default_value: self::_pinternal::field_type::OptionalUnsizedField::<
+    default_value: self::_pinternal::OptionalUnsizedField::<
         ::std::string::String,
         self::_pinternal::tags::String,
         6usize,
     >,
-    oneof_index: self::_pinternal::field_type::OptionalNumericalField::<
+    oneof_index: self::_pinternal::OptionalNumericalField::<
         i32,
         self::_pinternal::tags::Int32,
         7usize,
     >,
-    json_name: self::_pinternal::field_type::OptionalUnsizedField::<
+    json_name: self::_pinternal::OptionalUnsizedField::<
         ::std::string::String,
         self::_pinternal::tags::String,
         8usize,
     >,
-    options: self::_pinternal::field_type::SingularHeapMessageField::<
+    options: self::_pinternal::SingularHeapMessageField::<
         self::_root::google::protobuf::FieldOptions,
     >,
-    proto3_optional: self::_pinternal::field_type::OptionalNumericalField::<
+    proto3_optional: self::_pinternal::OptionalNumericalField::<
         bool,
         self::_pinternal::tags::Bool,
         9usize,
     >,
-    _bitfield: self::_pinternal::bitvec::BitArray<1usize>,
+    _bitfield: self::_pinternal::BitArray<1usize>,
 }
 impl FieldDescriptorProto {
     pub fn name(&self) -> &str {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
@@ -1736,16 +1736,16 @@ impl FieldDescriptorProto {
         )
     }
     pub fn name_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.name, &self._bitfield)
     }
     pub fn name_mut(&mut self) -> &mut ::std::string::String {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
@@ -1756,8 +1756,8 @@ impl FieldDescriptorProto {
         )
     }
     pub fn has_name(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
@@ -1765,16 +1765,16 @@ impl FieldDescriptorProto {
             .is_some()
     }
     pub fn clear_name(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::clear(&mut self.name, &mut self._bitfield)
     }
     pub fn number(&self) -> i32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             1usize,
@@ -1785,16 +1785,16 @@ impl FieldDescriptorProto {
         )
     }
     pub fn number_opt(&self) -> ::std::option::Option::<i32> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             1usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.number, &self._bitfield)
     }
     pub fn number_mut(&mut self) -> &mut i32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             1usize,
@@ -1805,8 +1805,8 @@ impl FieldDescriptorProto {
         )
     }
     pub fn has_number(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             1usize,
@@ -1814,16 +1814,16 @@ impl FieldDescriptorProto {
             .is_some()
     }
     pub fn clear_number(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             1usize,
         > as NonRepeatedFieldType>::clear(&mut self.number, &mut self._bitfield)
     }
     pub fn label(&self) -> self::_root::google::protobuf::field_descriptor_proto::Label {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             self::_root::google::protobuf::field_descriptor_proto::Label,
             self::_pinternal::tags::Enum2::<
                 self::_root::google::protobuf::field_descriptor_proto::Label,
@@ -1840,8 +1840,8 @@ impl FieldDescriptorProto {
     ) -> ::std::option::Option::<
         self::_root::google::protobuf::field_descriptor_proto::Label,
     > {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             self::_root::google::protobuf::field_descriptor_proto::Label,
             self::_pinternal::tags::Enum2::<
                 self::_root::google::protobuf::field_descriptor_proto::Label,
@@ -1852,8 +1852,8 @@ impl FieldDescriptorProto {
     pub fn label_mut(
         &mut self,
     ) -> &mut self::_root::google::protobuf::field_descriptor_proto::Label {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             self::_root::google::protobuf::field_descriptor_proto::Label,
             self::_pinternal::tags::Enum2::<
                 self::_root::google::protobuf::field_descriptor_proto::Label,
@@ -1866,8 +1866,8 @@ impl FieldDescriptorProto {
         )
     }
     pub fn has_label(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             self::_root::google::protobuf::field_descriptor_proto::Label,
             self::_pinternal::tags::Enum2::<
                 self::_root::google::protobuf::field_descriptor_proto::Label,
@@ -1877,8 +1877,8 @@ impl FieldDescriptorProto {
             .is_some()
     }
     pub fn clear_label(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             self::_root::google::protobuf::field_descriptor_proto::Label,
             self::_pinternal::tags::Enum2::<
                 self::_root::google::protobuf::field_descriptor_proto::Label,
@@ -1887,8 +1887,8 @@ impl FieldDescriptorProto {
         > as NonRepeatedFieldType>::clear(&mut self.label, &mut self._bitfield)
     }
     pub fn r#type(&self) -> self::_root::google::protobuf::field_descriptor_proto::Type {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             self::_root::google::protobuf::field_descriptor_proto::Type,
             self::_pinternal::tags::Enum2::<
                 self::_root::google::protobuf::field_descriptor_proto::Type,
@@ -1905,8 +1905,8 @@ impl FieldDescriptorProto {
     ) -> ::std::option::Option::<
         self::_root::google::protobuf::field_descriptor_proto::Type,
     > {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             self::_root::google::protobuf::field_descriptor_proto::Type,
             self::_pinternal::tags::Enum2::<
                 self::_root::google::protobuf::field_descriptor_proto::Type,
@@ -1917,8 +1917,8 @@ impl FieldDescriptorProto {
     pub fn type_mut(
         &mut self,
     ) -> &mut self::_root::google::protobuf::field_descriptor_proto::Type {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             self::_root::google::protobuf::field_descriptor_proto::Type,
             self::_pinternal::tags::Enum2::<
                 self::_root::google::protobuf::field_descriptor_proto::Type,
@@ -1931,8 +1931,8 @@ impl FieldDescriptorProto {
         )
     }
     pub fn has_type(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             self::_root::google::protobuf::field_descriptor_proto::Type,
             self::_pinternal::tags::Enum2::<
                 self::_root::google::protobuf::field_descriptor_proto::Type,
@@ -1942,8 +1942,8 @@ impl FieldDescriptorProto {
             .is_some()
     }
     pub fn clear_type(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             self::_root::google::protobuf::field_descriptor_proto::Type,
             self::_pinternal::tags::Enum2::<
                 self::_root::google::protobuf::field_descriptor_proto::Type,
@@ -1952,8 +1952,8 @@ impl FieldDescriptorProto {
         > as NonRepeatedFieldType>::clear(&mut self.r#type, &mut self._bitfield)
     }
     pub fn type_name(&self) -> &str {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             4usize,
@@ -1964,16 +1964,16 @@ impl FieldDescriptorProto {
         )
     }
     pub fn type_name_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             4usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.type_name, &self._bitfield)
     }
     pub fn type_name_mut(&mut self) -> &mut ::std::string::String {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             4usize,
@@ -1984,8 +1984,8 @@ impl FieldDescriptorProto {
         )
     }
     pub fn has_type_name(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             4usize,
@@ -1993,16 +1993,16 @@ impl FieldDescriptorProto {
             .is_some()
     }
     pub fn clear_type_name(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             4usize,
         > as NonRepeatedFieldType>::clear(&mut self.type_name, &mut self._bitfield)
     }
     pub fn extendee(&self) -> &str {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             5usize,
@@ -2013,16 +2013,16 @@ impl FieldDescriptorProto {
         )
     }
     pub fn extendee_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             5usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.extendee, &self._bitfield)
     }
     pub fn extendee_mut(&mut self) -> &mut ::std::string::String {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             5usize,
@@ -2033,8 +2033,8 @@ impl FieldDescriptorProto {
         )
     }
     pub fn has_extendee(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             5usize,
@@ -2042,16 +2042,16 @@ impl FieldDescriptorProto {
             .is_some()
     }
     pub fn clear_extendee(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             5usize,
         > as NonRepeatedFieldType>::clear(&mut self.extendee, &mut self._bitfield)
     }
     pub fn default_value(&self) -> &str {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             6usize,
@@ -2062,16 +2062,16 @@ impl FieldDescriptorProto {
         )
     }
     pub fn default_value_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             6usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.default_value, &self._bitfield)
     }
     pub fn default_value_mut(&mut self) -> &mut ::std::string::String {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             6usize,
@@ -2082,8 +2082,8 @@ impl FieldDescriptorProto {
         )
     }
     pub fn has_default_value(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             6usize,
@@ -2091,16 +2091,16 @@ impl FieldDescriptorProto {
             .is_some()
     }
     pub fn clear_default_value(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             6usize,
         > as NonRepeatedFieldType>::clear(&mut self.default_value, &mut self._bitfield)
     }
     pub fn oneof_index(&self) -> i32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             7usize,
@@ -2111,16 +2111,16 @@ impl FieldDescriptorProto {
         )
     }
     pub fn oneof_index_opt(&self) -> ::std::option::Option::<i32> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             7usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.oneof_index, &self._bitfield)
     }
     pub fn oneof_index_mut(&mut self) -> &mut i32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             7usize,
@@ -2131,8 +2131,8 @@ impl FieldDescriptorProto {
         )
     }
     pub fn has_oneof_index(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             7usize,
@@ -2140,16 +2140,16 @@ impl FieldDescriptorProto {
             .is_some()
     }
     pub fn clear_oneof_index(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             7usize,
         > as NonRepeatedFieldType>::clear(&mut self.oneof_index, &mut self._bitfield)
     }
     pub fn json_name(&self) -> &str {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             8usize,
@@ -2160,16 +2160,16 @@ impl FieldDescriptorProto {
         )
     }
     pub fn json_name_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             8usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.json_name, &self._bitfield)
     }
     pub fn json_name_mut(&mut self) -> &mut ::std::string::String {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             8usize,
@@ -2180,8 +2180,8 @@ impl FieldDescriptorProto {
         )
     }
     pub fn has_json_name(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             8usize,
@@ -2189,8 +2189,8 @@ impl FieldDescriptorProto {
             .is_some()
     }
     pub fn clear_json_name(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             8usize,
@@ -2199,8 +2199,8 @@ impl FieldDescriptorProto {
     pub fn options(
         &self,
     ) -> ::std::option::Option::<&self::_root::google::protobuf::FieldOptions> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::google::protobuf::FieldOptions,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.options,
@@ -2211,14 +2211,14 @@ impl FieldDescriptorProto {
     pub fn options_opt(
         &self,
     ) -> ::std::option::Option::<&self::_root::google::protobuf::FieldOptions> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::google::protobuf::FieldOptions,
         > as NonRepeatedFieldType>::get_field_opt(&self.options, &self._bitfield)
     }
     pub fn options_mut(&mut self) -> &mut self::_root::google::protobuf::FieldOptions {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::google::protobuf::FieldOptions,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.options,
@@ -2227,21 +2227,21 @@ impl FieldDescriptorProto {
         )
     }
     pub fn has_options(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::google::protobuf::FieldOptions,
         > as NonRepeatedFieldType>::get_field_opt(&self.options, &self._bitfield)
             .is_some()
     }
     pub fn clear_options(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::google::protobuf::FieldOptions,
         > as NonRepeatedFieldType>::clear(&mut self.options, &mut self._bitfield)
     }
     pub fn proto3_optional(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             9usize,
@@ -2252,16 +2252,16 @@ impl FieldDescriptorProto {
         )
     }
     pub fn proto3_optional_opt(&self) -> ::std::option::Option::<bool> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             9usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.proto3_optional, &self._bitfield)
     }
     pub fn proto3_optional_mut(&mut self) -> &mut bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             9usize,
@@ -2272,8 +2272,8 @@ impl FieldDescriptorProto {
         )
     }
     pub fn has_proto3_optional(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             9usize,
@@ -2281,8 +2281,8 @@ impl FieldDescriptorProto {
             .is_some()
     }
     pub fn clear_proto3_optional(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             9usize,
@@ -2303,128 +2303,128 @@ impl self::_puroro::Message for FieldDescriptorProto {
     ) -> self::_puroro::Result<()> {
         use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 1i32 => {
-                    <self::_pinternal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::OptionalUnsizedField::<
                         ::std::string::String,
                         self::_pinternal::tags::String,
                         0usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.name,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 3i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         i32,
                         self::_pinternal::tags::Int32,
                         1usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.number,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 4i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         self::_root::google::protobuf::field_descriptor_proto::Label,
                         self::_pinternal::tags::Enum2::<
                             self::_root::google::protobuf::field_descriptor_proto::Label,
                         >,
                         2usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.label,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 5i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         self::_root::google::protobuf::field_descriptor_proto::Type,
                         self::_pinternal::tags::Enum2::<
                             self::_root::google::protobuf::field_descriptor_proto::Type,
                         >,
                         3usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.r#type,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 6i32 => {
-                    <self::_pinternal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::OptionalUnsizedField::<
                         ::std::string::String,
                         self::_pinternal::tags::String,
                         4usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.type_name,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 2i32 => {
-                    <self::_pinternal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::OptionalUnsizedField::<
                         ::std::string::String,
                         self::_pinternal::tags::String,
                         5usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.extendee,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 7i32 => {
-                    <self::_pinternal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::OptionalUnsizedField::<
                         ::std::string::String,
                         self::_pinternal::tags::String,
                         6usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.default_value,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 9i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         i32,
                         self::_pinternal::tags::Int32,
                         7usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.oneof_index,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 10i32 => {
-                    <self::_pinternal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::OptionalUnsizedField::<
                         ::std::string::String,
                         self::_pinternal::tags::String,
                         8usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.json_name,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 8i32 => {
-                    <self::_pinternal::field_type::SingularHeapMessageField::<
+                    <self::_pinternal::SingularHeapMessageField::<
                         self::_root::google::protobuf::FieldOptions,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.options,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 17i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         bool,
                         self::_pinternal::tags::Bool,
                         9usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.proto3_optional,
                         &mut self._bitfield,
                         field_data,
@@ -2441,114 +2441,114 @@ impl self::_puroro::Message for FieldDescriptorProto {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::OneofUnion as _;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.name,
             &self._bitfield,
             1i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             1usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.number,
             &self._bitfield,
             3i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        <self::_pinternal::OptionalNumericalField::<
             self::_root::google::protobuf::field_descriptor_proto::Label,
             self::_pinternal::tags::Enum2::<
                 self::_root::google::protobuf::field_descriptor_proto::Label,
             >,
             2usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.label,
             &self._bitfield,
             4i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        <self::_pinternal::OptionalNumericalField::<
             self::_root::google::protobuf::field_descriptor_proto::Type,
             self::_pinternal::tags::Enum2::<
                 self::_root::google::protobuf::field_descriptor_proto::Type,
             >,
             3usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.r#type,
             &self._bitfield,
             5i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             4usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.type_name,
             &self._bitfield,
             6i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             5usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.extendee,
             &self._bitfield,
             2i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             6usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.default_value,
             &self._bitfield,
             7i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             7usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.oneof_index,
             &self._bitfield,
             9i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             8usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.json_name,
             &self._bitfield,
             10i32,
             out,
         )?;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::google::protobuf::FieldOptions,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.options,
             &self._bitfield,
             8i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             9usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.proto3_optional,
             &self._bitfield,
             17i32,
@@ -2560,59 +2560,59 @@ impl self::_puroro::Message for FieldDescriptorProto {
 impl ::std::clone::Clone for FieldDescriptorProto {
     fn clone(&self) -> Self {
         Self {
-            name: <self::_pinternal::field_type::OptionalUnsizedField::<
+            name: <self::_pinternal::OptionalUnsizedField::<
                 ::std::string::String,
                 self::_pinternal::tags::String,
                 0usize,
             > as ::std::clone::Clone>::clone(&self.name),
-            number: <self::_pinternal::field_type::OptionalNumericalField::<
+            number: <self::_pinternal::OptionalNumericalField::<
                 i32,
                 self::_pinternal::tags::Int32,
                 1usize,
             > as ::std::clone::Clone>::clone(&self.number),
-            label: <self::_pinternal::field_type::OptionalNumericalField::<
+            label: <self::_pinternal::OptionalNumericalField::<
                 self::_root::google::protobuf::field_descriptor_proto::Label,
                 self::_pinternal::tags::Enum2::<
                     self::_root::google::protobuf::field_descriptor_proto::Label,
                 >,
                 2usize,
             > as ::std::clone::Clone>::clone(&self.label),
-            r#type: <self::_pinternal::field_type::OptionalNumericalField::<
+            r#type: <self::_pinternal::OptionalNumericalField::<
                 self::_root::google::protobuf::field_descriptor_proto::Type,
                 self::_pinternal::tags::Enum2::<
                     self::_root::google::protobuf::field_descriptor_proto::Type,
                 >,
                 3usize,
             > as ::std::clone::Clone>::clone(&self.r#type),
-            type_name: <self::_pinternal::field_type::OptionalUnsizedField::<
+            type_name: <self::_pinternal::OptionalUnsizedField::<
                 ::std::string::String,
                 self::_pinternal::tags::String,
                 4usize,
             > as ::std::clone::Clone>::clone(&self.type_name),
-            extendee: <self::_pinternal::field_type::OptionalUnsizedField::<
+            extendee: <self::_pinternal::OptionalUnsizedField::<
                 ::std::string::String,
                 self::_pinternal::tags::String,
                 5usize,
             > as ::std::clone::Clone>::clone(&self.extendee),
-            default_value: <self::_pinternal::field_type::OptionalUnsizedField::<
+            default_value: <self::_pinternal::OptionalUnsizedField::<
                 ::std::string::String,
                 self::_pinternal::tags::String,
                 6usize,
             > as ::std::clone::Clone>::clone(&self.default_value),
-            oneof_index: <self::_pinternal::field_type::OptionalNumericalField::<
+            oneof_index: <self::_pinternal::OptionalNumericalField::<
                 i32,
                 self::_pinternal::tags::Int32,
                 7usize,
             > as ::std::clone::Clone>::clone(&self.oneof_index),
-            json_name: <self::_pinternal::field_type::OptionalUnsizedField::<
+            json_name: <self::_pinternal::OptionalUnsizedField::<
                 ::std::string::String,
                 self::_pinternal::tags::String,
                 8usize,
             > as ::std::clone::Clone>::clone(&self.json_name),
-            options: <self::_pinternal::field_type::SingularHeapMessageField::<
+            options: <self::_pinternal::SingularHeapMessageField::<
                 self::_root::google::protobuf::FieldOptions,
             > as ::std::clone::Clone>::clone(&self.options),
-            proto3_optional: <self::_pinternal::field_type::OptionalNumericalField::<
+            proto3_optional: <self::_pinternal::OptionalNumericalField::<
                 bool,
                 self::_pinternal::tags::Bool,
                 9usize,
@@ -2624,7 +2624,7 @@ impl ::std::clone::Clone for FieldDescriptorProto {
 impl ::std::ops::Drop for FieldDescriptorProto {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for FieldDescriptorProto {
@@ -2650,7 +2650,7 @@ impl ::std::fmt::Debug for FieldDescriptorProto {
 impl ::std::cmp::PartialEq for FieldDescriptorProto {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         true && self.name_opt() == rhs.name_opt()
             && self.number_opt() == rhs.number_opt()
             && self.label_opt() == rhs.label_opt() && self.type_opt() == rhs.type_opt()
@@ -2665,20 +2665,20 @@ impl ::std::cmp::PartialEq for FieldDescriptorProto {
 }
 #[derive(::std::default::Default)]
 pub struct OneofDescriptorProto {
-    name: self::_pinternal::field_type::OptionalUnsizedField::<
+    name: self::_pinternal::OptionalUnsizedField::<
         ::std::string::String,
         self::_pinternal::tags::String,
         0usize,
     >,
-    options: self::_pinternal::field_type::SingularHeapMessageField::<
+    options: self::_pinternal::SingularHeapMessageField::<
         self::_root::google::protobuf::OneofOptions,
     >,
-    _bitfield: self::_pinternal::bitvec::BitArray<1usize>,
+    _bitfield: self::_pinternal::BitArray<1usize>,
 }
 impl OneofDescriptorProto {
     pub fn name(&self) -> &str {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
@@ -2689,16 +2689,16 @@ impl OneofDescriptorProto {
         )
     }
     pub fn name_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.name, &self._bitfield)
     }
     pub fn name_mut(&mut self) -> &mut ::std::string::String {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
@@ -2709,8 +2709,8 @@ impl OneofDescriptorProto {
         )
     }
     pub fn has_name(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
@@ -2718,8 +2718,8 @@ impl OneofDescriptorProto {
             .is_some()
     }
     pub fn clear_name(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
@@ -2728,8 +2728,8 @@ impl OneofDescriptorProto {
     pub fn options(
         &self,
     ) -> ::std::option::Option::<&self::_root::google::protobuf::OneofOptions> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::google::protobuf::OneofOptions,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.options,
@@ -2740,14 +2740,14 @@ impl OneofDescriptorProto {
     pub fn options_opt(
         &self,
     ) -> ::std::option::Option::<&self::_root::google::protobuf::OneofOptions> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::google::protobuf::OneofOptions,
         > as NonRepeatedFieldType>::get_field_opt(&self.options, &self._bitfield)
     }
     pub fn options_mut(&mut self) -> &mut self::_root::google::protobuf::OneofOptions {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::google::protobuf::OneofOptions,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.options,
@@ -2756,15 +2756,15 @@ impl OneofDescriptorProto {
         )
     }
     pub fn has_options(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::google::protobuf::OneofOptions,
         > as NonRepeatedFieldType>::get_field_opt(&self.options, &self._bitfield)
             .is_some()
     }
     pub fn clear_options(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::google::protobuf::OneofOptions,
         > as NonRepeatedFieldType>::clear(&mut self.options, &mut self._bitfield)
     }
@@ -2783,25 +2783,25 @@ impl self::_puroro::Message for OneofDescriptorProto {
     ) -> self::_puroro::Result<()> {
         use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 1i32 => {
-                    <self::_pinternal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::OptionalUnsizedField::<
                         ::std::string::String,
                         self::_pinternal::tags::String,
                         0usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.name,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 2i32 => {
-                    <self::_pinternal::field_type::SingularHeapMessageField::<
+                    <self::_pinternal::SingularHeapMessageField::<
                         self::_root::google::protobuf::OneofOptions,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.options,
                         &mut self._bitfield,
                         field_data,
@@ -2818,20 +2818,20 @@ impl self::_puroro::Message for OneofDescriptorProto {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::OneofUnion as _;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.name,
             &self._bitfield,
             1i32,
             out,
         )?;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::google::protobuf::OneofOptions,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.options,
             &self._bitfield,
             2i32,
@@ -2843,12 +2843,12 @@ impl self::_puroro::Message for OneofDescriptorProto {
 impl ::std::clone::Clone for OneofDescriptorProto {
     fn clone(&self) -> Self {
         Self {
-            name: <self::_pinternal::field_type::OptionalUnsizedField::<
+            name: <self::_pinternal::OptionalUnsizedField::<
                 ::std::string::String,
                 self::_pinternal::tags::String,
                 0usize,
             > as ::std::clone::Clone>::clone(&self.name),
-            options: <self::_pinternal::field_type::SingularHeapMessageField::<
+            options: <self::_pinternal::SingularHeapMessageField::<
                 self::_root::google::protobuf::OneofOptions,
             > as ::std::clone::Clone>::clone(&self.options),
             _bitfield: ::std::clone::Clone::clone(&self._bitfield),
@@ -2858,7 +2858,7 @@ impl ::std::clone::Clone for OneofDescriptorProto {
 impl ::std::ops::Drop for OneofDescriptorProto {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for OneofDescriptorProto {
@@ -2875,37 +2875,37 @@ impl ::std::fmt::Debug for OneofDescriptorProto {
 impl ::std::cmp::PartialEq for OneofDescriptorProto {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         true && self.name_opt() == rhs.name_opt()
             && self.options_opt() == rhs.options_opt()
     }
 }
 #[derive(::std::default::Default)]
 pub struct EnumDescriptorProto {
-    name: self::_pinternal::field_type::OptionalUnsizedField::<
+    name: self::_pinternal::OptionalUnsizedField::<
         ::std::string::String,
         self::_pinternal::tags::String,
         0usize,
     >,
-    value: self::_pinternal::field_type::RepeatedMessageField::<
+    value: self::_pinternal::RepeatedMessageField::<
         self::_root::google::protobuf::EnumValueDescriptorProto,
     >,
-    options: self::_pinternal::field_type::SingularHeapMessageField::<
+    options: self::_pinternal::SingularHeapMessageField::<
         self::_root::google::protobuf::EnumOptions,
     >,
-    reserved_range: self::_pinternal::field_type::RepeatedMessageField::<
+    reserved_range: self::_pinternal::RepeatedMessageField::<
         self::_root::google::protobuf::enum_descriptor_proto::EnumReservedRange,
     >,
-    reserved_name: self::_pinternal::field_type::RepeatedUnsizedField::<
+    reserved_name: self::_pinternal::RepeatedUnsizedField::<
         ::std::string::String,
         self::_pinternal::tags::String,
     >,
-    _bitfield: self::_pinternal::bitvec::BitArray<1usize>,
+    _bitfield: self::_pinternal::BitArray<1usize>,
 }
 impl EnumDescriptorProto {
     pub fn name(&self) -> &str {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
@@ -2916,16 +2916,16 @@ impl EnumDescriptorProto {
         )
     }
     pub fn name_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.name, &self._bitfield)
     }
     pub fn name_mut(&mut self) -> &mut ::std::string::String {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
@@ -2936,8 +2936,8 @@ impl EnumDescriptorProto {
         )
     }
     pub fn has_name(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
@@ -2945,16 +2945,16 @@ impl EnumDescriptorProto {
             .is_some()
     }
     pub fn clear_name(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::clear(&mut self.name, &mut self._bitfield)
     }
     pub fn value(&self) -> &[self::_root::google::protobuf::EnumValueDescriptorProto] {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::EnumValueDescriptorProto,
         > as RepeatedFieldType>::get_field(&self.value, &self._bitfield)
     }
@@ -2963,22 +2963,22 @@ impl EnumDescriptorProto {
     ) -> &mut ::std::vec::Vec::<
         self::_root::google::protobuf::EnumValueDescriptorProto,
     > {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::EnumValueDescriptorProto,
         > as RepeatedFieldType>::get_field_mut(&mut self.value, &mut self._bitfield)
     }
     pub fn clear_value(&mut self) {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::EnumValueDescriptorProto,
         > as RepeatedFieldType>::clear(&mut self.value, &mut self._bitfield)
     }
     pub fn options(
         &self,
     ) -> ::std::option::Option::<&self::_root::google::protobuf::EnumOptions> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::google::protobuf::EnumOptions,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.options,
@@ -2989,14 +2989,14 @@ impl EnumDescriptorProto {
     pub fn options_opt(
         &self,
     ) -> ::std::option::Option::<&self::_root::google::protobuf::EnumOptions> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::google::protobuf::EnumOptions,
         > as NonRepeatedFieldType>::get_field_opt(&self.options, &self._bitfield)
     }
     pub fn options_mut(&mut self) -> &mut self::_root::google::protobuf::EnumOptions {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::google::protobuf::EnumOptions,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.options,
@@ -3005,23 +3005,23 @@ impl EnumDescriptorProto {
         )
     }
     pub fn has_options(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::google::protobuf::EnumOptions,
         > as NonRepeatedFieldType>::get_field_opt(&self.options, &self._bitfield)
             .is_some()
     }
     pub fn clear_options(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::google::protobuf::EnumOptions,
         > as NonRepeatedFieldType>::clear(&mut self.options, &mut self._bitfield)
     }
     pub fn reserved_range(
         &self,
     ) -> &[self::_root::google::protobuf::enum_descriptor_proto::EnumReservedRange] {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::enum_descriptor_proto::EnumReservedRange,
         > as RepeatedFieldType>::get_field(&self.reserved_range, &self._bitfield)
     }
@@ -3030,8 +3030,8 @@ impl EnumDescriptorProto {
     ) -> &mut ::std::vec::Vec::<
         self::_root::google::protobuf::enum_descriptor_proto::EnumReservedRange,
     > {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::enum_descriptor_proto::EnumReservedRange,
         > as RepeatedFieldType>::get_field_mut(
             &mut self.reserved_range,
@@ -3039,8 +3039,8 @@ impl EnumDescriptorProto {
         )
     }
     pub fn clear_reserved_range(&mut self) {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::enum_descriptor_proto::EnumReservedRange,
         > as RepeatedFieldType>::clear(&mut self.reserved_range, &mut self._bitfield)
     }
@@ -3049,8 +3049,8 @@ impl EnumDescriptorProto {
     ) -> &[impl ::std::ops::Deref::<
         Target = str,
     > + ::std::fmt::Debug + ::std::cmp::PartialEq] {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedUnsizedField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
         > as RepeatedFieldType>::get_field(&self.reserved_name, &self._bitfield)
@@ -3058,8 +3058,8 @@ impl EnumDescriptorProto {
     pub fn reserved_name_mut(
         &mut self,
     ) -> &mut ::std::vec::Vec::<::std::string::String> {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedUnsizedField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
         > as RepeatedFieldType>::get_field_mut(
@@ -3068,8 +3068,8 @@ impl EnumDescriptorProto {
         )
     }
     pub fn clear_reserved_name(&mut self) {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedUnsizedField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
         > as RepeatedFieldType>::clear(&mut self.reserved_name, &mut self._bitfield)
@@ -3089,53 +3089,53 @@ impl self::_puroro::Message for EnumDescriptorProto {
     ) -> self::_puroro::Result<()> {
         use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 1i32 => {
-                    <self::_pinternal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::OptionalUnsizedField::<
                         ::std::string::String,
                         self::_pinternal::tags::String,
                         0usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.name,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 2i32 => {
-                    <self::_pinternal::field_type::RepeatedMessageField::<
+                    <self::_pinternal::RepeatedMessageField::<
                         self::_root::google::protobuf::EnumValueDescriptorProto,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.value,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 3i32 => {
-                    <self::_pinternal::field_type::SingularHeapMessageField::<
+                    <self::_pinternal::SingularHeapMessageField::<
                         self::_root::google::protobuf::EnumOptions,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.options,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 4i32 => {
-                    <self::_pinternal::field_type::RepeatedMessageField::<
+                    <self::_pinternal::RepeatedMessageField::<
                         self::_root::google::protobuf::enum_descriptor_proto::EnumReservedRange,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.reserved_range,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 5i32 => {
-                    <self::_pinternal::field_type::RepeatedUnsizedField::<
+                    <self::_pinternal::RepeatedUnsizedField::<
                         ::std::string::String,
                         self::_pinternal::tags::String,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.reserved_name,
                         &mut self._bitfield,
                         field_data,
@@ -3152,45 +3152,45 @@ impl self::_puroro::Message for EnumDescriptorProto {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::OneofUnion as _;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.name,
             &self._bitfield,
             1i32,
             out,
         )?;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::EnumValueDescriptorProto,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.value,
             &self._bitfield,
             2i32,
             out,
         )?;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::google::protobuf::EnumOptions,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.options,
             &self._bitfield,
             3i32,
             out,
         )?;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::enum_descriptor_proto::EnumReservedRange,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.reserved_range,
             &self._bitfield,
             4i32,
             out,
         )?;
-        <self::_pinternal::field_type::RepeatedUnsizedField::<
+        <self::_pinternal::RepeatedUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.reserved_name,
             &self._bitfield,
             5i32,
@@ -3202,21 +3202,21 @@ impl self::_puroro::Message for EnumDescriptorProto {
 impl ::std::clone::Clone for EnumDescriptorProto {
     fn clone(&self) -> Self {
         Self {
-            name: <self::_pinternal::field_type::OptionalUnsizedField::<
+            name: <self::_pinternal::OptionalUnsizedField::<
                 ::std::string::String,
                 self::_pinternal::tags::String,
                 0usize,
             > as ::std::clone::Clone>::clone(&self.name),
-            value: <self::_pinternal::field_type::RepeatedMessageField::<
+            value: <self::_pinternal::RepeatedMessageField::<
                 self::_root::google::protobuf::EnumValueDescriptorProto,
             > as ::std::clone::Clone>::clone(&self.value),
-            options: <self::_pinternal::field_type::SingularHeapMessageField::<
+            options: <self::_pinternal::SingularHeapMessageField::<
                 self::_root::google::protobuf::EnumOptions,
             > as ::std::clone::Clone>::clone(&self.options),
-            reserved_range: <self::_pinternal::field_type::RepeatedMessageField::<
+            reserved_range: <self::_pinternal::RepeatedMessageField::<
                 self::_root::google::protobuf::enum_descriptor_proto::EnumReservedRange,
             > as ::std::clone::Clone>::clone(&self.reserved_range),
-            reserved_name: <self::_pinternal::field_type::RepeatedUnsizedField::<
+            reserved_name: <self::_pinternal::RepeatedUnsizedField::<
                 ::std::string::String,
                 self::_pinternal::tags::String,
             > as ::std::clone::Clone>::clone(&self.reserved_name),
@@ -3227,7 +3227,7 @@ impl ::std::clone::Clone for EnumDescriptorProto {
 impl ::std::ops::Drop for EnumDescriptorProto {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for EnumDescriptorProto {
@@ -3247,7 +3247,7 @@ impl ::std::fmt::Debug for EnumDescriptorProto {
 impl ::std::cmp::PartialEq for EnumDescriptorProto {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         true && self.name_opt() == rhs.name_opt() && self.value() == rhs.value()
             && self.options_opt() == rhs.options_opt()
             && self.reserved_range() == rhs.reserved_range()
@@ -3256,25 +3256,25 @@ impl ::std::cmp::PartialEq for EnumDescriptorProto {
 }
 #[derive(::std::default::Default)]
 pub struct EnumValueDescriptorProto {
-    name: self::_pinternal::field_type::OptionalUnsizedField::<
+    name: self::_pinternal::OptionalUnsizedField::<
         ::std::string::String,
         self::_pinternal::tags::String,
         0usize,
     >,
-    number: self::_pinternal::field_type::OptionalNumericalField::<
+    number: self::_pinternal::OptionalNumericalField::<
         i32,
         self::_pinternal::tags::Int32,
         1usize,
     >,
-    options: self::_pinternal::field_type::SingularHeapMessageField::<
+    options: self::_pinternal::SingularHeapMessageField::<
         self::_root::google::protobuf::EnumValueOptions,
     >,
-    _bitfield: self::_pinternal::bitvec::BitArray<1usize>,
+    _bitfield: self::_pinternal::BitArray<1usize>,
 }
 impl EnumValueDescriptorProto {
     pub fn name(&self) -> &str {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
@@ -3285,16 +3285,16 @@ impl EnumValueDescriptorProto {
         )
     }
     pub fn name_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.name, &self._bitfield)
     }
     pub fn name_mut(&mut self) -> &mut ::std::string::String {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
@@ -3305,8 +3305,8 @@ impl EnumValueDescriptorProto {
         )
     }
     pub fn has_name(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
@@ -3314,16 +3314,16 @@ impl EnumValueDescriptorProto {
             .is_some()
     }
     pub fn clear_name(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::clear(&mut self.name, &mut self._bitfield)
     }
     pub fn number(&self) -> i32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             1usize,
@@ -3334,16 +3334,16 @@ impl EnumValueDescriptorProto {
         )
     }
     pub fn number_opt(&self) -> ::std::option::Option::<i32> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             1usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.number, &self._bitfield)
     }
     pub fn number_mut(&mut self) -> &mut i32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             1usize,
@@ -3354,8 +3354,8 @@ impl EnumValueDescriptorProto {
         )
     }
     pub fn has_number(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             1usize,
@@ -3363,8 +3363,8 @@ impl EnumValueDescriptorProto {
             .is_some()
     }
     pub fn clear_number(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             1usize,
@@ -3373,8 +3373,8 @@ impl EnumValueDescriptorProto {
     pub fn options(
         &self,
     ) -> ::std::option::Option::<&self::_root::google::protobuf::EnumValueOptions> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::google::protobuf::EnumValueOptions,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.options,
@@ -3385,16 +3385,16 @@ impl EnumValueDescriptorProto {
     pub fn options_opt(
         &self,
     ) -> ::std::option::Option::<&self::_root::google::protobuf::EnumValueOptions> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::google::protobuf::EnumValueOptions,
         > as NonRepeatedFieldType>::get_field_opt(&self.options, &self._bitfield)
     }
     pub fn options_mut(
         &mut self,
     ) -> &mut self::_root::google::protobuf::EnumValueOptions {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::google::protobuf::EnumValueOptions,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.options,
@@ -3403,15 +3403,15 @@ impl EnumValueDescriptorProto {
         )
     }
     pub fn has_options(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::google::protobuf::EnumValueOptions,
         > as NonRepeatedFieldType>::get_field_opt(&self.options, &self._bitfield)
             .is_some()
     }
     pub fn clear_options(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::google::protobuf::EnumValueOptions,
         > as NonRepeatedFieldType>::clear(&mut self.options, &mut self._bitfield)
     }
@@ -3430,36 +3430,36 @@ impl self::_puroro::Message for EnumValueDescriptorProto {
     ) -> self::_puroro::Result<()> {
         use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 1i32 => {
-                    <self::_pinternal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::OptionalUnsizedField::<
                         ::std::string::String,
                         self::_pinternal::tags::String,
                         0usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.name,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 2i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         i32,
                         self::_pinternal::tags::Int32,
                         1usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.number,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 3i32 => {
-                    <self::_pinternal::field_type::SingularHeapMessageField::<
+                    <self::_pinternal::SingularHeapMessageField::<
                         self::_root::google::protobuf::EnumValueOptions,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.options,
                         &mut self._bitfield,
                         field_data,
@@ -3476,30 +3476,30 @@ impl self::_puroro::Message for EnumValueDescriptorProto {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::OneofUnion as _;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.name,
             &self._bitfield,
             1i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             1usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.number,
             &self._bitfield,
             2i32,
             out,
         )?;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::google::protobuf::EnumValueOptions,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.options,
             &self._bitfield,
             3i32,
@@ -3511,17 +3511,17 @@ impl self::_puroro::Message for EnumValueDescriptorProto {
 impl ::std::clone::Clone for EnumValueDescriptorProto {
     fn clone(&self) -> Self {
         Self {
-            name: <self::_pinternal::field_type::OptionalUnsizedField::<
+            name: <self::_pinternal::OptionalUnsizedField::<
                 ::std::string::String,
                 self::_pinternal::tags::String,
                 0usize,
             > as ::std::clone::Clone>::clone(&self.name),
-            number: <self::_pinternal::field_type::OptionalNumericalField::<
+            number: <self::_pinternal::OptionalNumericalField::<
                 i32,
                 self::_pinternal::tags::Int32,
                 1usize,
             > as ::std::clone::Clone>::clone(&self.number),
-            options: <self::_pinternal::field_type::SingularHeapMessageField::<
+            options: <self::_pinternal::SingularHeapMessageField::<
                 self::_root::google::protobuf::EnumValueOptions,
             > as ::std::clone::Clone>::clone(&self.options),
             _bitfield: ::std::clone::Clone::clone(&self._bitfield),
@@ -3531,7 +3531,7 @@ impl ::std::clone::Clone for EnumValueDescriptorProto {
 impl ::std::ops::Drop for EnumValueDescriptorProto {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for EnumValueDescriptorProto {
@@ -3549,7 +3549,7 @@ impl ::std::fmt::Debug for EnumValueDescriptorProto {
 impl ::std::cmp::PartialEq for EnumValueDescriptorProto {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         true && self.name_opt() == rhs.name_opt()
             && self.number_opt() == rhs.number_opt()
             && self.options_opt() == rhs.options_opt()
@@ -3557,23 +3557,23 @@ impl ::std::cmp::PartialEq for EnumValueDescriptorProto {
 }
 #[derive(::std::default::Default)]
 pub struct ServiceDescriptorProto {
-    name: self::_pinternal::field_type::OptionalUnsizedField::<
+    name: self::_pinternal::OptionalUnsizedField::<
         ::std::string::String,
         self::_pinternal::tags::String,
         0usize,
     >,
-    method: self::_pinternal::field_type::RepeatedMessageField::<
+    method: self::_pinternal::RepeatedMessageField::<
         self::_root::google::protobuf::MethodDescriptorProto,
     >,
-    options: self::_pinternal::field_type::SingularHeapMessageField::<
+    options: self::_pinternal::SingularHeapMessageField::<
         self::_root::google::protobuf::ServiceOptions,
     >,
-    _bitfield: self::_pinternal::bitvec::BitArray<1usize>,
+    _bitfield: self::_pinternal::BitArray<1usize>,
 }
 impl ServiceDescriptorProto {
     pub fn name(&self) -> &str {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
@@ -3584,16 +3584,16 @@ impl ServiceDescriptorProto {
         )
     }
     pub fn name_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.name, &self._bitfield)
     }
     pub fn name_mut(&mut self) -> &mut ::std::string::String {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
@@ -3604,8 +3604,8 @@ impl ServiceDescriptorProto {
         )
     }
     pub fn has_name(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
@@ -3613,38 +3613,38 @@ impl ServiceDescriptorProto {
             .is_some()
     }
     pub fn clear_name(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::clear(&mut self.name, &mut self._bitfield)
     }
     pub fn method(&self) -> &[self::_root::google::protobuf::MethodDescriptorProto] {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::MethodDescriptorProto,
         > as RepeatedFieldType>::get_field(&self.method, &self._bitfield)
     }
     pub fn method_mut(
         &mut self,
     ) -> &mut ::std::vec::Vec::<self::_root::google::protobuf::MethodDescriptorProto> {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::MethodDescriptorProto,
         > as RepeatedFieldType>::get_field_mut(&mut self.method, &mut self._bitfield)
     }
     pub fn clear_method(&mut self) {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::MethodDescriptorProto,
         > as RepeatedFieldType>::clear(&mut self.method, &mut self._bitfield)
     }
     pub fn options(
         &self,
     ) -> ::std::option::Option::<&self::_root::google::protobuf::ServiceOptions> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::google::protobuf::ServiceOptions,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.options,
@@ -3655,14 +3655,14 @@ impl ServiceDescriptorProto {
     pub fn options_opt(
         &self,
     ) -> ::std::option::Option::<&self::_root::google::protobuf::ServiceOptions> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::google::protobuf::ServiceOptions,
         > as NonRepeatedFieldType>::get_field_opt(&self.options, &self._bitfield)
     }
     pub fn options_mut(&mut self) -> &mut self::_root::google::protobuf::ServiceOptions {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::google::protobuf::ServiceOptions,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.options,
@@ -3671,15 +3671,15 @@ impl ServiceDescriptorProto {
         )
     }
     pub fn has_options(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::google::protobuf::ServiceOptions,
         > as NonRepeatedFieldType>::get_field_opt(&self.options, &self._bitfield)
             .is_some()
     }
     pub fn clear_options(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::google::protobuf::ServiceOptions,
         > as NonRepeatedFieldType>::clear(&mut self.options, &mut self._bitfield)
     }
@@ -3698,34 +3698,34 @@ impl self::_puroro::Message for ServiceDescriptorProto {
     ) -> self::_puroro::Result<()> {
         use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 1i32 => {
-                    <self::_pinternal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::OptionalUnsizedField::<
                         ::std::string::String,
                         self::_pinternal::tags::String,
                         0usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.name,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 2i32 => {
-                    <self::_pinternal::field_type::RepeatedMessageField::<
+                    <self::_pinternal::RepeatedMessageField::<
                         self::_root::google::protobuf::MethodDescriptorProto,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.method,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 3i32 => {
-                    <self::_pinternal::field_type::SingularHeapMessageField::<
+                    <self::_pinternal::SingularHeapMessageField::<
                         self::_root::google::protobuf::ServiceOptions,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.options,
                         &mut self._bitfield,
                         field_data,
@@ -3742,28 +3742,28 @@ impl self::_puroro::Message for ServiceDescriptorProto {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::OneofUnion as _;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.name,
             &self._bitfield,
             1i32,
             out,
         )?;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::MethodDescriptorProto,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.method,
             &self._bitfield,
             2i32,
             out,
         )?;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::google::protobuf::ServiceOptions,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.options,
             &self._bitfield,
             3i32,
@@ -3775,15 +3775,15 @@ impl self::_puroro::Message for ServiceDescriptorProto {
 impl ::std::clone::Clone for ServiceDescriptorProto {
     fn clone(&self) -> Self {
         Self {
-            name: <self::_pinternal::field_type::OptionalUnsizedField::<
+            name: <self::_pinternal::OptionalUnsizedField::<
                 ::std::string::String,
                 self::_pinternal::tags::String,
                 0usize,
             > as ::std::clone::Clone>::clone(&self.name),
-            method: <self::_pinternal::field_type::RepeatedMessageField::<
+            method: <self::_pinternal::RepeatedMessageField::<
                 self::_root::google::protobuf::MethodDescriptorProto,
             > as ::std::clone::Clone>::clone(&self.method),
-            options: <self::_pinternal::field_type::SingularHeapMessageField::<
+            options: <self::_pinternal::SingularHeapMessageField::<
                 self::_root::google::protobuf::ServiceOptions,
             > as ::std::clone::Clone>::clone(&self.options),
             _bitfield: ::std::clone::Clone::clone(&self._bitfield),
@@ -3793,7 +3793,7 @@ impl ::std::clone::Clone for ServiceDescriptorProto {
 impl ::std::ops::Drop for ServiceDescriptorProto {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for ServiceDescriptorProto {
@@ -3811,47 +3811,47 @@ impl ::std::fmt::Debug for ServiceDescriptorProto {
 impl ::std::cmp::PartialEq for ServiceDescriptorProto {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         true && self.name_opt() == rhs.name_opt() && self.method() == rhs.method()
             && self.options_opt() == rhs.options_opt()
     }
 }
 #[derive(::std::default::Default)]
 pub struct MethodDescriptorProto {
-    name: self::_pinternal::field_type::OptionalUnsizedField::<
+    name: self::_pinternal::OptionalUnsizedField::<
         ::std::string::String,
         self::_pinternal::tags::String,
         0usize,
     >,
-    input_type: self::_pinternal::field_type::OptionalUnsizedField::<
+    input_type: self::_pinternal::OptionalUnsizedField::<
         ::std::string::String,
         self::_pinternal::tags::String,
         1usize,
     >,
-    output_type: self::_pinternal::field_type::OptionalUnsizedField::<
+    output_type: self::_pinternal::OptionalUnsizedField::<
         ::std::string::String,
         self::_pinternal::tags::String,
         2usize,
     >,
-    options: self::_pinternal::field_type::SingularHeapMessageField::<
+    options: self::_pinternal::SingularHeapMessageField::<
         self::_root::google::protobuf::MethodOptions,
     >,
-    client_streaming: self::_pinternal::field_type::OptionalNumericalField::<
+    client_streaming: self::_pinternal::OptionalNumericalField::<
         bool,
         self::_pinternal::tags::Bool,
         3usize,
     >,
-    server_streaming: self::_pinternal::field_type::OptionalNumericalField::<
+    server_streaming: self::_pinternal::OptionalNumericalField::<
         bool,
         self::_pinternal::tags::Bool,
         4usize,
     >,
-    _bitfield: self::_pinternal::bitvec::BitArray<1usize>,
+    _bitfield: self::_pinternal::BitArray<1usize>,
 }
 impl MethodDescriptorProto {
     pub fn name(&self) -> &str {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
@@ -3862,16 +3862,16 @@ impl MethodDescriptorProto {
         )
     }
     pub fn name_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.name, &self._bitfield)
     }
     pub fn name_mut(&mut self) -> &mut ::std::string::String {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
@@ -3882,8 +3882,8 @@ impl MethodDescriptorProto {
         )
     }
     pub fn has_name(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
@@ -3891,16 +3891,16 @@ impl MethodDescriptorProto {
             .is_some()
     }
     pub fn clear_name(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::clear(&mut self.name, &mut self._bitfield)
     }
     pub fn input_type(&self) -> &str {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             1usize,
@@ -3911,16 +3911,16 @@ impl MethodDescriptorProto {
         )
     }
     pub fn input_type_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             1usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.input_type, &self._bitfield)
     }
     pub fn input_type_mut(&mut self) -> &mut ::std::string::String {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             1usize,
@@ -3931,8 +3931,8 @@ impl MethodDescriptorProto {
         )
     }
     pub fn has_input_type(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             1usize,
@@ -3940,16 +3940,16 @@ impl MethodDescriptorProto {
             .is_some()
     }
     pub fn clear_input_type(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             1usize,
         > as NonRepeatedFieldType>::clear(&mut self.input_type, &mut self._bitfield)
     }
     pub fn output_type(&self) -> &str {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             2usize,
@@ -3960,16 +3960,16 @@ impl MethodDescriptorProto {
         )
     }
     pub fn output_type_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             2usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.output_type, &self._bitfield)
     }
     pub fn output_type_mut(&mut self) -> &mut ::std::string::String {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             2usize,
@@ -3980,8 +3980,8 @@ impl MethodDescriptorProto {
         )
     }
     pub fn has_output_type(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             2usize,
@@ -3989,8 +3989,8 @@ impl MethodDescriptorProto {
             .is_some()
     }
     pub fn clear_output_type(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             2usize,
@@ -3999,8 +3999,8 @@ impl MethodDescriptorProto {
     pub fn options(
         &self,
     ) -> ::std::option::Option::<&self::_root::google::protobuf::MethodOptions> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::google::protobuf::MethodOptions,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.options,
@@ -4011,14 +4011,14 @@ impl MethodDescriptorProto {
     pub fn options_opt(
         &self,
     ) -> ::std::option::Option::<&self::_root::google::protobuf::MethodOptions> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::google::protobuf::MethodOptions,
         > as NonRepeatedFieldType>::get_field_opt(&self.options, &self._bitfield)
     }
     pub fn options_mut(&mut self) -> &mut self::_root::google::protobuf::MethodOptions {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::google::protobuf::MethodOptions,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.options,
@@ -4027,21 +4027,21 @@ impl MethodDescriptorProto {
         )
     }
     pub fn has_options(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::google::protobuf::MethodOptions,
         > as NonRepeatedFieldType>::get_field_opt(&self.options, &self._bitfield)
             .is_some()
     }
     pub fn clear_options(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::google::protobuf::MethodOptions,
         > as NonRepeatedFieldType>::clear(&mut self.options, &mut self._bitfield)
     }
     pub fn client_streaming(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             3usize,
@@ -4052,8 +4052,8 @@ impl MethodDescriptorProto {
         )
     }
     pub fn client_streaming_opt(&self) -> ::std::option::Option::<bool> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             3usize,
@@ -4063,8 +4063,8 @@ impl MethodDescriptorProto {
         )
     }
     pub fn client_streaming_mut(&mut self) -> &mut bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             3usize,
@@ -4075,8 +4075,8 @@ impl MethodDescriptorProto {
         )
     }
     pub fn has_client_streaming(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             3usize,
@@ -4087,8 +4087,8 @@ impl MethodDescriptorProto {
             .is_some()
     }
     pub fn clear_client_streaming(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             3usize,
@@ -4098,8 +4098,8 @@ impl MethodDescriptorProto {
         )
     }
     pub fn server_streaming(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             4usize,
@@ -4110,8 +4110,8 @@ impl MethodDescriptorProto {
         )
     }
     pub fn server_streaming_opt(&self) -> ::std::option::Option::<bool> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             4usize,
@@ -4121,8 +4121,8 @@ impl MethodDescriptorProto {
         )
     }
     pub fn server_streaming_mut(&mut self) -> &mut bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             4usize,
@@ -4133,8 +4133,8 @@ impl MethodDescriptorProto {
         )
     }
     pub fn has_server_streaming(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             4usize,
@@ -4145,8 +4145,8 @@ impl MethodDescriptorProto {
             .is_some()
     }
     pub fn clear_server_streaming(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             4usize,
@@ -4170,69 +4170,69 @@ impl self::_puroro::Message for MethodDescriptorProto {
     ) -> self::_puroro::Result<()> {
         use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 1i32 => {
-                    <self::_pinternal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::OptionalUnsizedField::<
                         ::std::string::String,
                         self::_pinternal::tags::String,
                         0usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.name,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 2i32 => {
-                    <self::_pinternal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::OptionalUnsizedField::<
                         ::std::string::String,
                         self::_pinternal::tags::String,
                         1usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.input_type,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 3i32 => {
-                    <self::_pinternal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::OptionalUnsizedField::<
                         ::std::string::String,
                         self::_pinternal::tags::String,
                         2usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.output_type,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 4i32 => {
-                    <self::_pinternal::field_type::SingularHeapMessageField::<
+                    <self::_pinternal::SingularHeapMessageField::<
                         self::_root::google::protobuf::MethodOptions,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.options,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 5i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         bool,
                         self::_pinternal::tags::Bool,
                         3usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.client_streaming,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 6i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         bool,
                         self::_pinternal::tags::Bool,
                         4usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.server_streaming,
                         &mut self._bitfield,
                         field_data,
@@ -4249,60 +4249,60 @@ impl self::_puroro::Message for MethodDescriptorProto {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::OneofUnion as _;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.name,
             &self._bitfield,
             1i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             1usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.input_type,
             &self._bitfield,
             2i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             2usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.output_type,
             &self._bitfield,
             3i32,
             out,
         )?;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::google::protobuf::MethodOptions,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.options,
             &self._bitfield,
             4i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             3usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.client_streaming,
             &self._bitfield,
             5i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             4usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.server_streaming,
             &self._bitfield,
             6i32,
@@ -4314,30 +4314,30 @@ impl self::_puroro::Message for MethodDescriptorProto {
 impl ::std::clone::Clone for MethodDescriptorProto {
     fn clone(&self) -> Self {
         Self {
-            name: <self::_pinternal::field_type::OptionalUnsizedField::<
+            name: <self::_pinternal::OptionalUnsizedField::<
                 ::std::string::String,
                 self::_pinternal::tags::String,
                 0usize,
             > as ::std::clone::Clone>::clone(&self.name),
-            input_type: <self::_pinternal::field_type::OptionalUnsizedField::<
+            input_type: <self::_pinternal::OptionalUnsizedField::<
                 ::std::string::String,
                 self::_pinternal::tags::String,
                 1usize,
             > as ::std::clone::Clone>::clone(&self.input_type),
-            output_type: <self::_pinternal::field_type::OptionalUnsizedField::<
+            output_type: <self::_pinternal::OptionalUnsizedField::<
                 ::std::string::String,
                 self::_pinternal::tags::String,
                 2usize,
             > as ::std::clone::Clone>::clone(&self.output_type),
-            options: <self::_pinternal::field_type::SingularHeapMessageField::<
+            options: <self::_pinternal::SingularHeapMessageField::<
                 self::_root::google::protobuf::MethodOptions,
             > as ::std::clone::Clone>::clone(&self.options),
-            client_streaming: <self::_pinternal::field_type::OptionalNumericalField::<
+            client_streaming: <self::_pinternal::OptionalNumericalField::<
                 bool,
                 self::_pinternal::tags::Bool,
                 3usize,
             > as ::std::clone::Clone>::clone(&self.client_streaming),
-            server_streaming: <self::_pinternal::field_type::OptionalNumericalField::<
+            server_streaming: <self::_pinternal::OptionalNumericalField::<
                 bool,
                 self::_pinternal::tags::Bool,
                 4usize,
@@ -4349,7 +4349,7 @@ impl ::std::clone::Clone for MethodDescriptorProto {
 impl ::std::ops::Drop for MethodDescriptorProto {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for MethodDescriptorProto {
@@ -4370,7 +4370,7 @@ impl ::std::fmt::Debug for MethodDescriptorProto {
 impl ::std::cmp::PartialEq for MethodDescriptorProto {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         true && self.name_opt() == rhs.name_opt()
             && self.input_type_opt() == rhs.input_type_opt()
             && self.output_type_opt() == rhs.output_type_opt()
@@ -4381,117 +4381,117 @@ impl ::std::cmp::PartialEq for MethodDescriptorProto {
 }
 #[derive(::std::default::Default)]
 pub struct FileOptions {
-    java_package: self::_pinternal::field_type::OptionalUnsizedField::<
+    java_package: self::_pinternal::OptionalUnsizedField::<
         ::std::string::String,
         self::_pinternal::tags::String,
         0usize,
     >,
-    java_outer_classname: self::_pinternal::field_type::OptionalUnsizedField::<
+    java_outer_classname: self::_pinternal::OptionalUnsizedField::<
         ::std::string::String,
         self::_pinternal::tags::String,
         1usize,
     >,
-    java_multiple_files: self::_pinternal::field_type::OptionalNumericalField::<
+    java_multiple_files: self::_pinternal::OptionalNumericalField::<
         bool,
         self::_pinternal::tags::Bool,
         2usize,
     >,
-    java_generate_equals_and_hash: self::_pinternal::field_type::OptionalNumericalField::<
+    java_generate_equals_and_hash: self::_pinternal::OptionalNumericalField::<
         bool,
         self::_pinternal::tags::Bool,
         3usize,
     >,
-    java_string_check_utf8: self::_pinternal::field_type::OptionalNumericalField::<
+    java_string_check_utf8: self::_pinternal::OptionalNumericalField::<
         bool,
         self::_pinternal::tags::Bool,
         4usize,
     >,
-    optimize_for: self::_pinternal::field_type::OptionalNumericalField::<
+    optimize_for: self::_pinternal::OptionalNumericalField::<
         self::_root::google::protobuf::file_options::OptimizeMode,
         self::_pinternal::tags::Enum2::<
             self::_root::google::protobuf::file_options::OptimizeMode,
         >,
         5usize,
     >,
-    go_package: self::_pinternal::field_type::OptionalUnsizedField::<
+    go_package: self::_pinternal::OptionalUnsizedField::<
         ::std::string::String,
         self::_pinternal::tags::String,
         6usize,
     >,
-    cc_generic_services: self::_pinternal::field_type::OptionalNumericalField::<
+    cc_generic_services: self::_pinternal::OptionalNumericalField::<
         bool,
         self::_pinternal::tags::Bool,
         7usize,
     >,
-    java_generic_services: self::_pinternal::field_type::OptionalNumericalField::<
+    java_generic_services: self::_pinternal::OptionalNumericalField::<
         bool,
         self::_pinternal::tags::Bool,
         8usize,
     >,
-    py_generic_services: self::_pinternal::field_type::OptionalNumericalField::<
+    py_generic_services: self::_pinternal::OptionalNumericalField::<
         bool,
         self::_pinternal::tags::Bool,
         9usize,
     >,
-    php_generic_services: self::_pinternal::field_type::OptionalNumericalField::<
+    php_generic_services: self::_pinternal::OptionalNumericalField::<
         bool,
         self::_pinternal::tags::Bool,
         10usize,
     >,
-    deprecated: self::_pinternal::field_type::OptionalNumericalField::<
+    deprecated: self::_pinternal::OptionalNumericalField::<
         bool,
         self::_pinternal::tags::Bool,
         11usize,
     >,
-    cc_enable_arenas: self::_pinternal::field_type::OptionalNumericalField::<
+    cc_enable_arenas: self::_pinternal::OptionalNumericalField::<
         bool,
         self::_pinternal::tags::Bool,
         12usize,
     >,
-    objc_class_prefix: self::_pinternal::field_type::OptionalUnsizedField::<
+    objc_class_prefix: self::_pinternal::OptionalUnsizedField::<
         ::std::string::String,
         self::_pinternal::tags::String,
         13usize,
     >,
-    csharp_namespace: self::_pinternal::field_type::OptionalUnsizedField::<
+    csharp_namespace: self::_pinternal::OptionalUnsizedField::<
         ::std::string::String,
         self::_pinternal::tags::String,
         14usize,
     >,
-    swift_prefix: self::_pinternal::field_type::OptionalUnsizedField::<
+    swift_prefix: self::_pinternal::OptionalUnsizedField::<
         ::std::string::String,
         self::_pinternal::tags::String,
         15usize,
     >,
-    php_class_prefix: self::_pinternal::field_type::OptionalUnsizedField::<
+    php_class_prefix: self::_pinternal::OptionalUnsizedField::<
         ::std::string::String,
         self::_pinternal::tags::String,
         16usize,
     >,
-    php_namespace: self::_pinternal::field_type::OptionalUnsizedField::<
+    php_namespace: self::_pinternal::OptionalUnsizedField::<
         ::std::string::String,
         self::_pinternal::tags::String,
         17usize,
     >,
-    php_metadata_namespace: self::_pinternal::field_type::OptionalUnsizedField::<
+    php_metadata_namespace: self::_pinternal::OptionalUnsizedField::<
         ::std::string::String,
         self::_pinternal::tags::String,
         18usize,
     >,
-    ruby_package: self::_pinternal::field_type::OptionalUnsizedField::<
+    ruby_package: self::_pinternal::OptionalUnsizedField::<
         ::std::string::String,
         self::_pinternal::tags::String,
         19usize,
     >,
-    uninterpreted_option: self::_pinternal::field_type::RepeatedMessageField::<
+    uninterpreted_option: self::_pinternal::RepeatedMessageField::<
         self::_root::google::protobuf::UninterpretedOption,
     >,
-    _bitfield: self::_pinternal::bitvec::BitArray<1usize>,
+    _bitfield: self::_pinternal::BitArray<1usize>,
 }
 impl FileOptions {
     pub fn java_package(&self) -> &str {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
@@ -4502,16 +4502,16 @@ impl FileOptions {
         )
     }
     pub fn java_package_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.java_package, &self._bitfield)
     }
     pub fn java_package_mut(&mut self) -> &mut ::std::string::String {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
@@ -4522,8 +4522,8 @@ impl FileOptions {
         )
     }
     pub fn has_java_package(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
@@ -4531,16 +4531,16 @@ impl FileOptions {
             .is_some()
     }
     pub fn clear_java_package(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::clear(&mut self.java_package, &mut self._bitfield)
     }
     pub fn java_outer_classname(&self) -> &str {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             1usize,
@@ -4551,8 +4551,8 @@ impl FileOptions {
         )
     }
     pub fn java_outer_classname_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             1usize,
@@ -4562,8 +4562,8 @@ impl FileOptions {
         )
     }
     pub fn java_outer_classname_mut(&mut self) -> &mut ::std::string::String {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             1usize,
@@ -4574,8 +4574,8 @@ impl FileOptions {
         )
     }
     pub fn has_java_outer_classname(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             1usize,
@@ -4586,8 +4586,8 @@ impl FileOptions {
             .is_some()
     }
     pub fn clear_java_outer_classname(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             1usize,
@@ -4597,8 +4597,8 @@ impl FileOptions {
         )
     }
     pub fn java_multiple_files(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             2usize,
@@ -4609,8 +4609,8 @@ impl FileOptions {
         )
     }
     pub fn java_multiple_files_opt(&self) -> ::std::option::Option::<bool> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             2usize,
@@ -4620,8 +4620,8 @@ impl FileOptions {
         )
     }
     pub fn java_multiple_files_mut(&mut self) -> &mut bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             2usize,
@@ -4632,8 +4632,8 @@ impl FileOptions {
         )
     }
     pub fn has_java_multiple_files(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             2usize,
@@ -4644,8 +4644,8 @@ impl FileOptions {
             .is_some()
     }
     pub fn clear_java_multiple_files(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             2usize,
@@ -4655,8 +4655,8 @@ impl FileOptions {
         )
     }
     pub fn java_generate_equals_and_hash(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             3usize,
@@ -4667,8 +4667,8 @@ impl FileOptions {
         )
     }
     pub fn java_generate_equals_and_hash_opt(&self) -> ::std::option::Option::<bool> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             3usize,
@@ -4678,8 +4678,8 @@ impl FileOptions {
         )
     }
     pub fn java_generate_equals_and_hash_mut(&mut self) -> &mut bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             3usize,
@@ -4690,8 +4690,8 @@ impl FileOptions {
         )
     }
     pub fn has_java_generate_equals_and_hash(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             3usize,
@@ -4702,8 +4702,8 @@ impl FileOptions {
             .is_some()
     }
     pub fn clear_java_generate_equals_and_hash(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             3usize,
@@ -4713,8 +4713,8 @@ impl FileOptions {
         )
     }
     pub fn java_string_check_utf8(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             4usize,
@@ -4725,8 +4725,8 @@ impl FileOptions {
         )
     }
     pub fn java_string_check_utf8_opt(&self) -> ::std::option::Option::<bool> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             4usize,
@@ -4736,8 +4736,8 @@ impl FileOptions {
         )
     }
     pub fn java_string_check_utf8_mut(&mut self) -> &mut bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             4usize,
@@ -4748,8 +4748,8 @@ impl FileOptions {
         )
     }
     pub fn has_java_string_check_utf8(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             4usize,
@@ -4760,8 +4760,8 @@ impl FileOptions {
             .is_some()
     }
     pub fn clear_java_string_check_utf8(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             4usize,
@@ -4773,8 +4773,8 @@ impl FileOptions {
     pub fn optimize_for(
         &self,
     ) -> self::_root::google::protobuf::file_options::OptimizeMode {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             self::_root::google::protobuf::file_options::OptimizeMode,
             self::_pinternal::tags::Enum2::<
                 self::_root::google::protobuf::file_options::OptimizeMode,
@@ -4791,8 +4791,8 @@ impl FileOptions {
     ) -> ::std::option::Option::<
         self::_root::google::protobuf::file_options::OptimizeMode,
     > {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             self::_root::google::protobuf::file_options::OptimizeMode,
             self::_pinternal::tags::Enum2::<
                 self::_root::google::protobuf::file_options::OptimizeMode,
@@ -4803,8 +4803,8 @@ impl FileOptions {
     pub fn optimize_for_mut(
         &mut self,
     ) -> &mut self::_root::google::protobuf::file_options::OptimizeMode {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             self::_root::google::protobuf::file_options::OptimizeMode,
             self::_pinternal::tags::Enum2::<
                 self::_root::google::protobuf::file_options::OptimizeMode,
@@ -4817,8 +4817,8 @@ impl FileOptions {
         )
     }
     pub fn has_optimize_for(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             self::_root::google::protobuf::file_options::OptimizeMode,
             self::_pinternal::tags::Enum2::<
                 self::_root::google::protobuf::file_options::OptimizeMode,
@@ -4828,8 +4828,8 @@ impl FileOptions {
             .is_some()
     }
     pub fn clear_optimize_for(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             self::_root::google::protobuf::file_options::OptimizeMode,
             self::_pinternal::tags::Enum2::<
                 self::_root::google::protobuf::file_options::OptimizeMode,
@@ -4838,8 +4838,8 @@ impl FileOptions {
         > as NonRepeatedFieldType>::clear(&mut self.optimize_for, &mut self._bitfield)
     }
     pub fn go_package(&self) -> &str {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             6usize,
@@ -4850,16 +4850,16 @@ impl FileOptions {
         )
     }
     pub fn go_package_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             6usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.go_package, &self._bitfield)
     }
     pub fn go_package_mut(&mut self) -> &mut ::std::string::String {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             6usize,
@@ -4870,8 +4870,8 @@ impl FileOptions {
         )
     }
     pub fn has_go_package(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             6usize,
@@ -4879,16 +4879,16 @@ impl FileOptions {
             .is_some()
     }
     pub fn clear_go_package(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             6usize,
         > as NonRepeatedFieldType>::clear(&mut self.go_package, &mut self._bitfield)
     }
     pub fn cc_generic_services(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             7usize,
@@ -4899,8 +4899,8 @@ impl FileOptions {
         )
     }
     pub fn cc_generic_services_opt(&self) -> ::std::option::Option::<bool> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             7usize,
@@ -4910,8 +4910,8 @@ impl FileOptions {
         )
     }
     pub fn cc_generic_services_mut(&mut self) -> &mut bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             7usize,
@@ -4922,8 +4922,8 @@ impl FileOptions {
         )
     }
     pub fn has_cc_generic_services(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             7usize,
@@ -4934,8 +4934,8 @@ impl FileOptions {
             .is_some()
     }
     pub fn clear_cc_generic_services(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             7usize,
@@ -4945,8 +4945,8 @@ impl FileOptions {
         )
     }
     pub fn java_generic_services(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             8usize,
@@ -4957,8 +4957,8 @@ impl FileOptions {
         )
     }
     pub fn java_generic_services_opt(&self) -> ::std::option::Option::<bool> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             8usize,
@@ -4968,8 +4968,8 @@ impl FileOptions {
         )
     }
     pub fn java_generic_services_mut(&mut self) -> &mut bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             8usize,
@@ -4980,8 +4980,8 @@ impl FileOptions {
         )
     }
     pub fn has_java_generic_services(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             8usize,
@@ -4992,8 +4992,8 @@ impl FileOptions {
             .is_some()
     }
     pub fn clear_java_generic_services(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             8usize,
@@ -5003,8 +5003,8 @@ impl FileOptions {
         )
     }
     pub fn py_generic_services(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             9usize,
@@ -5015,8 +5015,8 @@ impl FileOptions {
         )
     }
     pub fn py_generic_services_opt(&self) -> ::std::option::Option::<bool> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             9usize,
@@ -5026,8 +5026,8 @@ impl FileOptions {
         )
     }
     pub fn py_generic_services_mut(&mut self) -> &mut bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             9usize,
@@ -5038,8 +5038,8 @@ impl FileOptions {
         )
     }
     pub fn has_py_generic_services(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             9usize,
@@ -5050,8 +5050,8 @@ impl FileOptions {
             .is_some()
     }
     pub fn clear_py_generic_services(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             9usize,
@@ -5061,8 +5061,8 @@ impl FileOptions {
         )
     }
     pub fn php_generic_services(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             10usize,
@@ -5073,8 +5073,8 @@ impl FileOptions {
         )
     }
     pub fn php_generic_services_opt(&self) -> ::std::option::Option::<bool> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             10usize,
@@ -5084,8 +5084,8 @@ impl FileOptions {
         )
     }
     pub fn php_generic_services_mut(&mut self) -> &mut bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             10usize,
@@ -5096,8 +5096,8 @@ impl FileOptions {
         )
     }
     pub fn has_php_generic_services(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             10usize,
@@ -5108,8 +5108,8 @@ impl FileOptions {
             .is_some()
     }
     pub fn clear_php_generic_services(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             10usize,
@@ -5119,8 +5119,8 @@ impl FileOptions {
         )
     }
     pub fn deprecated(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             11usize,
@@ -5131,16 +5131,16 @@ impl FileOptions {
         )
     }
     pub fn deprecated_opt(&self) -> ::std::option::Option::<bool> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             11usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.deprecated, &self._bitfield)
     }
     pub fn deprecated_mut(&mut self) -> &mut bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             11usize,
@@ -5151,8 +5151,8 @@ impl FileOptions {
         )
     }
     pub fn has_deprecated(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             11usize,
@@ -5160,16 +5160,16 @@ impl FileOptions {
             .is_some()
     }
     pub fn clear_deprecated(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             11usize,
         > as NonRepeatedFieldType>::clear(&mut self.deprecated, &mut self._bitfield)
     }
     pub fn cc_enable_arenas(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             12usize,
@@ -5180,8 +5180,8 @@ impl FileOptions {
         )
     }
     pub fn cc_enable_arenas_opt(&self) -> ::std::option::Option::<bool> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             12usize,
@@ -5191,8 +5191,8 @@ impl FileOptions {
         )
     }
     pub fn cc_enable_arenas_mut(&mut self) -> &mut bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             12usize,
@@ -5203,8 +5203,8 @@ impl FileOptions {
         )
     }
     pub fn has_cc_enable_arenas(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             12usize,
@@ -5215,8 +5215,8 @@ impl FileOptions {
             .is_some()
     }
     pub fn clear_cc_enable_arenas(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             12usize,
@@ -5226,8 +5226,8 @@ impl FileOptions {
         )
     }
     pub fn objc_class_prefix(&self) -> &str {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             13usize,
@@ -5238,8 +5238,8 @@ impl FileOptions {
         )
     }
     pub fn objc_class_prefix_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             13usize,
@@ -5249,8 +5249,8 @@ impl FileOptions {
         )
     }
     pub fn objc_class_prefix_mut(&mut self) -> &mut ::std::string::String {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             13usize,
@@ -5261,8 +5261,8 @@ impl FileOptions {
         )
     }
     pub fn has_objc_class_prefix(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             13usize,
@@ -5273,8 +5273,8 @@ impl FileOptions {
             .is_some()
     }
     pub fn clear_objc_class_prefix(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             13usize,
@@ -5284,8 +5284,8 @@ impl FileOptions {
         )
     }
     pub fn csharp_namespace(&self) -> &str {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             14usize,
@@ -5296,8 +5296,8 @@ impl FileOptions {
         )
     }
     pub fn csharp_namespace_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             14usize,
@@ -5307,8 +5307,8 @@ impl FileOptions {
         )
     }
     pub fn csharp_namespace_mut(&mut self) -> &mut ::std::string::String {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             14usize,
@@ -5319,8 +5319,8 @@ impl FileOptions {
         )
     }
     pub fn has_csharp_namespace(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             14usize,
@@ -5331,8 +5331,8 @@ impl FileOptions {
             .is_some()
     }
     pub fn clear_csharp_namespace(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             14usize,
@@ -5342,8 +5342,8 @@ impl FileOptions {
         )
     }
     pub fn swift_prefix(&self) -> &str {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             15usize,
@@ -5354,16 +5354,16 @@ impl FileOptions {
         )
     }
     pub fn swift_prefix_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             15usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.swift_prefix, &self._bitfield)
     }
     pub fn swift_prefix_mut(&mut self) -> &mut ::std::string::String {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             15usize,
@@ -5374,8 +5374,8 @@ impl FileOptions {
         )
     }
     pub fn has_swift_prefix(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             15usize,
@@ -5383,16 +5383,16 @@ impl FileOptions {
             .is_some()
     }
     pub fn clear_swift_prefix(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             15usize,
         > as NonRepeatedFieldType>::clear(&mut self.swift_prefix, &mut self._bitfield)
     }
     pub fn php_class_prefix(&self) -> &str {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             16usize,
@@ -5403,8 +5403,8 @@ impl FileOptions {
         )
     }
     pub fn php_class_prefix_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             16usize,
@@ -5414,8 +5414,8 @@ impl FileOptions {
         )
     }
     pub fn php_class_prefix_mut(&mut self) -> &mut ::std::string::String {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             16usize,
@@ -5426,8 +5426,8 @@ impl FileOptions {
         )
     }
     pub fn has_php_class_prefix(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             16usize,
@@ -5438,8 +5438,8 @@ impl FileOptions {
             .is_some()
     }
     pub fn clear_php_class_prefix(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             16usize,
@@ -5449,8 +5449,8 @@ impl FileOptions {
         )
     }
     pub fn php_namespace(&self) -> &str {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             17usize,
@@ -5461,16 +5461,16 @@ impl FileOptions {
         )
     }
     pub fn php_namespace_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             17usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.php_namespace, &self._bitfield)
     }
     pub fn php_namespace_mut(&mut self) -> &mut ::std::string::String {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             17usize,
@@ -5481,8 +5481,8 @@ impl FileOptions {
         )
     }
     pub fn has_php_namespace(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             17usize,
@@ -5490,16 +5490,16 @@ impl FileOptions {
             .is_some()
     }
     pub fn clear_php_namespace(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             17usize,
         > as NonRepeatedFieldType>::clear(&mut self.php_namespace, &mut self._bitfield)
     }
     pub fn php_metadata_namespace(&self) -> &str {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             18usize,
@@ -5510,8 +5510,8 @@ impl FileOptions {
         )
     }
     pub fn php_metadata_namespace_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             18usize,
@@ -5521,8 +5521,8 @@ impl FileOptions {
         )
     }
     pub fn php_metadata_namespace_mut(&mut self) -> &mut ::std::string::String {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             18usize,
@@ -5533,8 +5533,8 @@ impl FileOptions {
         )
     }
     pub fn has_php_metadata_namespace(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             18usize,
@@ -5545,8 +5545,8 @@ impl FileOptions {
             .is_some()
     }
     pub fn clear_php_metadata_namespace(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             18usize,
@@ -5556,8 +5556,8 @@ impl FileOptions {
         )
     }
     pub fn ruby_package(&self) -> &str {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             19usize,
@@ -5568,16 +5568,16 @@ impl FileOptions {
         )
     }
     pub fn ruby_package_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             19usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.ruby_package, &self._bitfield)
     }
     pub fn ruby_package_mut(&mut self) -> &mut ::std::string::String {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             19usize,
@@ -5588,8 +5588,8 @@ impl FileOptions {
         )
     }
     pub fn has_ruby_package(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             19usize,
@@ -5597,8 +5597,8 @@ impl FileOptions {
             .is_some()
     }
     pub fn clear_ruby_package(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             19usize,
@@ -5607,16 +5607,16 @@ impl FileOptions {
     pub fn uninterpreted_option(
         &self,
     ) -> &[self::_root::google::protobuf::UninterpretedOption] {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::UninterpretedOption,
         > as RepeatedFieldType>::get_field(&self.uninterpreted_option, &self._bitfield)
     }
     pub fn uninterpreted_option_mut(
         &mut self,
     ) -> &mut ::std::vec::Vec::<self::_root::google::protobuf::UninterpretedOption> {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::UninterpretedOption,
         > as RepeatedFieldType>::get_field_mut(
             &mut self.uninterpreted_option,
@@ -5624,8 +5624,8 @@ impl FileOptions {
         )
     }
     pub fn clear_uninterpreted_option(&mut self) {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::UninterpretedOption,
         > as RepeatedFieldType>::clear(
             &mut self.uninterpreted_option,
@@ -5647,236 +5647,236 @@ impl self::_puroro::Message for FileOptions {
     ) -> self::_puroro::Result<()> {
         use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 1i32 => {
-                    <self::_pinternal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::OptionalUnsizedField::<
                         ::std::string::String,
                         self::_pinternal::tags::String,
                         0usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.java_package,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 8i32 => {
-                    <self::_pinternal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::OptionalUnsizedField::<
                         ::std::string::String,
                         self::_pinternal::tags::String,
                         1usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.java_outer_classname,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 10i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         bool,
                         self::_pinternal::tags::Bool,
                         2usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.java_multiple_files,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 20i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         bool,
                         self::_pinternal::tags::Bool,
                         3usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.java_generate_equals_and_hash,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 27i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         bool,
                         self::_pinternal::tags::Bool,
                         4usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.java_string_check_utf8,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 9i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         self::_root::google::protobuf::file_options::OptimizeMode,
                         self::_pinternal::tags::Enum2::<
                             self::_root::google::protobuf::file_options::OptimizeMode,
                         >,
                         5usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.optimize_for,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 11i32 => {
-                    <self::_pinternal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::OptionalUnsizedField::<
                         ::std::string::String,
                         self::_pinternal::tags::String,
                         6usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.go_package,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 16i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         bool,
                         self::_pinternal::tags::Bool,
                         7usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.cc_generic_services,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 17i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         bool,
                         self::_pinternal::tags::Bool,
                         8usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.java_generic_services,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 18i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         bool,
                         self::_pinternal::tags::Bool,
                         9usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.py_generic_services,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 42i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         bool,
                         self::_pinternal::tags::Bool,
                         10usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.php_generic_services,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 23i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         bool,
                         self::_pinternal::tags::Bool,
                         11usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.deprecated,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 31i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         bool,
                         self::_pinternal::tags::Bool,
                         12usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.cc_enable_arenas,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 36i32 => {
-                    <self::_pinternal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::OptionalUnsizedField::<
                         ::std::string::String,
                         self::_pinternal::tags::String,
                         13usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.objc_class_prefix,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 37i32 => {
-                    <self::_pinternal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::OptionalUnsizedField::<
                         ::std::string::String,
                         self::_pinternal::tags::String,
                         14usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.csharp_namespace,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 39i32 => {
-                    <self::_pinternal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::OptionalUnsizedField::<
                         ::std::string::String,
                         self::_pinternal::tags::String,
                         15usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.swift_prefix,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 40i32 => {
-                    <self::_pinternal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::OptionalUnsizedField::<
                         ::std::string::String,
                         self::_pinternal::tags::String,
                         16usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.php_class_prefix,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 41i32 => {
-                    <self::_pinternal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::OptionalUnsizedField::<
                         ::std::string::String,
                         self::_pinternal::tags::String,
                         17usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.php_namespace,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 44i32 => {
-                    <self::_pinternal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::OptionalUnsizedField::<
                         ::std::string::String,
                         self::_pinternal::tags::String,
                         18usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.php_metadata_namespace,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 45i32 => {
-                    <self::_pinternal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::OptionalUnsizedField::<
                         ::std::string::String,
                         self::_pinternal::tags::String,
                         19usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.ruby_package,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 999i32 => {
-                    <self::_pinternal::field_type::RepeatedMessageField::<
+                    <self::_pinternal::RepeatedMessageField::<
                         self::_root::google::protobuf::UninterpretedOption,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.uninterpreted_option,
                         &mut self._bitfield,
                         field_data,
@@ -5893,212 +5893,212 @@ impl self::_puroro::Message for FileOptions {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::OneofUnion as _;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.java_package,
             &self._bitfield,
             1i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             1usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.java_outer_classname,
             &self._bitfield,
             8i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             2usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.java_multiple_files,
             &self._bitfield,
             10i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             3usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.java_generate_equals_and_hash,
             &self._bitfield,
             20i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             4usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.java_string_check_utf8,
             &self._bitfield,
             27i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        <self::_pinternal::OptionalNumericalField::<
             self::_root::google::protobuf::file_options::OptimizeMode,
             self::_pinternal::tags::Enum2::<
                 self::_root::google::protobuf::file_options::OptimizeMode,
             >,
             5usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.optimize_for,
             &self._bitfield,
             9i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             6usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.go_package,
             &self._bitfield,
             11i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             7usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.cc_generic_services,
             &self._bitfield,
             16i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             8usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.java_generic_services,
             &self._bitfield,
             17i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             9usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.py_generic_services,
             &self._bitfield,
             18i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             10usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.php_generic_services,
             &self._bitfield,
             42i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             11usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.deprecated,
             &self._bitfield,
             23i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             12usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.cc_enable_arenas,
             &self._bitfield,
             31i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             13usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.objc_class_prefix,
             &self._bitfield,
             36i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             14usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.csharp_namespace,
             &self._bitfield,
             37i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             15usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.swift_prefix,
             &self._bitfield,
             39i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             16usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.php_class_prefix,
             &self._bitfield,
             40i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             17usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.php_namespace,
             &self._bitfield,
             41i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             18usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.php_metadata_namespace,
             &self._bitfield,
             44i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             19usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.ruby_package,
             &self._bitfield,
             45i32,
             out,
         )?;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::UninterpretedOption,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.uninterpreted_option,
             &self._bitfield,
             999i32,
@@ -6110,109 +6110,109 @@ impl self::_puroro::Message for FileOptions {
 impl ::std::clone::Clone for FileOptions {
     fn clone(&self) -> Self {
         Self {
-            java_package: <self::_pinternal::field_type::OptionalUnsizedField::<
+            java_package: <self::_pinternal::OptionalUnsizedField::<
                 ::std::string::String,
                 self::_pinternal::tags::String,
                 0usize,
             > as ::std::clone::Clone>::clone(&self.java_package),
-            java_outer_classname: <self::_pinternal::field_type::OptionalUnsizedField::<
+            java_outer_classname: <self::_pinternal::OptionalUnsizedField::<
                 ::std::string::String,
                 self::_pinternal::tags::String,
                 1usize,
             > as ::std::clone::Clone>::clone(&self.java_outer_classname),
-            java_multiple_files: <self::_pinternal::field_type::OptionalNumericalField::<
+            java_multiple_files: <self::_pinternal::OptionalNumericalField::<
                 bool,
                 self::_pinternal::tags::Bool,
                 2usize,
             > as ::std::clone::Clone>::clone(&self.java_multiple_files),
-            java_generate_equals_and_hash: <self::_pinternal::field_type::OptionalNumericalField::<
+            java_generate_equals_and_hash: <self::_pinternal::OptionalNumericalField::<
                 bool,
                 self::_pinternal::tags::Bool,
                 3usize,
             > as ::std::clone::Clone>::clone(&self.java_generate_equals_and_hash),
-            java_string_check_utf8: <self::_pinternal::field_type::OptionalNumericalField::<
+            java_string_check_utf8: <self::_pinternal::OptionalNumericalField::<
                 bool,
                 self::_pinternal::tags::Bool,
                 4usize,
             > as ::std::clone::Clone>::clone(&self.java_string_check_utf8),
-            optimize_for: <self::_pinternal::field_type::OptionalNumericalField::<
+            optimize_for: <self::_pinternal::OptionalNumericalField::<
                 self::_root::google::protobuf::file_options::OptimizeMode,
                 self::_pinternal::tags::Enum2::<
                     self::_root::google::protobuf::file_options::OptimizeMode,
                 >,
                 5usize,
             > as ::std::clone::Clone>::clone(&self.optimize_for),
-            go_package: <self::_pinternal::field_type::OptionalUnsizedField::<
+            go_package: <self::_pinternal::OptionalUnsizedField::<
                 ::std::string::String,
                 self::_pinternal::tags::String,
                 6usize,
             > as ::std::clone::Clone>::clone(&self.go_package),
-            cc_generic_services: <self::_pinternal::field_type::OptionalNumericalField::<
+            cc_generic_services: <self::_pinternal::OptionalNumericalField::<
                 bool,
                 self::_pinternal::tags::Bool,
                 7usize,
             > as ::std::clone::Clone>::clone(&self.cc_generic_services),
-            java_generic_services: <self::_pinternal::field_type::OptionalNumericalField::<
+            java_generic_services: <self::_pinternal::OptionalNumericalField::<
                 bool,
                 self::_pinternal::tags::Bool,
                 8usize,
             > as ::std::clone::Clone>::clone(&self.java_generic_services),
-            py_generic_services: <self::_pinternal::field_type::OptionalNumericalField::<
+            py_generic_services: <self::_pinternal::OptionalNumericalField::<
                 bool,
                 self::_pinternal::tags::Bool,
                 9usize,
             > as ::std::clone::Clone>::clone(&self.py_generic_services),
-            php_generic_services: <self::_pinternal::field_type::OptionalNumericalField::<
+            php_generic_services: <self::_pinternal::OptionalNumericalField::<
                 bool,
                 self::_pinternal::tags::Bool,
                 10usize,
             > as ::std::clone::Clone>::clone(&self.php_generic_services),
-            deprecated: <self::_pinternal::field_type::OptionalNumericalField::<
+            deprecated: <self::_pinternal::OptionalNumericalField::<
                 bool,
                 self::_pinternal::tags::Bool,
                 11usize,
             > as ::std::clone::Clone>::clone(&self.deprecated),
-            cc_enable_arenas: <self::_pinternal::field_type::OptionalNumericalField::<
+            cc_enable_arenas: <self::_pinternal::OptionalNumericalField::<
                 bool,
                 self::_pinternal::tags::Bool,
                 12usize,
             > as ::std::clone::Clone>::clone(&self.cc_enable_arenas),
-            objc_class_prefix: <self::_pinternal::field_type::OptionalUnsizedField::<
+            objc_class_prefix: <self::_pinternal::OptionalUnsizedField::<
                 ::std::string::String,
                 self::_pinternal::tags::String,
                 13usize,
             > as ::std::clone::Clone>::clone(&self.objc_class_prefix),
-            csharp_namespace: <self::_pinternal::field_type::OptionalUnsizedField::<
+            csharp_namespace: <self::_pinternal::OptionalUnsizedField::<
                 ::std::string::String,
                 self::_pinternal::tags::String,
                 14usize,
             > as ::std::clone::Clone>::clone(&self.csharp_namespace),
-            swift_prefix: <self::_pinternal::field_type::OptionalUnsizedField::<
+            swift_prefix: <self::_pinternal::OptionalUnsizedField::<
                 ::std::string::String,
                 self::_pinternal::tags::String,
                 15usize,
             > as ::std::clone::Clone>::clone(&self.swift_prefix),
-            php_class_prefix: <self::_pinternal::field_type::OptionalUnsizedField::<
+            php_class_prefix: <self::_pinternal::OptionalUnsizedField::<
                 ::std::string::String,
                 self::_pinternal::tags::String,
                 16usize,
             > as ::std::clone::Clone>::clone(&self.php_class_prefix),
-            php_namespace: <self::_pinternal::field_type::OptionalUnsizedField::<
+            php_namespace: <self::_pinternal::OptionalUnsizedField::<
                 ::std::string::String,
                 self::_pinternal::tags::String,
                 17usize,
             > as ::std::clone::Clone>::clone(&self.php_namespace),
-            php_metadata_namespace: <self::_pinternal::field_type::OptionalUnsizedField::<
+            php_metadata_namespace: <self::_pinternal::OptionalUnsizedField::<
                 ::std::string::String,
                 self::_pinternal::tags::String,
                 18usize,
             > as ::std::clone::Clone>::clone(&self.php_metadata_namespace),
-            ruby_package: <self::_pinternal::field_type::OptionalUnsizedField::<
+            ruby_package: <self::_pinternal::OptionalUnsizedField::<
                 ::std::string::String,
                 self::_pinternal::tags::String,
                 19usize,
             > as ::std::clone::Clone>::clone(&self.ruby_package),
-            uninterpreted_option: <self::_pinternal::field_type::RepeatedMessageField::<
+            uninterpreted_option: <self::_pinternal::RepeatedMessageField::<
                 self::_root::google::protobuf::UninterpretedOption,
             > as ::std::clone::Clone>::clone(&self.uninterpreted_option),
             _bitfield: ::std::clone::Clone::clone(&self._bitfield),
@@ -6222,7 +6222,7 @@ impl ::std::clone::Clone for FileOptions {
 impl ::std::ops::Drop for FileOptions {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for FileOptions {
@@ -6267,7 +6267,7 @@ impl ::std::fmt::Debug for FileOptions {
 impl ::std::cmp::PartialEq for FileOptions {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         true && self.java_package_opt() == rhs.java_package_opt()
             && self.java_outer_classname_opt() == rhs.java_outer_classname_opt()
             && self.java_multiple_files_opt() == rhs.java_multiple_files_opt()
@@ -6294,35 +6294,35 @@ impl ::std::cmp::PartialEq for FileOptions {
 }
 #[derive(::std::default::Default)]
 pub struct MessageOptions {
-    message_set_wire_format: self::_pinternal::field_type::OptionalNumericalField::<
+    message_set_wire_format: self::_pinternal::OptionalNumericalField::<
         bool,
         self::_pinternal::tags::Bool,
         0usize,
     >,
-    no_standard_descriptor_accessor: self::_pinternal::field_type::OptionalNumericalField::<
+    no_standard_descriptor_accessor: self::_pinternal::OptionalNumericalField::<
         bool,
         self::_pinternal::tags::Bool,
         1usize,
     >,
-    deprecated: self::_pinternal::field_type::OptionalNumericalField::<
+    deprecated: self::_pinternal::OptionalNumericalField::<
         bool,
         self::_pinternal::tags::Bool,
         2usize,
     >,
-    map_entry: self::_pinternal::field_type::OptionalNumericalField::<
+    map_entry: self::_pinternal::OptionalNumericalField::<
         bool,
         self::_pinternal::tags::Bool,
         3usize,
     >,
-    uninterpreted_option: self::_pinternal::field_type::RepeatedMessageField::<
+    uninterpreted_option: self::_pinternal::RepeatedMessageField::<
         self::_root::google::protobuf::UninterpretedOption,
     >,
-    _bitfield: self::_pinternal::bitvec::BitArray<1usize>,
+    _bitfield: self::_pinternal::BitArray<1usize>,
 }
 impl MessageOptions {
     pub fn message_set_wire_format(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             0usize,
@@ -6333,8 +6333,8 @@ impl MessageOptions {
         )
     }
     pub fn message_set_wire_format_opt(&self) -> ::std::option::Option::<bool> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             0usize,
@@ -6344,8 +6344,8 @@ impl MessageOptions {
         )
     }
     pub fn message_set_wire_format_mut(&mut self) -> &mut bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             0usize,
@@ -6356,8 +6356,8 @@ impl MessageOptions {
         )
     }
     pub fn has_message_set_wire_format(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             0usize,
@@ -6368,8 +6368,8 @@ impl MessageOptions {
             .is_some()
     }
     pub fn clear_message_set_wire_format(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             0usize,
@@ -6379,8 +6379,8 @@ impl MessageOptions {
         )
     }
     pub fn no_standard_descriptor_accessor(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             1usize,
@@ -6391,8 +6391,8 @@ impl MessageOptions {
         )
     }
     pub fn no_standard_descriptor_accessor_opt(&self) -> ::std::option::Option::<bool> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             1usize,
@@ -6402,8 +6402,8 @@ impl MessageOptions {
         )
     }
     pub fn no_standard_descriptor_accessor_mut(&mut self) -> &mut bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             1usize,
@@ -6414,8 +6414,8 @@ impl MessageOptions {
         )
     }
     pub fn has_no_standard_descriptor_accessor(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             1usize,
@@ -6426,8 +6426,8 @@ impl MessageOptions {
             .is_some()
     }
     pub fn clear_no_standard_descriptor_accessor(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             1usize,
@@ -6437,8 +6437,8 @@ impl MessageOptions {
         )
     }
     pub fn deprecated(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             2usize,
@@ -6449,16 +6449,16 @@ impl MessageOptions {
         )
     }
     pub fn deprecated_opt(&self) -> ::std::option::Option::<bool> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             2usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.deprecated, &self._bitfield)
     }
     pub fn deprecated_mut(&mut self) -> &mut bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             2usize,
@@ -6469,8 +6469,8 @@ impl MessageOptions {
         )
     }
     pub fn has_deprecated(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             2usize,
@@ -6478,16 +6478,16 @@ impl MessageOptions {
             .is_some()
     }
     pub fn clear_deprecated(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             2usize,
         > as NonRepeatedFieldType>::clear(&mut self.deprecated, &mut self._bitfield)
     }
     pub fn map_entry(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             3usize,
@@ -6498,16 +6498,16 @@ impl MessageOptions {
         )
     }
     pub fn map_entry_opt(&self) -> ::std::option::Option::<bool> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             3usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.map_entry, &self._bitfield)
     }
     pub fn map_entry_mut(&mut self) -> &mut bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             3usize,
@@ -6518,8 +6518,8 @@ impl MessageOptions {
         )
     }
     pub fn has_map_entry(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             3usize,
@@ -6527,8 +6527,8 @@ impl MessageOptions {
             .is_some()
     }
     pub fn clear_map_entry(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             3usize,
@@ -6537,16 +6537,16 @@ impl MessageOptions {
     pub fn uninterpreted_option(
         &self,
     ) -> &[self::_root::google::protobuf::UninterpretedOption] {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::UninterpretedOption,
         > as RepeatedFieldType>::get_field(&self.uninterpreted_option, &self._bitfield)
     }
     pub fn uninterpreted_option_mut(
         &mut self,
     ) -> &mut ::std::vec::Vec::<self::_root::google::protobuf::UninterpretedOption> {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::UninterpretedOption,
         > as RepeatedFieldType>::get_field_mut(
             &mut self.uninterpreted_option,
@@ -6554,8 +6554,8 @@ impl MessageOptions {
         )
     }
     pub fn clear_uninterpreted_option(&mut self) {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::UninterpretedOption,
         > as RepeatedFieldType>::clear(
             &mut self.uninterpreted_option,
@@ -6577,58 +6577,58 @@ impl self::_puroro::Message for MessageOptions {
     ) -> self::_puroro::Result<()> {
         use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 1i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         bool,
                         self::_pinternal::tags::Bool,
                         0usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.message_set_wire_format,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 2i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         bool,
                         self::_pinternal::tags::Bool,
                         1usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.no_standard_descriptor_accessor,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 3i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         bool,
                         self::_pinternal::tags::Bool,
                         2usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.deprecated,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 7i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         bool,
                         self::_pinternal::tags::Bool,
                         3usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.map_entry,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 999i32 => {
-                    <self::_pinternal::field_type::RepeatedMessageField::<
+                    <self::_pinternal::RepeatedMessageField::<
                         self::_root::google::protobuf::UninterpretedOption,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.uninterpreted_option,
                         &mut self._bitfield,
                         field_data,
@@ -6645,50 +6645,50 @@ impl self::_puroro::Message for MessageOptions {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::OneofUnion as _;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             0usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.message_set_wire_format,
             &self._bitfield,
             1i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             1usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.no_standard_descriptor_accessor,
             &self._bitfield,
             2i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             2usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.deprecated,
             &self._bitfield,
             3i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             3usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.map_entry,
             &self._bitfield,
             7i32,
             out,
         )?;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::UninterpretedOption,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.uninterpreted_option,
             &self._bitfield,
             999i32,
@@ -6700,27 +6700,27 @@ impl self::_puroro::Message for MessageOptions {
 impl ::std::clone::Clone for MessageOptions {
     fn clone(&self) -> Self {
         Self {
-            message_set_wire_format: <self::_pinternal::field_type::OptionalNumericalField::<
+            message_set_wire_format: <self::_pinternal::OptionalNumericalField::<
                 bool,
                 self::_pinternal::tags::Bool,
                 0usize,
             > as ::std::clone::Clone>::clone(&self.message_set_wire_format),
-            no_standard_descriptor_accessor: <self::_pinternal::field_type::OptionalNumericalField::<
+            no_standard_descriptor_accessor: <self::_pinternal::OptionalNumericalField::<
                 bool,
                 self::_pinternal::tags::Bool,
                 1usize,
             > as ::std::clone::Clone>::clone(&self.no_standard_descriptor_accessor),
-            deprecated: <self::_pinternal::field_type::OptionalNumericalField::<
+            deprecated: <self::_pinternal::OptionalNumericalField::<
                 bool,
                 self::_pinternal::tags::Bool,
                 2usize,
             > as ::std::clone::Clone>::clone(&self.deprecated),
-            map_entry: <self::_pinternal::field_type::OptionalNumericalField::<
+            map_entry: <self::_pinternal::OptionalNumericalField::<
                 bool,
                 self::_pinternal::tags::Bool,
                 3usize,
             > as ::std::clone::Clone>::clone(&self.map_entry),
-            uninterpreted_option: <self::_pinternal::field_type::RepeatedMessageField::<
+            uninterpreted_option: <self::_pinternal::RepeatedMessageField::<
                 self::_root::google::protobuf::UninterpretedOption,
             > as ::std::clone::Clone>::clone(&self.uninterpreted_option),
             _bitfield: ::std::clone::Clone::clone(&self._bitfield),
@@ -6730,7 +6730,7 @@ impl ::std::clone::Clone for MessageOptions {
 impl ::std::ops::Drop for MessageOptions {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for MessageOptions {
@@ -6756,7 +6756,7 @@ impl ::std::fmt::Debug for MessageOptions {
 impl ::std::cmp::PartialEq for MessageOptions {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         true && self.message_set_wire_format_opt() == rhs.message_set_wire_format_opt()
             && self.no_standard_descriptor_accessor_opt()
                 == rhs.no_standard_descriptor_accessor_opt()
@@ -6767,49 +6767,49 @@ impl ::std::cmp::PartialEq for MessageOptions {
 }
 #[derive(::std::default::Default)]
 pub struct FieldOptions {
-    ctype: self::_pinternal::field_type::OptionalNumericalField::<
+    ctype: self::_pinternal::OptionalNumericalField::<
         self::_root::google::protobuf::field_options::CType,
         self::_pinternal::tags::Enum2::<
             self::_root::google::protobuf::field_options::CType,
         >,
         0usize,
     >,
-    packed: self::_pinternal::field_type::OptionalNumericalField::<
+    packed: self::_pinternal::OptionalNumericalField::<
         bool,
         self::_pinternal::tags::Bool,
         1usize,
     >,
-    jstype: self::_pinternal::field_type::OptionalNumericalField::<
+    jstype: self::_pinternal::OptionalNumericalField::<
         self::_root::google::protobuf::field_options::JSType,
         self::_pinternal::tags::Enum2::<
             self::_root::google::protobuf::field_options::JSType,
         >,
         2usize,
     >,
-    lazy: self::_pinternal::field_type::OptionalNumericalField::<
+    lazy: self::_pinternal::OptionalNumericalField::<
         bool,
         self::_pinternal::tags::Bool,
         3usize,
     >,
-    deprecated: self::_pinternal::field_type::OptionalNumericalField::<
+    deprecated: self::_pinternal::OptionalNumericalField::<
         bool,
         self::_pinternal::tags::Bool,
         4usize,
     >,
-    weak: self::_pinternal::field_type::OptionalNumericalField::<
+    weak: self::_pinternal::OptionalNumericalField::<
         bool,
         self::_pinternal::tags::Bool,
         5usize,
     >,
-    uninterpreted_option: self::_pinternal::field_type::RepeatedMessageField::<
+    uninterpreted_option: self::_pinternal::RepeatedMessageField::<
         self::_root::google::protobuf::UninterpretedOption,
     >,
-    _bitfield: self::_pinternal::bitvec::BitArray<1usize>,
+    _bitfield: self::_pinternal::BitArray<1usize>,
 }
 impl FieldOptions {
     pub fn ctype(&self) -> self::_root::google::protobuf::field_options::CType {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             self::_root::google::protobuf::field_options::CType,
             self::_pinternal::tags::Enum2::<
                 self::_root::google::protobuf::field_options::CType,
@@ -6824,8 +6824,8 @@ impl FieldOptions {
     pub fn ctype_opt(
         &self,
     ) -> ::std::option::Option::<self::_root::google::protobuf::field_options::CType> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             self::_root::google::protobuf::field_options::CType,
             self::_pinternal::tags::Enum2::<
                 self::_root::google::protobuf::field_options::CType,
@@ -6836,8 +6836,8 @@ impl FieldOptions {
     pub fn ctype_mut(
         &mut self,
     ) -> &mut self::_root::google::protobuf::field_options::CType {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             self::_root::google::protobuf::field_options::CType,
             self::_pinternal::tags::Enum2::<
                 self::_root::google::protobuf::field_options::CType,
@@ -6850,8 +6850,8 @@ impl FieldOptions {
         )
     }
     pub fn has_ctype(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             self::_root::google::protobuf::field_options::CType,
             self::_pinternal::tags::Enum2::<
                 self::_root::google::protobuf::field_options::CType,
@@ -6861,8 +6861,8 @@ impl FieldOptions {
             .is_some()
     }
     pub fn clear_ctype(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             self::_root::google::protobuf::field_options::CType,
             self::_pinternal::tags::Enum2::<
                 self::_root::google::protobuf::field_options::CType,
@@ -6871,8 +6871,8 @@ impl FieldOptions {
         > as NonRepeatedFieldType>::clear(&mut self.ctype, &mut self._bitfield)
     }
     pub fn packed(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             1usize,
@@ -6883,16 +6883,16 @@ impl FieldOptions {
         )
     }
     pub fn packed_opt(&self) -> ::std::option::Option::<bool> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             1usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.packed, &self._bitfield)
     }
     pub fn packed_mut(&mut self) -> &mut bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             1usize,
@@ -6903,8 +6903,8 @@ impl FieldOptions {
         )
     }
     pub fn has_packed(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             1usize,
@@ -6912,16 +6912,16 @@ impl FieldOptions {
             .is_some()
     }
     pub fn clear_packed(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             1usize,
         > as NonRepeatedFieldType>::clear(&mut self.packed, &mut self._bitfield)
     }
     pub fn jstype(&self) -> self::_root::google::protobuf::field_options::JSType {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             self::_root::google::protobuf::field_options::JSType,
             self::_pinternal::tags::Enum2::<
                 self::_root::google::protobuf::field_options::JSType,
@@ -6936,8 +6936,8 @@ impl FieldOptions {
     pub fn jstype_opt(
         &self,
     ) -> ::std::option::Option::<self::_root::google::protobuf::field_options::JSType> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             self::_root::google::protobuf::field_options::JSType,
             self::_pinternal::tags::Enum2::<
                 self::_root::google::protobuf::field_options::JSType,
@@ -6948,8 +6948,8 @@ impl FieldOptions {
     pub fn jstype_mut(
         &mut self,
     ) -> &mut self::_root::google::protobuf::field_options::JSType {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             self::_root::google::protobuf::field_options::JSType,
             self::_pinternal::tags::Enum2::<
                 self::_root::google::protobuf::field_options::JSType,
@@ -6962,8 +6962,8 @@ impl FieldOptions {
         )
     }
     pub fn has_jstype(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             self::_root::google::protobuf::field_options::JSType,
             self::_pinternal::tags::Enum2::<
                 self::_root::google::protobuf::field_options::JSType,
@@ -6973,8 +6973,8 @@ impl FieldOptions {
             .is_some()
     }
     pub fn clear_jstype(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             self::_root::google::protobuf::field_options::JSType,
             self::_pinternal::tags::Enum2::<
                 self::_root::google::protobuf::field_options::JSType,
@@ -6983,8 +6983,8 @@ impl FieldOptions {
         > as NonRepeatedFieldType>::clear(&mut self.jstype, &mut self._bitfield)
     }
     pub fn lazy(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             3usize,
@@ -6995,16 +6995,16 @@ impl FieldOptions {
         )
     }
     pub fn lazy_opt(&self) -> ::std::option::Option::<bool> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             3usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.lazy, &self._bitfield)
     }
     pub fn lazy_mut(&mut self) -> &mut bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             3usize,
@@ -7015,8 +7015,8 @@ impl FieldOptions {
         )
     }
     pub fn has_lazy(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             3usize,
@@ -7024,16 +7024,16 @@ impl FieldOptions {
             .is_some()
     }
     pub fn clear_lazy(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             3usize,
         > as NonRepeatedFieldType>::clear(&mut self.lazy, &mut self._bitfield)
     }
     pub fn deprecated(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             4usize,
@@ -7044,16 +7044,16 @@ impl FieldOptions {
         )
     }
     pub fn deprecated_opt(&self) -> ::std::option::Option::<bool> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             4usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.deprecated, &self._bitfield)
     }
     pub fn deprecated_mut(&mut self) -> &mut bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             4usize,
@@ -7064,8 +7064,8 @@ impl FieldOptions {
         )
     }
     pub fn has_deprecated(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             4usize,
@@ -7073,16 +7073,16 @@ impl FieldOptions {
             .is_some()
     }
     pub fn clear_deprecated(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             4usize,
         > as NonRepeatedFieldType>::clear(&mut self.deprecated, &mut self._bitfield)
     }
     pub fn weak(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             5usize,
@@ -7093,16 +7093,16 @@ impl FieldOptions {
         )
     }
     pub fn weak_opt(&self) -> ::std::option::Option::<bool> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             5usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.weak, &self._bitfield)
     }
     pub fn weak_mut(&mut self) -> &mut bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             5usize,
@@ -7113,8 +7113,8 @@ impl FieldOptions {
         )
     }
     pub fn has_weak(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             5usize,
@@ -7122,8 +7122,8 @@ impl FieldOptions {
             .is_some()
     }
     pub fn clear_weak(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             5usize,
@@ -7132,16 +7132,16 @@ impl FieldOptions {
     pub fn uninterpreted_option(
         &self,
     ) -> &[self::_root::google::protobuf::UninterpretedOption] {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::UninterpretedOption,
         > as RepeatedFieldType>::get_field(&self.uninterpreted_option, &self._bitfield)
     }
     pub fn uninterpreted_option_mut(
         &mut self,
     ) -> &mut ::std::vec::Vec::<self::_root::google::protobuf::UninterpretedOption> {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::UninterpretedOption,
         > as RepeatedFieldType>::get_field_mut(
             &mut self.uninterpreted_option,
@@ -7149,8 +7149,8 @@ impl FieldOptions {
         )
     }
     pub fn clear_uninterpreted_option(&mut self) {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::UninterpretedOption,
         > as RepeatedFieldType>::clear(
             &mut self.uninterpreted_option,
@@ -7172,84 +7172,84 @@ impl self::_puroro::Message for FieldOptions {
     ) -> self::_puroro::Result<()> {
         use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 1i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         self::_root::google::protobuf::field_options::CType,
                         self::_pinternal::tags::Enum2::<
                             self::_root::google::protobuf::field_options::CType,
                         >,
                         0usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.ctype,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 2i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         bool,
                         self::_pinternal::tags::Bool,
                         1usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.packed,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 6i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         self::_root::google::protobuf::field_options::JSType,
                         self::_pinternal::tags::Enum2::<
                             self::_root::google::protobuf::field_options::JSType,
                         >,
                         2usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.jstype,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 5i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         bool,
                         self::_pinternal::tags::Bool,
                         3usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.lazy,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 3i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         bool,
                         self::_pinternal::tags::Bool,
                         4usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.deprecated,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 10i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         bool,
                         self::_pinternal::tags::Bool,
                         5usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.weak,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 999i32 => {
-                    <self::_pinternal::field_type::RepeatedMessageField::<
+                    <self::_pinternal::RepeatedMessageField::<
                         self::_root::google::protobuf::UninterpretedOption,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.uninterpreted_option,
                         &mut self._bitfield,
                         field_data,
@@ -7266,74 +7266,74 @@ impl self::_puroro::Message for FieldOptions {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::OneofUnion as _;
+        <self::_pinternal::OptionalNumericalField::<
             self::_root::google::protobuf::field_options::CType,
             self::_pinternal::tags::Enum2::<
                 self::_root::google::protobuf::field_options::CType,
             >,
             0usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.ctype,
             &self._bitfield,
             1i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             1usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.packed,
             &self._bitfield,
             2i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        <self::_pinternal::OptionalNumericalField::<
             self::_root::google::protobuf::field_options::JSType,
             self::_pinternal::tags::Enum2::<
                 self::_root::google::protobuf::field_options::JSType,
             >,
             2usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.jstype,
             &self._bitfield,
             6i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             3usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.lazy,
             &self._bitfield,
             5i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             4usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.deprecated,
             &self._bitfield,
             3i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             5usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.weak,
             &self._bitfield,
             10i32,
             out,
         )?;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::UninterpretedOption,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.uninterpreted_option,
             &self._bitfield,
             999i32,
@@ -7345,41 +7345,41 @@ impl self::_puroro::Message for FieldOptions {
 impl ::std::clone::Clone for FieldOptions {
     fn clone(&self) -> Self {
         Self {
-            ctype: <self::_pinternal::field_type::OptionalNumericalField::<
+            ctype: <self::_pinternal::OptionalNumericalField::<
                 self::_root::google::protobuf::field_options::CType,
                 self::_pinternal::tags::Enum2::<
                     self::_root::google::protobuf::field_options::CType,
                 >,
                 0usize,
             > as ::std::clone::Clone>::clone(&self.ctype),
-            packed: <self::_pinternal::field_type::OptionalNumericalField::<
+            packed: <self::_pinternal::OptionalNumericalField::<
                 bool,
                 self::_pinternal::tags::Bool,
                 1usize,
             > as ::std::clone::Clone>::clone(&self.packed),
-            jstype: <self::_pinternal::field_type::OptionalNumericalField::<
+            jstype: <self::_pinternal::OptionalNumericalField::<
                 self::_root::google::protobuf::field_options::JSType,
                 self::_pinternal::tags::Enum2::<
                     self::_root::google::protobuf::field_options::JSType,
                 >,
                 2usize,
             > as ::std::clone::Clone>::clone(&self.jstype),
-            lazy: <self::_pinternal::field_type::OptionalNumericalField::<
+            lazy: <self::_pinternal::OptionalNumericalField::<
                 bool,
                 self::_pinternal::tags::Bool,
                 3usize,
             > as ::std::clone::Clone>::clone(&self.lazy),
-            deprecated: <self::_pinternal::field_type::OptionalNumericalField::<
+            deprecated: <self::_pinternal::OptionalNumericalField::<
                 bool,
                 self::_pinternal::tags::Bool,
                 4usize,
             > as ::std::clone::Clone>::clone(&self.deprecated),
-            weak: <self::_pinternal::field_type::OptionalNumericalField::<
+            weak: <self::_pinternal::OptionalNumericalField::<
                 bool,
                 self::_pinternal::tags::Bool,
                 5usize,
             > as ::std::clone::Clone>::clone(&self.weak),
-            uninterpreted_option: <self::_pinternal::field_type::RepeatedMessageField::<
+            uninterpreted_option: <self::_pinternal::RepeatedMessageField::<
                 self::_root::google::protobuf::UninterpretedOption,
             > as ::std::clone::Clone>::clone(&self.uninterpreted_option),
             _bitfield: ::std::clone::Clone::clone(&self._bitfield),
@@ -7389,7 +7389,7 @@ impl ::std::clone::Clone for FieldOptions {
 impl ::std::ops::Drop for FieldOptions {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for FieldOptions {
@@ -7411,7 +7411,7 @@ impl ::std::fmt::Debug for FieldOptions {
 impl ::std::cmp::PartialEq for FieldOptions {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         true && self.ctype_opt() == rhs.ctype_opt()
             && self.packed_opt() == rhs.packed_opt()
             && self.jstype_opt() == rhs.jstype_opt() && self.lazy_opt() == rhs.lazy_opt()
@@ -7422,25 +7422,25 @@ impl ::std::cmp::PartialEq for FieldOptions {
 }
 #[derive(::std::default::Default)]
 pub struct OneofOptions {
-    uninterpreted_option: self::_pinternal::field_type::RepeatedMessageField::<
+    uninterpreted_option: self::_pinternal::RepeatedMessageField::<
         self::_root::google::protobuf::UninterpretedOption,
     >,
-    _bitfield: self::_pinternal::bitvec::BitArray<0usize>,
+    _bitfield: self::_pinternal::BitArray<0usize>,
 }
 impl OneofOptions {
     pub fn uninterpreted_option(
         &self,
     ) -> &[self::_root::google::protobuf::UninterpretedOption] {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::UninterpretedOption,
         > as RepeatedFieldType>::get_field(&self.uninterpreted_option, &self._bitfield)
     }
     pub fn uninterpreted_option_mut(
         &mut self,
     ) -> &mut ::std::vec::Vec::<self::_root::google::protobuf::UninterpretedOption> {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::UninterpretedOption,
         > as RepeatedFieldType>::get_field_mut(
             &mut self.uninterpreted_option,
@@ -7448,8 +7448,8 @@ impl OneofOptions {
         )
     }
     pub fn clear_uninterpreted_option(&mut self) {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::UninterpretedOption,
         > as RepeatedFieldType>::clear(
             &mut self.uninterpreted_option,
@@ -7471,14 +7471,14 @@ impl self::_puroro::Message for OneofOptions {
     ) -> self::_puroro::Result<()> {
         use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 999i32 => {
-                    <self::_pinternal::field_type::RepeatedMessageField::<
+                    <self::_pinternal::RepeatedMessageField::<
                         self::_root::google::protobuf::UninterpretedOption,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.uninterpreted_option,
                         &mut self._bitfield,
                         field_data,
@@ -7495,10 +7495,10 @@ impl self::_puroro::Message for OneofOptions {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::OneofUnion as _;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::UninterpretedOption,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.uninterpreted_option,
             &self._bitfield,
             999i32,
@@ -7510,7 +7510,7 @@ impl self::_puroro::Message for OneofOptions {
 impl ::std::clone::Clone for OneofOptions {
     fn clone(&self) -> Self {
         Self {
-            uninterpreted_option: <self::_pinternal::field_type::RepeatedMessageField::<
+            uninterpreted_option: <self::_pinternal::RepeatedMessageField::<
                 self::_root::google::protobuf::UninterpretedOption,
             > as ::std::clone::Clone>::clone(&self.uninterpreted_option),
             _bitfield: ::std::clone::Clone::clone(&self._bitfield),
@@ -7520,7 +7520,7 @@ impl ::std::clone::Clone for OneofOptions {
 impl ::std::ops::Drop for OneofOptions {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for OneofOptions {
@@ -7536,31 +7536,31 @@ impl ::std::fmt::Debug for OneofOptions {
 impl ::std::cmp::PartialEq for OneofOptions {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         true && self.uninterpreted_option() == rhs.uninterpreted_option()
     }
 }
 #[derive(::std::default::Default)]
 pub struct EnumOptions {
-    allow_alias: self::_pinternal::field_type::OptionalNumericalField::<
+    allow_alias: self::_pinternal::OptionalNumericalField::<
         bool,
         self::_pinternal::tags::Bool,
         0usize,
     >,
-    deprecated: self::_pinternal::field_type::OptionalNumericalField::<
+    deprecated: self::_pinternal::OptionalNumericalField::<
         bool,
         self::_pinternal::tags::Bool,
         1usize,
     >,
-    uninterpreted_option: self::_pinternal::field_type::RepeatedMessageField::<
+    uninterpreted_option: self::_pinternal::RepeatedMessageField::<
         self::_root::google::protobuf::UninterpretedOption,
     >,
-    _bitfield: self::_pinternal::bitvec::BitArray<1usize>,
+    _bitfield: self::_pinternal::BitArray<1usize>,
 }
 impl EnumOptions {
     pub fn allow_alias(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             0usize,
@@ -7571,16 +7571,16 @@ impl EnumOptions {
         )
     }
     pub fn allow_alias_opt(&self) -> ::std::option::Option::<bool> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.allow_alias, &self._bitfield)
     }
     pub fn allow_alias_mut(&mut self) -> &mut bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             0usize,
@@ -7591,8 +7591,8 @@ impl EnumOptions {
         )
     }
     pub fn has_allow_alias(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             0usize,
@@ -7600,16 +7600,16 @@ impl EnumOptions {
             .is_some()
     }
     pub fn clear_allow_alias(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             0usize,
         > as NonRepeatedFieldType>::clear(&mut self.allow_alias, &mut self._bitfield)
     }
     pub fn deprecated(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             1usize,
@@ -7620,16 +7620,16 @@ impl EnumOptions {
         )
     }
     pub fn deprecated_opt(&self) -> ::std::option::Option::<bool> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             1usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.deprecated, &self._bitfield)
     }
     pub fn deprecated_mut(&mut self) -> &mut bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             1usize,
@@ -7640,8 +7640,8 @@ impl EnumOptions {
         )
     }
     pub fn has_deprecated(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             1usize,
@@ -7649,8 +7649,8 @@ impl EnumOptions {
             .is_some()
     }
     pub fn clear_deprecated(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             1usize,
@@ -7659,16 +7659,16 @@ impl EnumOptions {
     pub fn uninterpreted_option(
         &self,
     ) -> &[self::_root::google::protobuf::UninterpretedOption] {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::UninterpretedOption,
         > as RepeatedFieldType>::get_field(&self.uninterpreted_option, &self._bitfield)
     }
     pub fn uninterpreted_option_mut(
         &mut self,
     ) -> &mut ::std::vec::Vec::<self::_root::google::protobuf::UninterpretedOption> {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::UninterpretedOption,
         > as RepeatedFieldType>::get_field_mut(
             &mut self.uninterpreted_option,
@@ -7676,8 +7676,8 @@ impl EnumOptions {
         )
     }
     pub fn clear_uninterpreted_option(&mut self) {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::UninterpretedOption,
         > as RepeatedFieldType>::clear(
             &mut self.uninterpreted_option,
@@ -7699,36 +7699,36 @@ impl self::_puroro::Message for EnumOptions {
     ) -> self::_puroro::Result<()> {
         use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 2i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         bool,
                         self::_pinternal::tags::Bool,
                         0usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.allow_alias,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 3i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         bool,
                         self::_pinternal::tags::Bool,
                         1usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.deprecated,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 999i32 => {
-                    <self::_pinternal::field_type::RepeatedMessageField::<
+                    <self::_pinternal::RepeatedMessageField::<
                         self::_root::google::protobuf::UninterpretedOption,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.uninterpreted_option,
                         &mut self._bitfield,
                         field_data,
@@ -7745,30 +7745,30 @@ impl self::_puroro::Message for EnumOptions {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::OneofUnion as _;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             0usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.allow_alias,
             &self._bitfield,
             2i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             1usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.deprecated,
             &self._bitfield,
             3i32,
             out,
         )?;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::UninterpretedOption,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.uninterpreted_option,
             &self._bitfield,
             999i32,
@@ -7780,17 +7780,17 @@ impl self::_puroro::Message for EnumOptions {
 impl ::std::clone::Clone for EnumOptions {
     fn clone(&self) -> Self {
         Self {
-            allow_alias: <self::_pinternal::field_type::OptionalNumericalField::<
+            allow_alias: <self::_pinternal::OptionalNumericalField::<
                 bool,
                 self::_pinternal::tags::Bool,
                 0usize,
             > as ::std::clone::Clone>::clone(&self.allow_alias),
-            deprecated: <self::_pinternal::field_type::OptionalNumericalField::<
+            deprecated: <self::_pinternal::OptionalNumericalField::<
                 bool,
                 self::_pinternal::tags::Bool,
                 1usize,
             > as ::std::clone::Clone>::clone(&self.deprecated),
-            uninterpreted_option: <self::_pinternal::field_type::RepeatedMessageField::<
+            uninterpreted_option: <self::_pinternal::RepeatedMessageField::<
                 self::_root::google::protobuf::UninterpretedOption,
             > as ::std::clone::Clone>::clone(&self.uninterpreted_option),
             _bitfield: ::std::clone::Clone::clone(&self._bitfield),
@@ -7800,7 +7800,7 @@ impl ::std::clone::Clone for EnumOptions {
 impl ::std::ops::Drop for EnumOptions {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for EnumOptions {
@@ -7818,7 +7818,7 @@ impl ::std::fmt::Debug for EnumOptions {
 impl ::std::cmp::PartialEq for EnumOptions {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         true && self.allow_alias_opt() == rhs.allow_alias_opt()
             && self.deprecated_opt() == rhs.deprecated_opt()
             && self.uninterpreted_option() == rhs.uninterpreted_option()
@@ -7826,20 +7826,20 @@ impl ::std::cmp::PartialEq for EnumOptions {
 }
 #[derive(::std::default::Default)]
 pub struct EnumValueOptions {
-    deprecated: self::_pinternal::field_type::OptionalNumericalField::<
+    deprecated: self::_pinternal::OptionalNumericalField::<
         bool,
         self::_pinternal::tags::Bool,
         0usize,
     >,
-    uninterpreted_option: self::_pinternal::field_type::RepeatedMessageField::<
+    uninterpreted_option: self::_pinternal::RepeatedMessageField::<
         self::_root::google::protobuf::UninterpretedOption,
     >,
-    _bitfield: self::_pinternal::bitvec::BitArray<1usize>,
+    _bitfield: self::_pinternal::BitArray<1usize>,
 }
 impl EnumValueOptions {
     pub fn deprecated(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             0usize,
@@ -7850,16 +7850,16 @@ impl EnumValueOptions {
         )
     }
     pub fn deprecated_opt(&self) -> ::std::option::Option::<bool> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.deprecated, &self._bitfield)
     }
     pub fn deprecated_mut(&mut self) -> &mut bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             0usize,
@@ -7870,8 +7870,8 @@ impl EnumValueOptions {
         )
     }
     pub fn has_deprecated(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             0usize,
@@ -7879,8 +7879,8 @@ impl EnumValueOptions {
             .is_some()
     }
     pub fn clear_deprecated(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             0usize,
@@ -7889,16 +7889,16 @@ impl EnumValueOptions {
     pub fn uninterpreted_option(
         &self,
     ) -> &[self::_root::google::protobuf::UninterpretedOption] {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::UninterpretedOption,
         > as RepeatedFieldType>::get_field(&self.uninterpreted_option, &self._bitfield)
     }
     pub fn uninterpreted_option_mut(
         &mut self,
     ) -> &mut ::std::vec::Vec::<self::_root::google::protobuf::UninterpretedOption> {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::UninterpretedOption,
         > as RepeatedFieldType>::get_field_mut(
             &mut self.uninterpreted_option,
@@ -7906,8 +7906,8 @@ impl EnumValueOptions {
         )
     }
     pub fn clear_uninterpreted_option(&mut self) {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::UninterpretedOption,
         > as RepeatedFieldType>::clear(
             &mut self.uninterpreted_option,
@@ -7929,25 +7929,25 @@ impl self::_puroro::Message for EnumValueOptions {
     ) -> self::_puroro::Result<()> {
         use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 1i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         bool,
                         self::_pinternal::tags::Bool,
                         0usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.deprecated,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 999i32 => {
-                    <self::_pinternal::field_type::RepeatedMessageField::<
+                    <self::_pinternal::RepeatedMessageField::<
                         self::_root::google::protobuf::UninterpretedOption,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.uninterpreted_option,
                         &mut self._bitfield,
                         field_data,
@@ -7964,20 +7964,20 @@ impl self::_puroro::Message for EnumValueOptions {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::OneofUnion as _;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             0usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.deprecated,
             &self._bitfield,
             1i32,
             out,
         )?;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::UninterpretedOption,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.uninterpreted_option,
             &self._bitfield,
             999i32,
@@ -7989,12 +7989,12 @@ impl self::_puroro::Message for EnumValueOptions {
 impl ::std::clone::Clone for EnumValueOptions {
     fn clone(&self) -> Self {
         Self {
-            deprecated: <self::_pinternal::field_type::OptionalNumericalField::<
+            deprecated: <self::_pinternal::OptionalNumericalField::<
                 bool,
                 self::_pinternal::tags::Bool,
                 0usize,
             > as ::std::clone::Clone>::clone(&self.deprecated),
-            uninterpreted_option: <self::_pinternal::field_type::RepeatedMessageField::<
+            uninterpreted_option: <self::_pinternal::RepeatedMessageField::<
                 self::_root::google::protobuf::UninterpretedOption,
             > as ::std::clone::Clone>::clone(&self.uninterpreted_option),
             _bitfield: ::std::clone::Clone::clone(&self._bitfield),
@@ -8004,7 +8004,7 @@ impl ::std::clone::Clone for EnumValueOptions {
 impl ::std::ops::Drop for EnumValueOptions {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for EnumValueOptions {
@@ -8021,27 +8021,27 @@ impl ::std::fmt::Debug for EnumValueOptions {
 impl ::std::cmp::PartialEq for EnumValueOptions {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         true && self.deprecated_opt() == rhs.deprecated_opt()
             && self.uninterpreted_option() == rhs.uninterpreted_option()
     }
 }
 #[derive(::std::default::Default)]
 pub struct ServiceOptions {
-    deprecated: self::_pinternal::field_type::OptionalNumericalField::<
+    deprecated: self::_pinternal::OptionalNumericalField::<
         bool,
         self::_pinternal::tags::Bool,
         0usize,
     >,
-    uninterpreted_option: self::_pinternal::field_type::RepeatedMessageField::<
+    uninterpreted_option: self::_pinternal::RepeatedMessageField::<
         self::_root::google::protobuf::UninterpretedOption,
     >,
-    _bitfield: self::_pinternal::bitvec::BitArray<1usize>,
+    _bitfield: self::_pinternal::BitArray<1usize>,
 }
 impl ServiceOptions {
     pub fn deprecated(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             0usize,
@@ -8052,16 +8052,16 @@ impl ServiceOptions {
         )
     }
     pub fn deprecated_opt(&self) -> ::std::option::Option::<bool> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.deprecated, &self._bitfield)
     }
     pub fn deprecated_mut(&mut self) -> &mut bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             0usize,
@@ -8072,8 +8072,8 @@ impl ServiceOptions {
         )
     }
     pub fn has_deprecated(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             0usize,
@@ -8081,8 +8081,8 @@ impl ServiceOptions {
             .is_some()
     }
     pub fn clear_deprecated(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             0usize,
@@ -8091,16 +8091,16 @@ impl ServiceOptions {
     pub fn uninterpreted_option(
         &self,
     ) -> &[self::_root::google::protobuf::UninterpretedOption] {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::UninterpretedOption,
         > as RepeatedFieldType>::get_field(&self.uninterpreted_option, &self._bitfield)
     }
     pub fn uninterpreted_option_mut(
         &mut self,
     ) -> &mut ::std::vec::Vec::<self::_root::google::protobuf::UninterpretedOption> {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::UninterpretedOption,
         > as RepeatedFieldType>::get_field_mut(
             &mut self.uninterpreted_option,
@@ -8108,8 +8108,8 @@ impl ServiceOptions {
         )
     }
     pub fn clear_uninterpreted_option(&mut self) {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::UninterpretedOption,
         > as RepeatedFieldType>::clear(
             &mut self.uninterpreted_option,
@@ -8131,25 +8131,25 @@ impl self::_puroro::Message for ServiceOptions {
     ) -> self::_puroro::Result<()> {
         use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 33i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         bool,
                         self::_pinternal::tags::Bool,
                         0usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.deprecated,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 999i32 => {
-                    <self::_pinternal::field_type::RepeatedMessageField::<
+                    <self::_pinternal::RepeatedMessageField::<
                         self::_root::google::protobuf::UninterpretedOption,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.uninterpreted_option,
                         &mut self._bitfield,
                         field_data,
@@ -8166,20 +8166,20 @@ impl self::_puroro::Message for ServiceOptions {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::OneofUnion as _;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             0usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.deprecated,
             &self._bitfield,
             33i32,
             out,
         )?;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::UninterpretedOption,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.uninterpreted_option,
             &self._bitfield,
             999i32,
@@ -8191,12 +8191,12 @@ impl self::_puroro::Message for ServiceOptions {
 impl ::std::clone::Clone for ServiceOptions {
     fn clone(&self) -> Self {
         Self {
-            deprecated: <self::_pinternal::field_type::OptionalNumericalField::<
+            deprecated: <self::_pinternal::OptionalNumericalField::<
                 bool,
                 self::_pinternal::tags::Bool,
                 0usize,
             > as ::std::clone::Clone>::clone(&self.deprecated),
-            uninterpreted_option: <self::_pinternal::field_type::RepeatedMessageField::<
+            uninterpreted_option: <self::_pinternal::RepeatedMessageField::<
                 self::_root::google::protobuf::UninterpretedOption,
             > as ::std::clone::Clone>::clone(&self.uninterpreted_option),
             _bitfield: ::std::clone::Clone::clone(&self._bitfield),
@@ -8206,7 +8206,7 @@ impl ::std::clone::Clone for ServiceOptions {
 impl ::std::ops::Drop for ServiceOptions {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for ServiceOptions {
@@ -8223,34 +8223,34 @@ impl ::std::fmt::Debug for ServiceOptions {
 impl ::std::cmp::PartialEq for ServiceOptions {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         true && self.deprecated_opt() == rhs.deprecated_opt()
             && self.uninterpreted_option() == rhs.uninterpreted_option()
     }
 }
 #[derive(::std::default::Default)]
 pub struct MethodOptions {
-    deprecated: self::_pinternal::field_type::OptionalNumericalField::<
+    deprecated: self::_pinternal::OptionalNumericalField::<
         bool,
         self::_pinternal::tags::Bool,
         0usize,
     >,
-    idempotency_level: self::_pinternal::field_type::OptionalNumericalField::<
+    idempotency_level: self::_pinternal::OptionalNumericalField::<
         self::_root::google::protobuf::method_options::IdempotencyLevel,
         self::_pinternal::tags::Enum2::<
             self::_root::google::protobuf::method_options::IdempotencyLevel,
         >,
         1usize,
     >,
-    uninterpreted_option: self::_pinternal::field_type::RepeatedMessageField::<
+    uninterpreted_option: self::_pinternal::RepeatedMessageField::<
         self::_root::google::protobuf::UninterpretedOption,
     >,
-    _bitfield: self::_pinternal::bitvec::BitArray<1usize>,
+    _bitfield: self::_pinternal::BitArray<1usize>,
 }
 impl MethodOptions {
     pub fn deprecated(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             0usize,
@@ -8261,16 +8261,16 @@ impl MethodOptions {
         )
     }
     pub fn deprecated_opt(&self) -> ::std::option::Option::<bool> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.deprecated, &self._bitfield)
     }
     pub fn deprecated_mut(&mut self) -> &mut bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             0usize,
@@ -8281,8 +8281,8 @@ impl MethodOptions {
         )
     }
     pub fn has_deprecated(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             0usize,
@@ -8290,8 +8290,8 @@ impl MethodOptions {
             .is_some()
     }
     pub fn clear_deprecated(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             0usize,
@@ -8300,8 +8300,8 @@ impl MethodOptions {
     pub fn idempotency_level(
         &self,
     ) -> self::_root::google::protobuf::method_options::IdempotencyLevel {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             self::_root::google::protobuf::method_options::IdempotencyLevel,
             self::_pinternal::tags::Enum2::<
                 self::_root::google::protobuf::method_options::IdempotencyLevel,
@@ -8320,8 +8320,8 @@ impl MethodOptions {
     ) -> ::std::option::Option::<
         self::_root::google::protobuf::method_options::IdempotencyLevel,
     > {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             self::_root::google::protobuf::method_options::IdempotencyLevel,
             self::_pinternal::tags::Enum2::<
                 self::_root::google::protobuf::method_options::IdempotencyLevel,
@@ -8335,8 +8335,8 @@ impl MethodOptions {
     pub fn idempotency_level_mut(
         &mut self,
     ) -> &mut self::_root::google::protobuf::method_options::IdempotencyLevel {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             self::_root::google::protobuf::method_options::IdempotencyLevel,
             self::_pinternal::tags::Enum2::<
                 self::_root::google::protobuf::method_options::IdempotencyLevel,
@@ -8351,8 +8351,8 @@ impl MethodOptions {
         )
     }
     pub fn has_idempotency_level(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             self::_root::google::protobuf::method_options::IdempotencyLevel,
             self::_pinternal::tags::Enum2::<
                 self::_root::google::protobuf::method_options::IdempotencyLevel,
@@ -8365,8 +8365,8 @@ impl MethodOptions {
             .is_some()
     }
     pub fn clear_idempotency_level(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             self::_root::google::protobuf::method_options::IdempotencyLevel,
             self::_pinternal::tags::Enum2::<
                 self::_root::google::protobuf::method_options::IdempotencyLevel,
@@ -8380,16 +8380,16 @@ impl MethodOptions {
     pub fn uninterpreted_option(
         &self,
     ) -> &[self::_root::google::protobuf::UninterpretedOption] {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::UninterpretedOption,
         > as RepeatedFieldType>::get_field(&self.uninterpreted_option, &self._bitfield)
     }
     pub fn uninterpreted_option_mut(
         &mut self,
     ) -> &mut ::std::vec::Vec::<self::_root::google::protobuf::UninterpretedOption> {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::UninterpretedOption,
         > as RepeatedFieldType>::get_field_mut(
             &mut self.uninterpreted_option,
@@ -8397,8 +8397,8 @@ impl MethodOptions {
         )
     }
     pub fn clear_uninterpreted_option(&mut self) {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::UninterpretedOption,
         > as RepeatedFieldType>::clear(
             &mut self.uninterpreted_option,
@@ -8420,38 +8420,38 @@ impl self::_puroro::Message for MethodOptions {
     ) -> self::_puroro::Result<()> {
         use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 33i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         bool,
                         self::_pinternal::tags::Bool,
                         0usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.deprecated,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 34i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         self::_root::google::protobuf::method_options::IdempotencyLevel,
                         self::_pinternal::tags::Enum2::<
                             self::_root::google::protobuf::method_options::IdempotencyLevel,
                         >,
                         1usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.idempotency_level,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 999i32 => {
-                    <self::_pinternal::field_type::RepeatedMessageField::<
+                    <self::_pinternal::RepeatedMessageField::<
                         self::_root::google::protobuf::UninterpretedOption,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.uninterpreted_option,
                         &mut self._bitfield,
                         field_data,
@@ -8468,32 +8468,32 @@ impl self::_puroro::Message for MethodOptions {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::OneofUnion as _;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             0usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.deprecated,
             &self._bitfield,
             33i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        <self::_pinternal::OptionalNumericalField::<
             self::_root::google::protobuf::method_options::IdempotencyLevel,
             self::_pinternal::tags::Enum2::<
                 self::_root::google::protobuf::method_options::IdempotencyLevel,
             >,
             1usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.idempotency_level,
             &self._bitfield,
             34i32,
             out,
         )?;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::UninterpretedOption,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.uninterpreted_option,
             &self._bitfield,
             999i32,
@@ -8505,19 +8505,19 @@ impl self::_puroro::Message for MethodOptions {
 impl ::std::clone::Clone for MethodOptions {
     fn clone(&self) -> Self {
         Self {
-            deprecated: <self::_pinternal::field_type::OptionalNumericalField::<
+            deprecated: <self::_pinternal::OptionalNumericalField::<
                 bool,
                 self::_pinternal::tags::Bool,
                 0usize,
             > as ::std::clone::Clone>::clone(&self.deprecated),
-            idempotency_level: <self::_pinternal::field_type::OptionalNumericalField::<
+            idempotency_level: <self::_pinternal::OptionalNumericalField::<
                 self::_root::google::protobuf::method_options::IdempotencyLevel,
                 self::_pinternal::tags::Enum2::<
                     self::_root::google::protobuf::method_options::IdempotencyLevel,
                 >,
                 1usize,
             > as ::std::clone::Clone>::clone(&self.idempotency_level),
-            uninterpreted_option: <self::_pinternal::field_type::RepeatedMessageField::<
+            uninterpreted_option: <self::_pinternal::RepeatedMessageField::<
                 self::_root::google::protobuf::UninterpretedOption,
             > as ::std::clone::Clone>::clone(&self.uninterpreted_option),
             _bitfield: ::std::clone::Clone::clone(&self._bitfield),
@@ -8527,7 +8527,7 @@ impl ::std::clone::Clone for MethodOptions {
 impl ::std::ops::Drop for MethodOptions {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for MethodOptions {
@@ -8545,7 +8545,7 @@ impl ::std::fmt::Debug for MethodOptions {
 impl ::std::cmp::PartialEq for MethodOptions {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         true && self.deprecated_opt() == rhs.deprecated_opt()
             && self.idempotency_level_opt() == rhs.idempotency_level_opt()
             && self.uninterpreted_option() == rhs.uninterpreted_option()
@@ -8553,47 +8553,47 @@ impl ::std::cmp::PartialEq for MethodOptions {
 }
 #[derive(::std::default::Default)]
 pub struct UninterpretedOption {
-    name: self::_pinternal::field_type::RepeatedMessageField::<
+    name: self::_pinternal::RepeatedMessageField::<
         self::_root::google::protobuf::uninterpreted_option::NamePart,
     >,
-    identifier_value: self::_pinternal::field_type::OptionalUnsizedField::<
+    identifier_value: self::_pinternal::OptionalUnsizedField::<
         ::std::string::String,
         self::_pinternal::tags::String,
         0usize,
     >,
-    positive_int_value: self::_pinternal::field_type::OptionalNumericalField::<
+    positive_int_value: self::_pinternal::OptionalNumericalField::<
         u64,
         self::_pinternal::tags::UInt64,
         1usize,
     >,
-    negative_int_value: self::_pinternal::field_type::OptionalNumericalField::<
+    negative_int_value: self::_pinternal::OptionalNumericalField::<
         i64,
         self::_pinternal::tags::Int64,
         2usize,
     >,
-    double_value: self::_pinternal::field_type::OptionalNumericalField::<
+    double_value: self::_pinternal::OptionalNumericalField::<
         f64,
         self::_pinternal::tags::Double,
         3usize,
     >,
-    string_value: self::_pinternal::field_type::OptionalUnsizedField::<
+    string_value: self::_pinternal::OptionalUnsizedField::<
         ::std::vec::Vec<u8>,
         self::_pinternal::tags::Bytes,
         4usize,
     >,
-    aggregate_value: self::_pinternal::field_type::OptionalUnsizedField::<
+    aggregate_value: self::_pinternal::OptionalUnsizedField::<
         ::std::string::String,
         self::_pinternal::tags::String,
         5usize,
     >,
-    _bitfield: self::_pinternal::bitvec::BitArray<1usize>,
+    _bitfield: self::_pinternal::BitArray<1usize>,
 }
 impl UninterpretedOption {
     pub fn name(
         &self,
     ) -> &[self::_root::google::protobuf::uninterpreted_option::NamePart] {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::uninterpreted_option::NamePart,
         > as RepeatedFieldType>::get_field(&self.name, &self._bitfield)
     }
@@ -8602,20 +8602,20 @@ impl UninterpretedOption {
     ) -> &mut ::std::vec::Vec::<
         self::_root::google::protobuf::uninterpreted_option::NamePart,
     > {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::uninterpreted_option::NamePart,
         > as RepeatedFieldType>::get_field_mut(&mut self.name, &mut self._bitfield)
     }
     pub fn clear_name(&mut self) {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::uninterpreted_option::NamePart,
         > as RepeatedFieldType>::clear(&mut self.name, &mut self._bitfield)
     }
     pub fn identifier_value(&self) -> &str {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
@@ -8626,8 +8626,8 @@ impl UninterpretedOption {
         )
     }
     pub fn identifier_value_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
@@ -8637,8 +8637,8 @@ impl UninterpretedOption {
         )
     }
     pub fn identifier_value_mut(&mut self) -> &mut ::std::string::String {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
@@ -8649,8 +8649,8 @@ impl UninterpretedOption {
         )
     }
     pub fn has_identifier_value(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
@@ -8661,8 +8661,8 @@ impl UninterpretedOption {
             .is_some()
     }
     pub fn clear_identifier_value(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
@@ -8672,8 +8672,8 @@ impl UninterpretedOption {
         )
     }
     pub fn positive_int_value(&self) -> u64 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             u64,
             self::_pinternal::tags::UInt64,
             1usize,
@@ -8684,8 +8684,8 @@ impl UninterpretedOption {
         )
     }
     pub fn positive_int_value_opt(&self) -> ::std::option::Option::<u64> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             u64,
             self::_pinternal::tags::UInt64,
             1usize,
@@ -8695,8 +8695,8 @@ impl UninterpretedOption {
         )
     }
     pub fn positive_int_value_mut(&mut self) -> &mut u64 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             u64,
             self::_pinternal::tags::UInt64,
             1usize,
@@ -8707,8 +8707,8 @@ impl UninterpretedOption {
         )
     }
     pub fn has_positive_int_value(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             u64,
             self::_pinternal::tags::UInt64,
             1usize,
@@ -8719,8 +8719,8 @@ impl UninterpretedOption {
             .is_some()
     }
     pub fn clear_positive_int_value(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             u64,
             self::_pinternal::tags::UInt64,
             1usize,
@@ -8730,8 +8730,8 @@ impl UninterpretedOption {
         )
     }
     pub fn negative_int_value(&self) -> i64 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i64,
             self::_pinternal::tags::Int64,
             2usize,
@@ -8742,8 +8742,8 @@ impl UninterpretedOption {
         )
     }
     pub fn negative_int_value_opt(&self) -> ::std::option::Option::<i64> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i64,
             self::_pinternal::tags::Int64,
             2usize,
@@ -8753,8 +8753,8 @@ impl UninterpretedOption {
         )
     }
     pub fn negative_int_value_mut(&mut self) -> &mut i64 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i64,
             self::_pinternal::tags::Int64,
             2usize,
@@ -8765,8 +8765,8 @@ impl UninterpretedOption {
         )
     }
     pub fn has_negative_int_value(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i64,
             self::_pinternal::tags::Int64,
             2usize,
@@ -8777,8 +8777,8 @@ impl UninterpretedOption {
             .is_some()
     }
     pub fn clear_negative_int_value(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i64,
             self::_pinternal::tags::Int64,
             2usize,
@@ -8788,8 +8788,8 @@ impl UninterpretedOption {
         )
     }
     pub fn double_value(&self) -> f64 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             f64,
             self::_pinternal::tags::Double,
             3usize,
@@ -8800,16 +8800,16 @@ impl UninterpretedOption {
         )
     }
     pub fn double_value_opt(&self) -> ::std::option::Option::<f64> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             f64,
             self::_pinternal::tags::Double,
             3usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.double_value, &self._bitfield)
     }
     pub fn double_value_mut(&mut self) -> &mut f64 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             f64,
             self::_pinternal::tags::Double,
             3usize,
@@ -8820,8 +8820,8 @@ impl UninterpretedOption {
         )
     }
     pub fn has_double_value(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             f64,
             self::_pinternal::tags::Double,
             3usize,
@@ -8829,16 +8829,16 @@ impl UninterpretedOption {
             .is_some()
     }
     pub fn clear_double_value(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             f64,
             self::_pinternal::tags::Double,
             3usize,
         > as NonRepeatedFieldType>::clear(&mut self.double_value, &mut self._bitfield)
     }
     pub fn string_value(&self) -> &[u8] {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::vec::Vec<u8>,
             self::_pinternal::tags::Bytes,
             4usize,
@@ -8849,16 +8849,16 @@ impl UninterpretedOption {
         )
     }
     pub fn string_value_opt(&self) -> ::std::option::Option::<&[u8]> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::vec::Vec<u8>,
             self::_pinternal::tags::Bytes,
             4usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.string_value, &self._bitfield)
     }
     pub fn string_value_mut(&mut self) -> &mut ::std::vec::Vec::<u8> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::vec::Vec<u8>,
             self::_pinternal::tags::Bytes,
             4usize,
@@ -8869,8 +8869,8 @@ impl UninterpretedOption {
         )
     }
     pub fn has_string_value(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::vec::Vec<u8>,
             self::_pinternal::tags::Bytes,
             4usize,
@@ -8878,16 +8878,16 @@ impl UninterpretedOption {
             .is_some()
     }
     pub fn clear_string_value(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::vec::Vec<u8>,
             self::_pinternal::tags::Bytes,
             4usize,
         > as NonRepeatedFieldType>::clear(&mut self.string_value, &mut self._bitfield)
     }
     pub fn aggregate_value(&self) -> &str {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             5usize,
@@ -8898,16 +8898,16 @@ impl UninterpretedOption {
         )
     }
     pub fn aggregate_value_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             5usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.aggregate_value, &self._bitfield)
     }
     pub fn aggregate_value_mut(&mut self) -> &mut ::std::string::String {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             5usize,
@@ -8918,8 +8918,8 @@ impl UninterpretedOption {
         )
     }
     pub fn has_aggregate_value(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             5usize,
@@ -8927,8 +8927,8 @@ impl UninterpretedOption {
             .is_some()
     }
     pub fn clear_aggregate_value(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             5usize,
@@ -8949,80 +8949,80 @@ impl self::_puroro::Message for UninterpretedOption {
     ) -> self::_puroro::Result<()> {
         use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 2i32 => {
-                    <self::_pinternal::field_type::RepeatedMessageField::<
+                    <self::_pinternal::RepeatedMessageField::<
                         self::_root::google::protobuf::uninterpreted_option::NamePart,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.name,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 3i32 => {
-                    <self::_pinternal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::OptionalUnsizedField::<
                         ::std::string::String,
                         self::_pinternal::tags::String,
                         0usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.identifier_value,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 4i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         u64,
                         self::_pinternal::tags::UInt64,
                         1usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.positive_int_value,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 5i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         i64,
                         self::_pinternal::tags::Int64,
                         2usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.negative_int_value,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 6i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         f64,
                         self::_pinternal::tags::Double,
                         3usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.double_value,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 7i32 => {
-                    <self::_pinternal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::OptionalUnsizedField::<
                         ::std::vec::Vec<u8>,
                         self::_pinternal::tags::Bytes,
                         4usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.string_value,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 8i32 => {
-                    <self::_pinternal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::OptionalUnsizedField::<
                         ::std::string::String,
                         self::_pinternal::tags::String,
                         5usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.aggregate_value,
                         &mut self._bitfield,
                         field_data,
@@ -9039,70 +9039,70 @@ impl self::_puroro::Message for UninterpretedOption {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::OneofUnion as _;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::uninterpreted_option::NamePart,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.name,
             &self._bitfield,
             2i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.identifier_value,
             &self._bitfield,
             3i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        <self::_pinternal::OptionalNumericalField::<
             u64,
             self::_pinternal::tags::UInt64,
             1usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.positive_int_value,
             &self._bitfield,
             4i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        <self::_pinternal::OptionalNumericalField::<
             i64,
             self::_pinternal::tags::Int64,
             2usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.negative_int_value,
             &self._bitfield,
             5i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        <self::_pinternal::OptionalNumericalField::<
             f64,
             self::_pinternal::tags::Double,
             3usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.double_value,
             &self._bitfield,
             6i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::vec::Vec<u8>,
             self::_pinternal::tags::Bytes,
             4usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.string_value,
             &self._bitfield,
             7i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             5usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.aggregate_value,
             &self._bitfield,
             8i32,
@@ -9114,35 +9114,35 @@ impl self::_puroro::Message for UninterpretedOption {
 impl ::std::clone::Clone for UninterpretedOption {
     fn clone(&self) -> Self {
         Self {
-            name: <self::_pinternal::field_type::RepeatedMessageField::<
+            name: <self::_pinternal::RepeatedMessageField::<
                 self::_root::google::protobuf::uninterpreted_option::NamePart,
             > as ::std::clone::Clone>::clone(&self.name),
-            identifier_value: <self::_pinternal::field_type::OptionalUnsizedField::<
+            identifier_value: <self::_pinternal::OptionalUnsizedField::<
                 ::std::string::String,
                 self::_pinternal::tags::String,
                 0usize,
             > as ::std::clone::Clone>::clone(&self.identifier_value),
-            positive_int_value: <self::_pinternal::field_type::OptionalNumericalField::<
+            positive_int_value: <self::_pinternal::OptionalNumericalField::<
                 u64,
                 self::_pinternal::tags::UInt64,
                 1usize,
             > as ::std::clone::Clone>::clone(&self.positive_int_value),
-            negative_int_value: <self::_pinternal::field_type::OptionalNumericalField::<
+            negative_int_value: <self::_pinternal::OptionalNumericalField::<
                 i64,
                 self::_pinternal::tags::Int64,
                 2usize,
             > as ::std::clone::Clone>::clone(&self.negative_int_value),
-            double_value: <self::_pinternal::field_type::OptionalNumericalField::<
+            double_value: <self::_pinternal::OptionalNumericalField::<
                 f64,
                 self::_pinternal::tags::Double,
                 3usize,
             > as ::std::clone::Clone>::clone(&self.double_value),
-            string_value: <self::_pinternal::field_type::OptionalUnsizedField::<
+            string_value: <self::_pinternal::OptionalUnsizedField::<
                 ::std::vec::Vec<u8>,
                 self::_pinternal::tags::Bytes,
                 4usize,
             > as ::std::clone::Clone>::clone(&self.string_value),
-            aggregate_value: <self::_pinternal::field_type::OptionalUnsizedField::<
+            aggregate_value: <self::_pinternal::OptionalUnsizedField::<
                 ::std::string::String,
                 self::_pinternal::tags::String,
                 5usize,
@@ -9154,7 +9154,7 @@ impl ::std::clone::Clone for UninterpretedOption {
 impl ::std::ops::Drop for UninterpretedOption {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for UninterpretedOption {
@@ -9176,7 +9176,7 @@ impl ::std::fmt::Debug for UninterpretedOption {
 impl ::std::cmp::PartialEq for UninterpretedOption {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         true && self.name() == rhs.name()
             && self.identifier_value_opt() == rhs.identifier_value_opt()
             && self.positive_int_value_opt() == rhs.positive_int_value_opt()
@@ -9188,17 +9188,17 @@ impl ::std::cmp::PartialEq for UninterpretedOption {
 }
 #[derive(::std::default::Default)]
 pub struct SourceCodeInfo {
-    location: self::_pinternal::field_type::RepeatedMessageField::<
+    location: self::_pinternal::RepeatedMessageField::<
         self::_root::google::protobuf::source_code_info::Location,
     >,
-    _bitfield: self::_pinternal::bitvec::BitArray<0usize>,
+    _bitfield: self::_pinternal::BitArray<0usize>,
 }
 impl SourceCodeInfo {
     pub fn location(
         &self,
     ) -> &[self::_root::google::protobuf::source_code_info::Location] {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::source_code_info::Location,
         > as RepeatedFieldType>::get_field(&self.location, &self._bitfield)
     }
@@ -9207,14 +9207,14 @@ impl SourceCodeInfo {
     ) -> &mut ::std::vec::Vec::<
         self::_root::google::protobuf::source_code_info::Location,
     > {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::source_code_info::Location,
         > as RepeatedFieldType>::get_field_mut(&mut self.location, &mut self._bitfield)
     }
     pub fn clear_location(&mut self) {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::source_code_info::Location,
         > as RepeatedFieldType>::clear(&mut self.location, &mut self._bitfield)
     }
@@ -9233,14 +9233,14 @@ impl self::_puroro::Message for SourceCodeInfo {
     ) -> self::_puroro::Result<()> {
         use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 1i32 => {
-                    <self::_pinternal::field_type::RepeatedMessageField::<
+                    <self::_pinternal::RepeatedMessageField::<
                         self::_root::google::protobuf::source_code_info::Location,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.location,
                         &mut self._bitfield,
                         field_data,
@@ -9257,10 +9257,10 @@ impl self::_puroro::Message for SourceCodeInfo {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::OneofUnion as _;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::source_code_info::Location,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.location,
             &self._bitfield,
             1i32,
@@ -9272,7 +9272,7 @@ impl self::_puroro::Message for SourceCodeInfo {
 impl ::std::clone::Clone for SourceCodeInfo {
     fn clone(&self) -> Self {
         Self {
-            location: <self::_pinternal::field_type::RepeatedMessageField::<
+            location: <self::_pinternal::RepeatedMessageField::<
                 self::_root::google::protobuf::source_code_info::Location,
             > as ::std::clone::Clone>::clone(&self.location),
             _bitfield: ::std::clone::Clone::clone(&self._bitfield),
@@ -9282,7 +9282,7 @@ impl ::std::clone::Clone for SourceCodeInfo {
 impl ::std::ops::Drop for SourceCodeInfo {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for SourceCodeInfo {
@@ -9298,23 +9298,23 @@ impl ::std::fmt::Debug for SourceCodeInfo {
 impl ::std::cmp::PartialEq for SourceCodeInfo {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         true && self.location() == rhs.location()
     }
 }
 #[derive(::std::default::Default)]
 pub struct GeneratedCodeInfo {
-    annotation: self::_pinternal::field_type::RepeatedMessageField::<
+    annotation: self::_pinternal::RepeatedMessageField::<
         self::_root::google::protobuf::generated_code_info::Annotation,
     >,
-    _bitfield: self::_pinternal::bitvec::BitArray<0usize>,
+    _bitfield: self::_pinternal::BitArray<0usize>,
 }
 impl GeneratedCodeInfo {
     pub fn annotation(
         &self,
     ) -> &[self::_root::google::protobuf::generated_code_info::Annotation] {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::generated_code_info::Annotation,
         > as RepeatedFieldType>::get_field(&self.annotation, &self._bitfield)
     }
@@ -9323,14 +9323,14 @@ impl GeneratedCodeInfo {
     ) -> &mut ::std::vec::Vec::<
         self::_root::google::protobuf::generated_code_info::Annotation,
     > {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::generated_code_info::Annotation,
         > as RepeatedFieldType>::get_field_mut(&mut self.annotation, &mut self._bitfield)
     }
     pub fn clear_annotation(&mut self) {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::generated_code_info::Annotation,
         > as RepeatedFieldType>::clear(&mut self.annotation, &mut self._bitfield)
     }
@@ -9349,14 +9349,14 @@ impl self::_puroro::Message for GeneratedCodeInfo {
     ) -> self::_puroro::Result<()> {
         use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 1i32 => {
-                    <self::_pinternal::field_type::RepeatedMessageField::<
+                    <self::_pinternal::RepeatedMessageField::<
                         self::_root::google::protobuf::generated_code_info::Annotation,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.annotation,
                         &mut self._bitfield,
                         field_data,
@@ -9373,10 +9373,10 @@ impl self::_puroro::Message for GeneratedCodeInfo {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::OneofUnion as _;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::generated_code_info::Annotation,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.annotation,
             &self._bitfield,
             1i32,
@@ -9388,7 +9388,7 @@ impl self::_puroro::Message for GeneratedCodeInfo {
 impl ::std::clone::Clone for GeneratedCodeInfo {
     fn clone(&self) -> Self {
         Self {
-            annotation: <self::_pinternal::field_type::RepeatedMessageField::<
+            annotation: <self::_pinternal::RepeatedMessageField::<
                 self::_root::google::protobuf::generated_code_info::Annotation,
             > as ::std::clone::Clone>::clone(&self.annotation),
             _bitfield: ::std::clone::Clone::clone(&self._bitfield),
@@ -9398,7 +9398,7 @@ impl ::std::clone::Clone for GeneratedCodeInfo {
 impl ::std::ops::Drop for GeneratedCodeInfo {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for GeneratedCodeInfo {
@@ -9414,7 +9414,7 @@ impl ::std::fmt::Debug for GeneratedCodeInfo {
 impl ::std::cmp::PartialEq for GeneratedCodeInfo {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         true && self.annotation() == rhs.annotation()
     }
 }

--- a/puroro-protobuf-compiled/src/google/protobuf/compiler.rs
+++ b/puroro-protobuf-compiled/src/google/protobuf/compiler.rs
@@ -13,32 +13,32 @@ mod _pinternal {
 pub mod code_generator_response;
 #[derive(::std::default::Default)]
 pub struct Version {
-    major: self::_pinternal::field_type::OptionalNumericalField::<
+    major: self::_pinternal::OptionalNumericalField::<
         i32,
         self::_pinternal::tags::Int32,
         0usize,
     >,
-    minor: self::_pinternal::field_type::OptionalNumericalField::<
+    minor: self::_pinternal::OptionalNumericalField::<
         i32,
         self::_pinternal::tags::Int32,
         1usize,
     >,
-    patch: self::_pinternal::field_type::OptionalNumericalField::<
+    patch: self::_pinternal::OptionalNumericalField::<
         i32,
         self::_pinternal::tags::Int32,
         2usize,
     >,
-    suffix: self::_pinternal::field_type::OptionalUnsizedField::<
+    suffix: self::_pinternal::OptionalUnsizedField::<
         ::std::string::String,
         self::_pinternal::tags::String,
         3usize,
     >,
-    _bitfield: self::_pinternal::bitvec::BitArray<1usize>,
+    _bitfield: self::_pinternal::BitArray<1usize>,
 }
 impl Version {
     pub fn major(&self) -> i32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             0usize,
@@ -49,16 +49,16 @@ impl Version {
         )
     }
     pub fn major_opt(&self) -> ::std::option::Option::<i32> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.major, &self._bitfield)
     }
     pub fn major_mut(&mut self) -> &mut i32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             0usize,
@@ -69,8 +69,8 @@ impl Version {
         )
     }
     pub fn has_major(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             0usize,
@@ -78,16 +78,16 @@ impl Version {
             .is_some()
     }
     pub fn clear_major(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             0usize,
         > as NonRepeatedFieldType>::clear(&mut self.major, &mut self._bitfield)
     }
     pub fn minor(&self) -> i32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             1usize,
@@ -98,16 +98,16 @@ impl Version {
         )
     }
     pub fn minor_opt(&self) -> ::std::option::Option::<i32> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             1usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.minor, &self._bitfield)
     }
     pub fn minor_mut(&mut self) -> &mut i32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             1usize,
@@ -118,8 +118,8 @@ impl Version {
         )
     }
     pub fn has_minor(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             1usize,
@@ -127,16 +127,16 @@ impl Version {
             .is_some()
     }
     pub fn clear_minor(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             1usize,
         > as NonRepeatedFieldType>::clear(&mut self.minor, &mut self._bitfield)
     }
     pub fn patch(&self) -> i32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             2usize,
@@ -147,16 +147,16 @@ impl Version {
         )
     }
     pub fn patch_opt(&self) -> ::std::option::Option::<i32> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             2usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.patch, &self._bitfield)
     }
     pub fn patch_mut(&mut self) -> &mut i32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             2usize,
@@ -167,8 +167,8 @@ impl Version {
         )
     }
     pub fn has_patch(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             2usize,
@@ -176,16 +176,16 @@ impl Version {
             .is_some()
     }
     pub fn clear_patch(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             2usize,
         > as NonRepeatedFieldType>::clear(&mut self.patch, &mut self._bitfield)
     }
     pub fn suffix(&self) -> &str {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             3usize,
@@ -196,16 +196,16 @@ impl Version {
         )
     }
     pub fn suffix_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             3usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.suffix, &self._bitfield)
     }
     pub fn suffix_mut(&mut self) -> &mut ::std::string::String {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             3usize,
@@ -216,8 +216,8 @@ impl Version {
         )
     }
     pub fn has_suffix(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             3usize,
@@ -225,8 +225,8 @@ impl Version {
             .is_some()
     }
     pub fn clear_suffix(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             3usize,
@@ -247,49 +247,49 @@ impl self::_puroro::Message for Version {
     ) -> self::_puroro::Result<()> {
         use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 1i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         i32,
                         self::_pinternal::tags::Int32,
                         0usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.major,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 2i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         i32,
                         self::_pinternal::tags::Int32,
                         1usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.minor,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 3i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         i32,
                         self::_pinternal::tags::Int32,
                         2usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.patch,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 4i32 => {
-                    <self::_pinternal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::OptionalUnsizedField::<
                         ::std::string::String,
                         self::_pinternal::tags::String,
                         3usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.suffix,
                         &mut self._bitfield,
                         field_data,
@@ -306,42 +306,42 @@ impl self::_puroro::Message for Version {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::OneofUnion as _;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             0usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.major,
             &self._bitfield,
             1i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             1usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.minor,
             &self._bitfield,
             2i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             2usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.patch,
             &self._bitfield,
             3i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             3usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.suffix,
             &self._bitfield,
             4i32,
@@ -353,22 +353,22 @@ impl self::_puroro::Message for Version {
 impl ::std::clone::Clone for Version {
     fn clone(&self) -> Self {
         Self {
-            major: <self::_pinternal::field_type::OptionalNumericalField::<
+            major: <self::_pinternal::OptionalNumericalField::<
                 i32,
                 self::_pinternal::tags::Int32,
                 0usize,
             > as ::std::clone::Clone>::clone(&self.major),
-            minor: <self::_pinternal::field_type::OptionalNumericalField::<
+            minor: <self::_pinternal::OptionalNumericalField::<
                 i32,
                 self::_pinternal::tags::Int32,
                 1usize,
             > as ::std::clone::Clone>::clone(&self.minor),
-            patch: <self::_pinternal::field_type::OptionalNumericalField::<
+            patch: <self::_pinternal::OptionalNumericalField::<
                 i32,
                 self::_pinternal::tags::Int32,
                 2usize,
             > as ::std::clone::Clone>::clone(&self.patch),
-            suffix: <self::_pinternal::field_type::OptionalUnsizedField::<
+            suffix: <self::_pinternal::OptionalUnsizedField::<
                 ::std::string::String,
                 self::_pinternal::tags::String,
                 3usize,
@@ -380,7 +380,7 @@ impl ::std::clone::Clone for Version {
 impl ::std::ops::Drop for Version {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for Version {
@@ -399,7 +399,7 @@ impl ::std::fmt::Debug for Version {
 impl ::std::cmp::PartialEq for Version {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         true && self.major_opt() == rhs.major_opt()
             && self.minor_opt() == rhs.minor_opt() && self.patch_opt() == rhs.patch_opt()
             && self.suffix_opt() == rhs.suffix_opt()
@@ -407,22 +407,22 @@ impl ::std::cmp::PartialEq for Version {
 }
 #[derive(::std::default::Default)]
 pub struct CodeGeneratorRequest {
-    file_to_generate: self::_pinternal::field_type::RepeatedUnsizedField::<
+    file_to_generate: self::_pinternal::RepeatedUnsizedField::<
         ::std::string::String,
         self::_pinternal::tags::String,
     >,
-    parameter: self::_pinternal::field_type::OptionalUnsizedField::<
+    parameter: self::_pinternal::OptionalUnsizedField::<
         ::std::string::String,
         self::_pinternal::tags::String,
         0usize,
     >,
-    proto_file: self::_pinternal::field_type::RepeatedMessageField::<
+    proto_file: self::_pinternal::RepeatedMessageField::<
         self::_root::google::protobuf::FileDescriptorProto,
     >,
-    compiler_version: self::_pinternal::field_type::SingularHeapMessageField::<
+    compiler_version: self::_pinternal::SingularHeapMessageField::<
         self::_root::google::protobuf::compiler::Version,
     >,
-    _bitfield: self::_pinternal::bitvec::BitArray<1usize>,
+    _bitfield: self::_pinternal::BitArray<1usize>,
 }
 impl CodeGeneratorRequest {
     pub fn file_to_generate(
@@ -430,8 +430,8 @@ impl CodeGeneratorRequest {
     ) -> &[impl ::std::ops::Deref::<
         Target = str,
     > + ::std::fmt::Debug + ::std::cmp::PartialEq] {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedUnsizedField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
         > as RepeatedFieldType>::get_field(&self.file_to_generate, &self._bitfield)
@@ -439,8 +439,8 @@ impl CodeGeneratorRequest {
     pub fn file_to_generate_mut(
         &mut self,
     ) -> &mut ::std::vec::Vec::<::std::string::String> {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedUnsizedField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
         > as RepeatedFieldType>::get_field_mut(
@@ -449,15 +449,15 @@ impl CodeGeneratorRequest {
         )
     }
     pub fn clear_file_to_generate(&mut self) {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedUnsizedField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
         > as RepeatedFieldType>::clear(&mut self.file_to_generate, &mut self._bitfield)
     }
     pub fn parameter(&self) -> &str {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
@@ -468,16 +468,16 @@ impl CodeGeneratorRequest {
         )
     }
     pub fn parameter_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.parameter, &self._bitfield)
     }
     pub fn parameter_mut(&mut self) -> &mut ::std::string::String {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
@@ -488,8 +488,8 @@ impl CodeGeneratorRequest {
         )
     }
     pub fn has_parameter(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
@@ -497,38 +497,38 @@ impl CodeGeneratorRequest {
             .is_some()
     }
     pub fn clear_parameter(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::clear(&mut self.parameter, &mut self._bitfield)
     }
     pub fn proto_file(&self) -> &[self::_root::google::protobuf::FileDescriptorProto] {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::FileDescriptorProto,
         > as RepeatedFieldType>::get_field(&self.proto_file, &self._bitfield)
     }
     pub fn proto_file_mut(
         &mut self,
     ) -> &mut ::std::vec::Vec::<self::_root::google::protobuf::FileDescriptorProto> {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::FileDescriptorProto,
         > as RepeatedFieldType>::get_field_mut(&mut self.proto_file, &mut self._bitfield)
     }
     pub fn clear_proto_file(&mut self) {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::FileDescriptorProto,
         > as RepeatedFieldType>::clear(&mut self.proto_file, &mut self._bitfield)
     }
     pub fn compiler_version(
         &self,
     ) -> ::std::option::Option::<&self::_root::google::protobuf::compiler::Version> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::google::protobuf::compiler::Version,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.compiler_version,
@@ -539,8 +539,8 @@ impl CodeGeneratorRequest {
     pub fn compiler_version_opt(
         &self,
     ) -> ::std::option::Option::<&self::_root::google::protobuf::compiler::Version> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::google::protobuf::compiler::Version,
         > as NonRepeatedFieldType>::get_field_opt(
             &self.compiler_version,
@@ -550,8 +550,8 @@ impl CodeGeneratorRequest {
     pub fn compiler_version_mut(
         &mut self,
     ) -> &mut self::_root::google::protobuf::compiler::Version {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::google::protobuf::compiler::Version,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.compiler_version,
@@ -560,8 +560,8 @@ impl CodeGeneratorRequest {
         )
     }
     pub fn has_compiler_version(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::google::protobuf::compiler::Version,
         > as NonRepeatedFieldType>::get_field_opt(
                 &self.compiler_version,
@@ -570,8 +570,8 @@ impl CodeGeneratorRequest {
             .is_some()
     }
     pub fn clear_compiler_version(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::google::protobuf::compiler::Version,
         > as NonRepeatedFieldType>::clear(
             &mut self.compiler_version,
@@ -593,44 +593,44 @@ impl self::_puroro::Message for CodeGeneratorRequest {
     ) -> self::_puroro::Result<()> {
         use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 1i32 => {
-                    <self::_pinternal::field_type::RepeatedUnsizedField::<
+                    <self::_pinternal::RepeatedUnsizedField::<
                         ::std::string::String,
                         self::_pinternal::tags::String,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.file_to_generate,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 2i32 => {
-                    <self::_pinternal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::OptionalUnsizedField::<
                         ::std::string::String,
                         self::_pinternal::tags::String,
                         0usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.parameter,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 15i32 => {
-                    <self::_pinternal::field_type::RepeatedMessageField::<
+                    <self::_pinternal::RepeatedMessageField::<
                         self::_root::google::protobuf::FileDescriptorProto,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.proto_file,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 3i32 => {
-                    <self::_pinternal::field_type::SingularHeapMessageField::<
+                    <self::_pinternal::SingularHeapMessageField::<
                         self::_root::google::protobuf::compiler::Version,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.compiler_version,
                         &mut self._bitfield,
                         field_data,
@@ -647,37 +647,37 @@ impl self::_puroro::Message for CodeGeneratorRequest {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
-        <self::_pinternal::field_type::RepeatedUnsizedField::<
+        use self::_pinternal::OneofUnion as _;
+        <self::_pinternal::RepeatedUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.file_to_generate,
             &self._bitfield,
             1i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.parameter,
             &self._bitfield,
             2i32,
             out,
         )?;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::FileDescriptorProto,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.proto_file,
             &self._bitfield,
             15i32,
             out,
         )?;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::google::protobuf::compiler::Version,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.compiler_version,
             &self._bitfield,
             3i32,
@@ -689,19 +689,19 @@ impl self::_puroro::Message for CodeGeneratorRequest {
 impl ::std::clone::Clone for CodeGeneratorRequest {
     fn clone(&self) -> Self {
         Self {
-            file_to_generate: <self::_pinternal::field_type::RepeatedUnsizedField::<
+            file_to_generate: <self::_pinternal::RepeatedUnsizedField::<
                 ::std::string::String,
                 self::_pinternal::tags::String,
             > as ::std::clone::Clone>::clone(&self.file_to_generate),
-            parameter: <self::_pinternal::field_type::OptionalUnsizedField::<
+            parameter: <self::_pinternal::OptionalUnsizedField::<
                 ::std::string::String,
                 self::_pinternal::tags::String,
                 0usize,
             > as ::std::clone::Clone>::clone(&self.parameter),
-            proto_file: <self::_pinternal::field_type::RepeatedMessageField::<
+            proto_file: <self::_pinternal::RepeatedMessageField::<
                 self::_root::google::protobuf::FileDescriptorProto,
             > as ::std::clone::Clone>::clone(&self.proto_file),
-            compiler_version: <self::_pinternal::field_type::SingularHeapMessageField::<
+            compiler_version: <self::_pinternal::SingularHeapMessageField::<
                 self::_root::google::protobuf::compiler::Version,
             > as ::std::clone::Clone>::clone(&self.compiler_version),
             _bitfield: ::std::clone::Clone::clone(&self._bitfield),
@@ -711,7 +711,7 @@ impl ::std::clone::Clone for CodeGeneratorRequest {
 impl ::std::ops::Drop for CodeGeneratorRequest {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for CodeGeneratorRequest {
@@ -730,7 +730,7 @@ impl ::std::fmt::Debug for CodeGeneratorRequest {
 impl ::std::cmp::PartialEq for CodeGeneratorRequest {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         true && self.file_to_generate() == rhs.file_to_generate()
             && self.parameter_opt() == rhs.parameter_opt()
             && self.proto_file() == rhs.proto_file()
@@ -739,25 +739,25 @@ impl ::std::cmp::PartialEq for CodeGeneratorRequest {
 }
 #[derive(::std::default::Default)]
 pub struct CodeGeneratorResponse {
-    error: self::_pinternal::field_type::OptionalUnsizedField::<
+    error: self::_pinternal::OptionalUnsizedField::<
         ::std::string::String,
         self::_pinternal::tags::String,
         0usize,
     >,
-    supported_features: self::_pinternal::field_type::OptionalNumericalField::<
+    supported_features: self::_pinternal::OptionalNumericalField::<
         u64,
         self::_pinternal::tags::UInt64,
         1usize,
     >,
-    file: self::_pinternal::field_type::RepeatedMessageField::<
+    file: self::_pinternal::RepeatedMessageField::<
         self::_root::google::protobuf::compiler::code_generator_response::File,
     >,
-    _bitfield: self::_pinternal::bitvec::BitArray<1usize>,
+    _bitfield: self::_pinternal::BitArray<1usize>,
 }
 impl CodeGeneratorResponse {
     pub fn error(&self) -> &str {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
@@ -768,16 +768,16 @@ impl CodeGeneratorResponse {
         )
     }
     pub fn error_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.error, &self._bitfield)
     }
     pub fn error_mut(&mut self) -> &mut ::std::string::String {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
@@ -788,8 +788,8 @@ impl CodeGeneratorResponse {
         )
     }
     pub fn has_error(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
@@ -797,16 +797,16 @@ impl CodeGeneratorResponse {
             .is_some()
     }
     pub fn clear_error(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::clear(&mut self.error, &mut self._bitfield)
     }
     pub fn supported_features(&self) -> u64 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             u64,
             self::_pinternal::tags::UInt64,
             1usize,
@@ -817,8 +817,8 @@ impl CodeGeneratorResponse {
         )
     }
     pub fn supported_features_opt(&self) -> ::std::option::Option::<u64> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             u64,
             self::_pinternal::tags::UInt64,
             1usize,
@@ -828,8 +828,8 @@ impl CodeGeneratorResponse {
         )
     }
     pub fn supported_features_mut(&mut self) -> &mut u64 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             u64,
             self::_pinternal::tags::UInt64,
             1usize,
@@ -840,8 +840,8 @@ impl CodeGeneratorResponse {
         )
     }
     pub fn has_supported_features(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             u64,
             self::_pinternal::tags::UInt64,
             1usize,
@@ -852,8 +852,8 @@ impl CodeGeneratorResponse {
             .is_some()
     }
     pub fn clear_supported_features(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             u64,
             self::_pinternal::tags::UInt64,
             1usize,
@@ -865,8 +865,8 @@ impl CodeGeneratorResponse {
     pub fn file(
         &self,
     ) -> &[self::_root::google::protobuf::compiler::code_generator_response::File] {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::compiler::code_generator_response::File,
         > as RepeatedFieldType>::get_field(&self.file, &self._bitfield)
     }
@@ -875,14 +875,14 @@ impl CodeGeneratorResponse {
     ) -> &mut ::std::vec::Vec::<
         self::_root::google::protobuf::compiler::code_generator_response::File,
     > {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::compiler::code_generator_response::File,
         > as RepeatedFieldType>::get_field_mut(&mut self.file, &mut self._bitfield)
     }
     pub fn clear_file(&mut self) {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::compiler::code_generator_response::File,
         > as RepeatedFieldType>::clear(&mut self.file, &mut self._bitfield)
     }
@@ -901,36 +901,36 @@ impl self::_puroro::Message for CodeGeneratorResponse {
     ) -> self::_puroro::Result<()> {
         use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 1i32 => {
-                    <self::_pinternal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::OptionalUnsizedField::<
                         ::std::string::String,
                         self::_pinternal::tags::String,
                         0usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.error,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 2i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         u64,
                         self::_pinternal::tags::UInt64,
                         1usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.supported_features,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 15i32 => {
-                    <self::_pinternal::field_type::RepeatedMessageField::<
+                    <self::_pinternal::RepeatedMessageField::<
                         self::_root::google::protobuf::compiler::code_generator_response::File,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.file,
                         &mut self._bitfield,
                         field_data,
@@ -947,30 +947,30 @@ impl self::_puroro::Message for CodeGeneratorResponse {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::OneofUnion as _;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.error,
             &self._bitfield,
             1i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        <self::_pinternal::OptionalNumericalField::<
             u64,
             self::_pinternal::tags::UInt64,
             1usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.supported_features,
             &self._bitfield,
             2i32,
             out,
         )?;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::google::protobuf::compiler::code_generator_response::File,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.file,
             &self._bitfield,
             15i32,
@@ -982,17 +982,17 @@ impl self::_puroro::Message for CodeGeneratorResponse {
 impl ::std::clone::Clone for CodeGeneratorResponse {
     fn clone(&self) -> Self {
         Self {
-            error: <self::_pinternal::field_type::OptionalUnsizedField::<
+            error: <self::_pinternal::OptionalUnsizedField::<
                 ::std::string::String,
                 self::_pinternal::tags::String,
                 0usize,
             > as ::std::clone::Clone>::clone(&self.error),
-            supported_features: <self::_pinternal::field_type::OptionalNumericalField::<
+            supported_features: <self::_pinternal::OptionalNumericalField::<
                 u64,
                 self::_pinternal::tags::UInt64,
                 1usize,
             > as ::std::clone::Clone>::clone(&self.supported_features),
-            file: <self::_pinternal::field_type::RepeatedMessageField::<
+            file: <self::_pinternal::RepeatedMessageField::<
                 self::_root::google::protobuf::compiler::code_generator_response::File,
             > as ::std::clone::Clone>::clone(&self.file),
             _bitfield: ::std::clone::Clone::clone(&self._bitfield),
@@ -1002,7 +1002,7 @@ impl ::std::clone::Clone for CodeGeneratorResponse {
 impl ::std::ops::Drop for CodeGeneratorResponse {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for CodeGeneratorResponse {
@@ -1020,7 +1020,7 @@ impl ::std::fmt::Debug for CodeGeneratorResponse {
 impl ::std::cmp::PartialEq for CodeGeneratorResponse {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         true && self.error_opt() == rhs.error_opt()
             && self.supported_features_opt() == rhs.supported_features_opt()
             && self.file() == rhs.file()

--- a/puroro-protobuf-compiled/src/google/protobuf/compiler.rs
+++ b/puroro-protobuf-compiled/src/google/protobuf/compiler.rs
@@ -1,42 +1,46 @@
-mod _puroro_root {
+mod _root {
     #[allow(unused)]
-    pub(crate) use super::super::_puroro_root::*;
+    pub(crate) use super::super::_root::*;
 }
 mod _puroro {
     #[allow(unused)]
     pub(crate) use ::puroro::*;
 }
+mod _pinternal {
+    #[allow(unused)]
+    pub(crate) use ::puroro::internal::*;
+}
 pub mod code_generator_response;
 #[derive(::std::default::Default)]
 pub struct Version {
-    major: self::_puroro::internal::field_type::OptionalNumericalField::<
+    major: self::_pinternal::field_type::OptionalNumericalField::<
         i32,
-        self::_puroro::internal::tags::Int32,
+        self::_pinternal::tags::Int32,
         0usize,
     >,
-    minor: self::_puroro::internal::field_type::OptionalNumericalField::<
+    minor: self::_pinternal::field_type::OptionalNumericalField::<
         i32,
-        self::_puroro::internal::tags::Int32,
+        self::_pinternal::tags::Int32,
         1usize,
     >,
-    patch: self::_puroro::internal::field_type::OptionalNumericalField::<
+    patch: self::_pinternal::field_type::OptionalNumericalField::<
         i32,
-        self::_puroro::internal::tags::Int32,
+        self::_pinternal::tags::Int32,
         2usize,
     >,
-    suffix: self::_puroro::internal::field_type::OptionalUnsizedField::<
+    suffix: self::_pinternal::field_type::OptionalUnsizedField::<
         ::std::string::String,
-        self::_puroro::internal::tags::String,
+        self::_pinternal::tags::String,
         3usize,
     >,
-    _bitfield: self::_puroro::internal::bitvec::BitArray<1usize>,
+    _bitfield: self::_pinternal::bitvec::BitArray<1usize>,
 }
 impl Version {
     pub fn major(&self) -> i32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             0usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.major,
@@ -45,18 +49,18 @@ impl Version {
         )
     }
     pub fn major_opt(&self) -> ::std::option::Option::<i32> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.major, &self._bitfield)
     }
     pub fn major_mut(&mut self) -> &mut i32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             0usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.major,
@@ -65,27 +69,27 @@ impl Version {
         )
     }
     pub fn has_major(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.major, &self._bitfield)
             .is_some()
     }
     pub fn clear_major(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             0usize,
         > as NonRepeatedFieldType>::clear(&mut self.major, &mut self._bitfield)
     }
     pub fn minor(&self) -> i32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             1usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.minor,
@@ -94,18 +98,18 @@ impl Version {
         )
     }
     pub fn minor_opt(&self) -> ::std::option::Option::<i32> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             1usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.minor, &self._bitfield)
     }
     pub fn minor_mut(&mut self) -> &mut i32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             1usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.minor,
@@ -114,27 +118,27 @@ impl Version {
         )
     }
     pub fn has_minor(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             1usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.minor, &self._bitfield)
             .is_some()
     }
     pub fn clear_minor(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             1usize,
         > as NonRepeatedFieldType>::clear(&mut self.minor, &mut self._bitfield)
     }
     pub fn patch(&self) -> i32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             2usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.patch,
@@ -143,18 +147,18 @@ impl Version {
         )
     }
     pub fn patch_opt(&self) -> ::std::option::Option::<i32> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             2usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.patch, &self._bitfield)
     }
     pub fn patch_mut(&mut self) -> &mut i32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             2usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.patch,
@@ -163,27 +167,27 @@ impl Version {
         )
     }
     pub fn has_patch(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             2usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.patch, &self._bitfield)
             .is_some()
     }
     pub fn clear_patch(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             2usize,
         > as NonRepeatedFieldType>::clear(&mut self.patch, &mut self._bitfield)
     }
     pub fn suffix(&self) -> &str {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             3usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.suffix,
@@ -192,18 +196,18 @@ impl Version {
         )
     }
     pub fn suffix_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             3usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.suffix, &self._bitfield)
     }
     pub fn suffix_mut(&mut self) -> &mut ::std::string::String {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             3usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.suffix,
@@ -212,19 +216,19 @@ impl Version {
         )
     }
     pub fn has_suffix(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             3usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.suffix, &self._bitfield)
             .is_some()
     }
     pub fn clear_suffix(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             3usize,
         > as NonRepeatedFieldType>::clear(&mut self.suffix, &mut self._bitfield)
     }
@@ -241,51 +245,51 @@ impl self::_puroro::Message for Version {
         &mut self,
         mut iter: I,
     ) -> self::_puroro::Result<()> {
-        use self::_puroro::internal::ser::FieldData;
+        use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 1i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         i32,
-                        self::_puroro::internal::tags::Int32,
+                        self::_pinternal::tags::Int32,
                         0usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.major,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 2i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         i32,
-                        self::_puroro::internal::tags::Int32,
+                        self::_pinternal::tags::Int32,
                         1usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.minor,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 3i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         i32,
-                        self::_puroro::internal::tags::Int32,
+                        self::_pinternal::tags::Int32,
                         2usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.patch,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 4i32 => {
-                    <self::_puroro::internal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::field_type::OptionalUnsizedField::<
                         ::std::string::String,
-                        self::_puroro::internal::tags::String,
+                        self::_pinternal::tags::String,
                         3usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.suffix,
                         &mut self._bitfield,
                         field_data,
@@ -302,42 +306,42 @@ impl self::_puroro::Message for Version {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::oneof_type::OneofUnion as _;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             0usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.major,
             &self._bitfield,
             1i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             1usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.minor,
             &self._bitfield,
             2i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             2usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.patch,
             &self._bitfield,
             3i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             3usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.suffix,
             &self._bitfield,
             4i32,
@@ -349,24 +353,24 @@ impl self::_puroro::Message for Version {
 impl ::std::clone::Clone for Version {
     fn clone(&self) -> Self {
         Self {
-            major: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            major: <self::_pinternal::field_type::OptionalNumericalField::<
                 i32,
-                self::_puroro::internal::tags::Int32,
+                self::_pinternal::tags::Int32,
                 0usize,
             > as ::std::clone::Clone>::clone(&self.major),
-            minor: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            minor: <self::_pinternal::field_type::OptionalNumericalField::<
                 i32,
-                self::_puroro::internal::tags::Int32,
+                self::_pinternal::tags::Int32,
                 1usize,
             > as ::std::clone::Clone>::clone(&self.minor),
-            patch: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            patch: <self::_pinternal::field_type::OptionalNumericalField::<
                 i32,
-                self::_puroro::internal::tags::Int32,
+                self::_pinternal::tags::Int32,
                 2usize,
             > as ::std::clone::Clone>::clone(&self.patch),
-            suffix: <self::_puroro::internal::field_type::OptionalUnsizedField::<
+            suffix: <self::_pinternal::field_type::OptionalUnsizedField::<
                 ::std::string::String,
-                self::_puroro::internal::tags::String,
+                self::_pinternal::tags::String,
                 3usize,
             > as ::std::clone::Clone>::clone(&self.suffix),
             _bitfield: ::std::clone::Clone::clone(&self._bitfield),
@@ -376,7 +380,7 @@ impl ::std::clone::Clone for Version {
 impl ::std::ops::Drop for Version {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for Version {
@@ -395,7 +399,7 @@ impl ::std::fmt::Debug for Version {
 impl ::std::cmp::PartialEq for Version {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         true && self.major_opt() == rhs.major_opt()
             && self.minor_opt() == rhs.minor_opt() && self.patch_opt() == rhs.patch_opt()
             && self.suffix_opt() == rhs.suffix_opt()
@@ -403,22 +407,22 @@ impl ::std::cmp::PartialEq for Version {
 }
 #[derive(::std::default::Default)]
 pub struct CodeGeneratorRequest {
-    file_to_generate: self::_puroro::internal::field_type::RepeatedUnsizedField::<
+    file_to_generate: self::_pinternal::field_type::RepeatedUnsizedField::<
         ::std::string::String,
-        self::_puroro::internal::tags::String,
+        self::_pinternal::tags::String,
     >,
-    parameter: self::_puroro::internal::field_type::OptionalUnsizedField::<
+    parameter: self::_pinternal::field_type::OptionalUnsizedField::<
         ::std::string::String,
-        self::_puroro::internal::tags::String,
+        self::_pinternal::tags::String,
         0usize,
     >,
-    proto_file: self::_puroro::internal::field_type::RepeatedMessageField::<
-        self::_puroro_root::google::protobuf::FileDescriptorProto,
+    proto_file: self::_pinternal::field_type::RepeatedMessageField::<
+        self::_root::google::protobuf::FileDescriptorProto,
     >,
-    compiler_version: self::_puroro::internal::field_type::SingularHeapMessageField::<
-        self::_puroro_root::google::protobuf::compiler::Version,
+    compiler_version: self::_pinternal::field_type::SingularHeapMessageField::<
+        self::_root::google::protobuf::compiler::Version,
     >,
-    _bitfield: self::_puroro::internal::bitvec::BitArray<1usize>,
+    _bitfield: self::_pinternal::bitvec::BitArray<1usize>,
 }
 impl CodeGeneratorRequest {
     pub fn file_to_generate(
@@ -426,36 +430,36 @@ impl CodeGeneratorRequest {
     ) -> &[impl ::std::ops::Deref::<
         Target = str,
     > + ::std::fmt::Debug + ::std::cmp::PartialEq] {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedUnsizedField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
         > as RepeatedFieldType>::get_field(&self.file_to_generate, &self._bitfield)
     }
     pub fn file_to_generate_mut(
         &mut self,
     ) -> &mut ::std::vec::Vec::<::std::string::String> {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedUnsizedField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
         > as RepeatedFieldType>::get_field_mut(
             &mut self.file_to_generate,
             &mut self._bitfield,
         )
     }
     pub fn clear_file_to_generate(&mut self) {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedUnsizedField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
         > as RepeatedFieldType>::clear(&mut self.file_to_generate, &mut self._bitfield)
     }
     pub fn parameter(&self) -> &str {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.parameter,
@@ -464,18 +468,18 @@ impl CodeGeneratorRequest {
         )
     }
     pub fn parameter_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.parameter, &self._bitfield)
     }
     pub fn parameter_mut(&mut self) -> &mut ::std::string::String {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.parameter,
@@ -484,54 +488,48 @@ impl CodeGeneratorRequest {
         )
     }
     pub fn has_parameter(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.parameter, &self._bitfield)
             .is_some()
     }
     pub fn clear_parameter(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::clear(&mut self.parameter, &mut self._bitfield)
     }
-    pub fn proto_file(
-        &self,
-    ) -> &[self::_puroro_root::google::protobuf::FileDescriptorProto] {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::FileDescriptorProto,
+    pub fn proto_file(&self) -> &[self::_root::google::protobuf::FileDescriptorProto] {
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::FileDescriptorProto,
         > as RepeatedFieldType>::get_field(&self.proto_file, &self._bitfield)
     }
     pub fn proto_file_mut(
         &mut self,
-    ) -> &mut ::std::vec::Vec::<
-        self::_puroro_root::google::protobuf::FileDescriptorProto,
-    > {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::FileDescriptorProto,
+    ) -> &mut ::std::vec::Vec::<self::_root::google::protobuf::FileDescriptorProto> {
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::FileDescriptorProto,
         > as RepeatedFieldType>::get_field_mut(&mut self.proto_file, &mut self._bitfield)
     }
     pub fn clear_proto_file(&mut self) {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::FileDescriptorProto,
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::FileDescriptorProto,
         > as RepeatedFieldType>::clear(&mut self.proto_file, &mut self._bitfield)
     }
     pub fn compiler_version(
         &self,
-    ) -> ::std::option::Option::<
-        &self::_puroro_root::google::protobuf::compiler::Version,
-    > {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::google::protobuf::compiler::Version,
+    ) -> ::std::option::Option::<&self::_root::google::protobuf::compiler::Version> {
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::google::protobuf::compiler::Version,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.compiler_version,
             &self._bitfield,
@@ -540,12 +538,10 @@ impl CodeGeneratorRequest {
     }
     pub fn compiler_version_opt(
         &self,
-    ) -> ::std::option::Option::<
-        &self::_puroro_root::google::protobuf::compiler::Version,
-    > {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::google::protobuf::compiler::Version,
+    ) -> ::std::option::Option::<&self::_root::google::protobuf::compiler::Version> {
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::google::protobuf::compiler::Version,
         > as NonRepeatedFieldType>::get_field_opt(
             &self.compiler_version,
             &self._bitfield,
@@ -553,10 +549,10 @@ impl CodeGeneratorRequest {
     }
     pub fn compiler_version_mut(
         &mut self,
-    ) -> &mut self::_puroro_root::google::protobuf::compiler::Version {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::google::protobuf::compiler::Version,
+    ) -> &mut self::_root::google::protobuf::compiler::Version {
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::google::protobuf::compiler::Version,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.compiler_version,
             &mut self._bitfield,
@@ -564,9 +560,9 @@ impl CodeGeneratorRequest {
         )
     }
     pub fn has_compiler_version(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::google::protobuf::compiler::Version,
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::google::protobuf::compiler::Version,
         > as NonRepeatedFieldType>::get_field_opt(
                 &self.compiler_version,
                 &self._bitfield,
@@ -574,9 +570,9 @@ impl CodeGeneratorRequest {
             .is_some()
     }
     pub fn clear_compiler_version(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::google::protobuf::compiler::Version,
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::google::protobuf::compiler::Version,
         > as NonRepeatedFieldType>::clear(
             &mut self.compiler_version,
             &mut self._bitfield,
@@ -595,46 +591,46 @@ impl self::_puroro::Message for CodeGeneratorRequest {
         &mut self,
         mut iter: I,
     ) -> self::_puroro::Result<()> {
-        use self::_puroro::internal::ser::FieldData;
+        use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 1i32 => {
-                    <self::_puroro::internal::field_type::RepeatedUnsizedField::<
+                    <self::_pinternal::field_type::RepeatedUnsizedField::<
                         ::std::string::String,
-                        self::_puroro::internal::tags::String,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                        self::_pinternal::tags::String,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.file_to_generate,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 2i32 => {
-                    <self::_puroro::internal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::field_type::OptionalUnsizedField::<
                         ::std::string::String,
-                        self::_puroro::internal::tags::String,
+                        self::_pinternal::tags::String,
                         0usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.parameter,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 15i32 => {
-                    <self::_puroro::internal::field_type::RepeatedMessageField::<
-                        self::_puroro_root::google::protobuf::FileDescriptorProto,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    <self::_pinternal::field_type::RepeatedMessageField::<
+                        self::_root::google::protobuf::FileDescriptorProto,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.proto_file,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 3i32 => {
-                    <self::_puroro::internal::field_type::SingularHeapMessageField::<
-                        self::_puroro_root::google::protobuf::compiler::Version,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    <self::_pinternal::field_type::SingularHeapMessageField::<
+                        self::_root::google::protobuf::compiler::Version,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.compiler_version,
                         &mut self._bitfield,
                         field_data,
@@ -651,37 +647,37 @@ impl self::_puroro::Message for CodeGeneratorRequest {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
-        <self::_puroro::internal::field_type::RepeatedUnsizedField::<
+        use self::_pinternal::oneof_type::OneofUnion as _;
+        <self::_pinternal::field_type::RepeatedUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+            self::_pinternal::tags::String,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.file_to_generate,
             &self._bitfield,
             1i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.parameter,
             &self._bitfield,
             2i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::FileDescriptorProto,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::FileDescriptorProto,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.proto_file,
             &self._bitfield,
             15i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::google::protobuf::compiler::Version,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::google::protobuf::compiler::Version,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.compiler_version,
             &self._bitfield,
             3i32,
@@ -693,20 +689,20 @@ impl self::_puroro::Message for CodeGeneratorRequest {
 impl ::std::clone::Clone for CodeGeneratorRequest {
     fn clone(&self) -> Self {
         Self {
-            file_to_generate: <self::_puroro::internal::field_type::RepeatedUnsizedField::<
+            file_to_generate: <self::_pinternal::field_type::RepeatedUnsizedField::<
                 ::std::string::String,
-                self::_puroro::internal::tags::String,
+                self::_pinternal::tags::String,
             > as ::std::clone::Clone>::clone(&self.file_to_generate),
-            parameter: <self::_puroro::internal::field_type::OptionalUnsizedField::<
+            parameter: <self::_pinternal::field_type::OptionalUnsizedField::<
                 ::std::string::String,
-                self::_puroro::internal::tags::String,
+                self::_pinternal::tags::String,
                 0usize,
             > as ::std::clone::Clone>::clone(&self.parameter),
-            proto_file: <self::_puroro::internal::field_type::RepeatedMessageField::<
-                self::_puroro_root::google::protobuf::FileDescriptorProto,
+            proto_file: <self::_pinternal::field_type::RepeatedMessageField::<
+                self::_root::google::protobuf::FileDescriptorProto,
             > as ::std::clone::Clone>::clone(&self.proto_file),
-            compiler_version: <self::_puroro::internal::field_type::SingularHeapMessageField::<
-                self::_puroro_root::google::protobuf::compiler::Version,
+            compiler_version: <self::_pinternal::field_type::SingularHeapMessageField::<
+                self::_root::google::protobuf::compiler::Version,
             > as ::std::clone::Clone>::clone(&self.compiler_version),
             _bitfield: ::std::clone::Clone::clone(&self._bitfield),
         }
@@ -715,7 +711,7 @@ impl ::std::clone::Clone for CodeGeneratorRequest {
 impl ::std::ops::Drop for CodeGeneratorRequest {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for CodeGeneratorRequest {
@@ -734,7 +730,7 @@ impl ::std::fmt::Debug for CodeGeneratorRequest {
 impl ::std::cmp::PartialEq for CodeGeneratorRequest {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         true && self.file_to_generate() == rhs.file_to_generate()
             && self.parameter_opt() == rhs.parameter_opt()
             && self.proto_file() == rhs.proto_file()
@@ -743,27 +739,27 @@ impl ::std::cmp::PartialEq for CodeGeneratorRequest {
 }
 #[derive(::std::default::Default)]
 pub struct CodeGeneratorResponse {
-    error: self::_puroro::internal::field_type::OptionalUnsizedField::<
+    error: self::_pinternal::field_type::OptionalUnsizedField::<
         ::std::string::String,
-        self::_puroro::internal::tags::String,
+        self::_pinternal::tags::String,
         0usize,
     >,
-    supported_features: self::_puroro::internal::field_type::OptionalNumericalField::<
+    supported_features: self::_pinternal::field_type::OptionalNumericalField::<
         u64,
-        self::_puroro::internal::tags::UInt64,
+        self::_pinternal::tags::UInt64,
         1usize,
     >,
-    file: self::_puroro::internal::field_type::RepeatedMessageField::<
-        self::_puroro_root::google::protobuf::compiler::code_generator_response::File,
+    file: self::_pinternal::field_type::RepeatedMessageField::<
+        self::_root::google::protobuf::compiler::code_generator_response::File,
     >,
-    _bitfield: self::_puroro::internal::bitvec::BitArray<1usize>,
+    _bitfield: self::_pinternal::bitvec::BitArray<1usize>,
 }
 impl CodeGeneratorResponse {
     pub fn error(&self) -> &str {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.error,
@@ -772,18 +768,18 @@ impl CodeGeneratorResponse {
         )
     }
     pub fn error_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.error, &self._bitfield)
     }
     pub fn error_mut(&mut self) -> &mut ::std::string::String {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.error,
@@ -792,27 +788,27 @@ impl CodeGeneratorResponse {
         )
     }
     pub fn has_error(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.error, &self._bitfield)
             .is_some()
     }
     pub fn clear_error(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::clear(&mut self.error, &mut self._bitfield)
     }
     pub fn supported_features(&self) -> u64 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u64,
-            self::_puroro::internal::tags::UInt64,
+            self::_pinternal::tags::UInt64,
             1usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.supported_features,
@@ -821,10 +817,10 @@ impl CodeGeneratorResponse {
         )
     }
     pub fn supported_features_opt(&self) -> ::std::option::Option::<u64> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u64,
-            self::_puroro::internal::tags::UInt64,
+            self::_pinternal::tags::UInt64,
             1usize,
         > as NonRepeatedFieldType>::get_field_opt(
             &self.supported_features,
@@ -832,10 +828,10 @@ impl CodeGeneratorResponse {
         )
     }
     pub fn supported_features_mut(&mut self) -> &mut u64 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u64,
-            self::_puroro::internal::tags::UInt64,
+            self::_pinternal::tags::UInt64,
             1usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.supported_features,
@@ -844,10 +840,10 @@ impl CodeGeneratorResponse {
         )
     }
     pub fn has_supported_features(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u64,
-            self::_puroro::internal::tags::UInt64,
+            self::_pinternal::tags::UInt64,
             1usize,
         > as NonRepeatedFieldType>::get_field_opt(
                 &self.supported_features,
@@ -856,10 +852,10 @@ impl CodeGeneratorResponse {
             .is_some()
     }
     pub fn clear_supported_features(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u64,
-            self::_puroro::internal::tags::UInt64,
+            self::_pinternal::tags::UInt64,
             1usize,
         > as NonRepeatedFieldType>::clear(
             &mut self.supported_features,
@@ -868,26 +864,26 @@ impl CodeGeneratorResponse {
     }
     pub fn file(
         &self,
-    ) -> &[self::_puroro_root::google::protobuf::compiler::code_generator_response::File] {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::compiler::code_generator_response::File,
+    ) -> &[self::_root::google::protobuf::compiler::code_generator_response::File] {
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::compiler::code_generator_response::File,
         > as RepeatedFieldType>::get_field(&self.file, &self._bitfield)
     }
     pub fn file_mut(
         &mut self,
     ) -> &mut ::std::vec::Vec::<
-        self::_puroro_root::google::protobuf::compiler::code_generator_response::File,
+        self::_root::google::protobuf::compiler::code_generator_response::File,
     > {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::compiler::code_generator_response::File,
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::compiler::code_generator_response::File,
         > as RepeatedFieldType>::get_field_mut(&mut self.file, &mut self._bitfield)
     }
     pub fn clear_file(&mut self) {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::compiler::code_generator_response::File,
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::compiler::code_generator_response::File,
         > as RepeatedFieldType>::clear(&mut self.file, &mut self._bitfield)
     }
 }
@@ -903,38 +899,38 @@ impl self::_puroro::Message for CodeGeneratorResponse {
         &mut self,
         mut iter: I,
     ) -> self::_puroro::Result<()> {
-        use self::_puroro::internal::ser::FieldData;
+        use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 1i32 => {
-                    <self::_puroro::internal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::field_type::OptionalUnsizedField::<
                         ::std::string::String,
-                        self::_puroro::internal::tags::String,
+                        self::_pinternal::tags::String,
                         0usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.error,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 2i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         u64,
-                        self::_puroro::internal::tags::UInt64,
+                        self::_pinternal::tags::UInt64,
                         1usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.supported_features,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 15i32 => {
-                    <self::_puroro::internal::field_type::RepeatedMessageField::<
-                        self::_puroro_root::google::protobuf::compiler::code_generator_response::File,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    <self::_pinternal::field_type::RepeatedMessageField::<
+                        self::_root::google::protobuf::compiler::code_generator_response::File,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.file,
                         &mut self._bitfield,
                         field_data,
@@ -951,30 +947,30 @@ impl self::_puroro::Message for CodeGeneratorResponse {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::oneof_type::OneofUnion as _;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.error,
             &self._bitfield,
             1i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u64,
-            self::_puroro::internal::tags::UInt64,
+            self::_pinternal::tags::UInt64,
             1usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.supported_features,
             &self._bitfield,
             2i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::google::protobuf::compiler::code_generator_response::File,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::google::protobuf::compiler::code_generator_response::File,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.file,
             &self._bitfield,
             15i32,
@@ -986,18 +982,18 @@ impl self::_puroro::Message for CodeGeneratorResponse {
 impl ::std::clone::Clone for CodeGeneratorResponse {
     fn clone(&self) -> Self {
         Self {
-            error: <self::_puroro::internal::field_type::OptionalUnsizedField::<
+            error: <self::_pinternal::field_type::OptionalUnsizedField::<
                 ::std::string::String,
-                self::_puroro::internal::tags::String,
+                self::_pinternal::tags::String,
                 0usize,
             > as ::std::clone::Clone>::clone(&self.error),
-            supported_features: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            supported_features: <self::_pinternal::field_type::OptionalNumericalField::<
                 u64,
-                self::_puroro::internal::tags::UInt64,
+                self::_pinternal::tags::UInt64,
                 1usize,
             > as ::std::clone::Clone>::clone(&self.supported_features),
-            file: <self::_puroro::internal::field_type::RepeatedMessageField::<
-                self::_puroro_root::google::protobuf::compiler::code_generator_response::File,
+            file: <self::_pinternal::field_type::RepeatedMessageField::<
+                self::_root::google::protobuf::compiler::code_generator_response::File,
             > as ::std::clone::Clone>::clone(&self.file),
             _bitfield: ::std::clone::Clone::clone(&self._bitfield),
         }
@@ -1006,7 +1002,7 @@ impl ::std::clone::Clone for CodeGeneratorResponse {
 impl ::std::ops::Drop for CodeGeneratorResponse {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for CodeGeneratorResponse {
@@ -1024,7 +1020,7 @@ impl ::std::fmt::Debug for CodeGeneratorResponse {
 impl ::std::cmp::PartialEq for CodeGeneratorResponse {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         true && self.error_opt() == rhs.error_opt()
             && self.supported_features_opt() == rhs.supported_features_opt()
             && self.file() == rhs.file()

--- a/puroro-protobuf-compiled/src/google/protobuf/compiler/code_generator_response.rs
+++ b/puroro-protobuf-compiled/src/google/protobuf/compiler/code_generator_response.rs
@@ -1,39 +1,43 @@
-mod _puroro_root {
+mod _root {
     #[allow(unused)]
-    pub(crate) use super::super::_puroro_root::*;
+    pub(crate) use super::super::_root::*;
 }
 mod _puroro {
     #[allow(unused)]
     pub(crate) use ::puroro::*;
 }
+mod _pinternal {
+    #[allow(unused)]
+    pub(crate) use ::puroro::internal::*;
+}
 #[derive(::std::default::Default)]
 pub struct File {
-    name: self::_puroro::internal::field_type::OptionalUnsizedField::<
+    name: self::_pinternal::field_type::OptionalUnsizedField::<
         ::std::string::String,
-        self::_puroro::internal::tags::String,
+        self::_pinternal::tags::String,
         0usize,
     >,
-    insertion_point: self::_puroro::internal::field_type::OptionalUnsizedField::<
+    insertion_point: self::_pinternal::field_type::OptionalUnsizedField::<
         ::std::string::String,
-        self::_puroro::internal::tags::String,
+        self::_pinternal::tags::String,
         1usize,
     >,
-    content: self::_puroro::internal::field_type::OptionalUnsizedField::<
+    content: self::_pinternal::field_type::OptionalUnsizedField::<
         ::std::string::String,
-        self::_puroro::internal::tags::String,
+        self::_pinternal::tags::String,
         2usize,
     >,
-    generated_code_info: self::_puroro::internal::field_type::SingularHeapMessageField::<
-        self::_puroro_root::google::protobuf::GeneratedCodeInfo,
+    generated_code_info: self::_pinternal::field_type::SingularHeapMessageField::<
+        self::_root::google::protobuf::GeneratedCodeInfo,
     >,
-    _bitfield: self::_puroro::internal::bitvec::BitArray<1usize>,
+    _bitfield: self::_pinternal::bitvec::BitArray<1usize>,
 }
 impl File {
     pub fn name(&self) -> &str {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.name,
@@ -42,18 +46,18 @@ impl File {
         )
     }
     pub fn name_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.name, &self._bitfield)
     }
     pub fn name_mut(&mut self) -> &mut ::std::string::String {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.name,
@@ -62,27 +66,27 @@ impl File {
         )
     }
     pub fn has_name(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.name, &self._bitfield)
             .is_some()
     }
     pub fn clear_name(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::clear(&mut self.name, &mut self._bitfield)
     }
     pub fn insertion_point(&self) -> &str {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             1usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.insertion_point,
@@ -91,18 +95,18 @@ impl File {
         )
     }
     pub fn insertion_point_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             1usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.insertion_point, &self._bitfield)
     }
     pub fn insertion_point_mut(&mut self) -> &mut ::std::string::String {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             1usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.insertion_point,
@@ -111,27 +115,27 @@ impl File {
         )
     }
     pub fn has_insertion_point(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             1usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.insertion_point, &self._bitfield)
             .is_some()
     }
     pub fn clear_insertion_point(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             1usize,
         > as NonRepeatedFieldType>::clear(&mut self.insertion_point, &mut self._bitfield)
     }
     pub fn content(&self) -> &str {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             2usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.content,
@@ -140,18 +144,18 @@ impl File {
         )
     }
     pub fn content_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             2usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.content, &self._bitfield)
     }
     pub fn content_mut(&mut self) -> &mut ::std::string::String {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             2usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.content,
@@ -160,30 +164,28 @@ impl File {
         )
     }
     pub fn has_content(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             2usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.content, &self._bitfield)
             .is_some()
     }
     pub fn clear_content(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             2usize,
         > as NonRepeatedFieldType>::clear(&mut self.content, &mut self._bitfield)
     }
     pub fn generated_code_info(
         &self,
-    ) -> ::std::option::Option::<
-        &self::_puroro_root::google::protobuf::GeneratedCodeInfo,
-    > {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::google::protobuf::GeneratedCodeInfo,
+    ) -> ::std::option::Option::<&self::_root::google::protobuf::GeneratedCodeInfo> {
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::google::protobuf::GeneratedCodeInfo,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.generated_code_info,
             &self._bitfield,
@@ -192,12 +194,10 @@ impl File {
     }
     pub fn generated_code_info_opt(
         &self,
-    ) -> ::std::option::Option::<
-        &self::_puroro_root::google::protobuf::GeneratedCodeInfo,
-    > {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::google::protobuf::GeneratedCodeInfo,
+    ) -> ::std::option::Option::<&self::_root::google::protobuf::GeneratedCodeInfo> {
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::google::protobuf::GeneratedCodeInfo,
         > as NonRepeatedFieldType>::get_field_opt(
             &self.generated_code_info,
             &self._bitfield,
@@ -205,10 +205,10 @@ impl File {
     }
     pub fn generated_code_info_mut(
         &mut self,
-    ) -> &mut self::_puroro_root::google::protobuf::GeneratedCodeInfo {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::google::protobuf::GeneratedCodeInfo,
+    ) -> &mut self::_root::google::protobuf::GeneratedCodeInfo {
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::google::protobuf::GeneratedCodeInfo,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.generated_code_info,
             &mut self._bitfield,
@@ -216,9 +216,9 @@ impl File {
         )
     }
     pub fn has_generated_code_info(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::google::protobuf::GeneratedCodeInfo,
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::google::protobuf::GeneratedCodeInfo,
         > as NonRepeatedFieldType>::get_field_opt(
                 &self.generated_code_info,
                 &self._bitfield,
@@ -226,9 +226,9 @@ impl File {
             .is_some()
     }
     pub fn clear_generated_code_info(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::google::protobuf::GeneratedCodeInfo,
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::google::protobuf::GeneratedCodeInfo,
         > as NonRepeatedFieldType>::clear(
             &mut self.generated_code_info,
             &mut self._bitfield,
@@ -247,49 +247,49 @@ impl self::_puroro::Message for File {
         &mut self,
         mut iter: I,
     ) -> self::_puroro::Result<()> {
-        use self::_puroro::internal::ser::FieldData;
+        use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 1i32 => {
-                    <self::_puroro::internal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::field_type::OptionalUnsizedField::<
                         ::std::string::String,
-                        self::_puroro::internal::tags::String,
+                        self::_pinternal::tags::String,
                         0usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.name,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 2i32 => {
-                    <self::_puroro::internal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::field_type::OptionalUnsizedField::<
                         ::std::string::String,
-                        self::_puroro::internal::tags::String,
+                        self::_pinternal::tags::String,
                         1usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.insertion_point,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 15i32 => {
-                    <self::_puroro::internal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::field_type::OptionalUnsizedField::<
                         ::std::string::String,
-                        self::_puroro::internal::tags::String,
+                        self::_pinternal::tags::String,
                         2usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.content,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 16i32 => {
-                    <self::_puroro::internal::field_type::SingularHeapMessageField::<
-                        self::_puroro_root::google::protobuf::GeneratedCodeInfo,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    <self::_pinternal::field_type::SingularHeapMessageField::<
+                        self::_root::google::protobuf::GeneratedCodeInfo,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.generated_code_info,
                         &mut self._bitfield,
                         field_data,
@@ -306,40 +306,40 @@ impl self::_puroro::Message for File {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::oneof_type::OneofUnion as _;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.name,
             &self._bitfield,
             1i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             1usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.insertion_point,
             &self._bitfield,
             2i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             2usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.content,
             &self._bitfield,
             15i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::google::protobuf::GeneratedCodeInfo,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::google::protobuf::GeneratedCodeInfo,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.generated_code_info,
             &self._bitfield,
             16i32,
@@ -351,23 +351,23 @@ impl self::_puroro::Message for File {
 impl ::std::clone::Clone for File {
     fn clone(&self) -> Self {
         Self {
-            name: <self::_puroro::internal::field_type::OptionalUnsizedField::<
+            name: <self::_pinternal::field_type::OptionalUnsizedField::<
                 ::std::string::String,
-                self::_puroro::internal::tags::String,
+                self::_pinternal::tags::String,
                 0usize,
             > as ::std::clone::Clone>::clone(&self.name),
-            insertion_point: <self::_puroro::internal::field_type::OptionalUnsizedField::<
+            insertion_point: <self::_pinternal::field_type::OptionalUnsizedField::<
                 ::std::string::String,
-                self::_puroro::internal::tags::String,
+                self::_pinternal::tags::String,
                 1usize,
             > as ::std::clone::Clone>::clone(&self.insertion_point),
-            content: <self::_puroro::internal::field_type::OptionalUnsizedField::<
+            content: <self::_pinternal::field_type::OptionalUnsizedField::<
                 ::std::string::String,
-                self::_puroro::internal::tags::String,
+                self::_pinternal::tags::String,
                 2usize,
             > as ::std::clone::Clone>::clone(&self.content),
-            generated_code_info: <self::_puroro::internal::field_type::SingularHeapMessageField::<
-                self::_puroro_root::google::protobuf::GeneratedCodeInfo,
+            generated_code_info: <self::_pinternal::field_type::SingularHeapMessageField::<
+                self::_root::google::protobuf::GeneratedCodeInfo,
             > as ::std::clone::Clone>::clone(&self.generated_code_info),
             _bitfield: ::std::clone::Clone::clone(&self._bitfield),
         }
@@ -376,7 +376,7 @@ impl ::std::clone::Clone for File {
 impl ::std::ops::Drop for File {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for File {
@@ -395,7 +395,7 @@ impl ::std::fmt::Debug for File {
 impl ::std::cmp::PartialEq for File {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         true && self.name_opt() == rhs.name_opt()
             && self.insertion_point_opt() == rhs.insertion_point_opt()
             && self.content_opt() == rhs.content_opt()

--- a/puroro-protobuf-compiled/src/google/protobuf/compiler/code_generator_response.rs
+++ b/puroro-protobuf-compiled/src/google/protobuf/compiler/code_generator_response.rs
@@ -12,30 +12,30 @@ mod _pinternal {
 }
 #[derive(::std::default::Default)]
 pub struct File {
-    name: self::_pinternal::field_type::OptionalUnsizedField::<
+    name: self::_pinternal::OptionalUnsizedField::<
         ::std::string::String,
         self::_pinternal::tags::String,
         0usize,
     >,
-    insertion_point: self::_pinternal::field_type::OptionalUnsizedField::<
+    insertion_point: self::_pinternal::OptionalUnsizedField::<
         ::std::string::String,
         self::_pinternal::tags::String,
         1usize,
     >,
-    content: self::_pinternal::field_type::OptionalUnsizedField::<
+    content: self::_pinternal::OptionalUnsizedField::<
         ::std::string::String,
         self::_pinternal::tags::String,
         2usize,
     >,
-    generated_code_info: self::_pinternal::field_type::SingularHeapMessageField::<
+    generated_code_info: self::_pinternal::SingularHeapMessageField::<
         self::_root::google::protobuf::GeneratedCodeInfo,
     >,
-    _bitfield: self::_pinternal::bitvec::BitArray<1usize>,
+    _bitfield: self::_pinternal::BitArray<1usize>,
 }
 impl File {
     pub fn name(&self) -> &str {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
@@ -46,16 +46,16 @@ impl File {
         )
     }
     pub fn name_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.name, &self._bitfield)
     }
     pub fn name_mut(&mut self) -> &mut ::std::string::String {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
@@ -66,8 +66,8 @@ impl File {
         )
     }
     pub fn has_name(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
@@ -75,16 +75,16 @@ impl File {
             .is_some()
     }
     pub fn clear_name(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::clear(&mut self.name, &mut self._bitfield)
     }
     pub fn insertion_point(&self) -> &str {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             1usize,
@@ -95,16 +95,16 @@ impl File {
         )
     }
     pub fn insertion_point_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             1usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.insertion_point, &self._bitfield)
     }
     pub fn insertion_point_mut(&mut self) -> &mut ::std::string::String {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             1usize,
@@ -115,8 +115,8 @@ impl File {
         )
     }
     pub fn has_insertion_point(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             1usize,
@@ -124,16 +124,16 @@ impl File {
             .is_some()
     }
     pub fn clear_insertion_point(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             1usize,
         > as NonRepeatedFieldType>::clear(&mut self.insertion_point, &mut self._bitfield)
     }
     pub fn content(&self) -> &str {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             2usize,
@@ -144,16 +144,16 @@ impl File {
         )
     }
     pub fn content_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             2usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.content, &self._bitfield)
     }
     pub fn content_mut(&mut self) -> &mut ::std::string::String {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             2usize,
@@ -164,8 +164,8 @@ impl File {
         )
     }
     pub fn has_content(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             2usize,
@@ -173,8 +173,8 @@ impl File {
             .is_some()
     }
     pub fn clear_content(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             2usize,
@@ -183,8 +183,8 @@ impl File {
     pub fn generated_code_info(
         &self,
     ) -> ::std::option::Option::<&self::_root::google::protobuf::GeneratedCodeInfo> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::google::protobuf::GeneratedCodeInfo,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.generated_code_info,
@@ -195,8 +195,8 @@ impl File {
     pub fn generated_code_info_opt(
         &self,
     ) -> ::std::option::Option::<&self::_root::google::protobuf::GeneratedCodeInfo> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::google::protobuf::GeneratedCodeInfo,
         > as NonRepeatedFieldType>::get_field_opt(
             &self.generated_code_info,
@@ -206,8 +206,8 @@ impl File {
     pub fn generated_code_info_mut(
         &mut self,
     ) -> &mut self::_root::google::protobuf::GeneratedCodeInfo {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::google::protobuf::GeneratedCodeInfo,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.generated_code_info,
@@ -216,8 +216,8 @@ impl File {
         )
     }
     pub fn has_generated_code_info(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::google::protobuf::GeneratedCodeInfo,
         > as NonRepeatedFieldType>::get_field_opt(
                 &self.generated_code_info,
@@ -226,8 +226,8 @@ impl File {
             .is_some()
     }
     pub fn clear_generated_code_info(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::google::protobuf::GeneratedCodeInfo,
         > as NonRepeatedFieldType>::clear(
             &mut self.generated_code_info,
@@ -249,47 +249,47 @@ impl self::_puroro::Message for File {
     ) -> self::_puroro::Result<()> {
         use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 1i32 => {
-                    <self::_pinternal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::OptionalUnsizedField::<
                         ::std::string::String,
                         self::_pinternal::tags::String,
                         0usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.name,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 2i32 => {
-                    <self::_pinternal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::OptionalUnsizedField::<
                         ::std::string::String,
                         self::_pinternal::tags::String,
                         1usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.insertion_point,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 15i32 => {
-                    <self::_pinternal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::OptionalUnsizedField::<
                         ::std::string::String,
                         self::_pinternal::tags::String,
                         2usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.content,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 16i32 => {
-                    <self::_pinternal::field_type::SingularHeapMessageField::<
+                    <self::_pinternal::SingularHeapMessageField::<
                         self::_root::google::protobuf::GeneratedCodeInfo,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.generated_code_info,
                         &mut self._bitfield,
                         field_data,
@@ -306,40 +306,40 @@ impl self::_puroro::Message for File {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::OneofUnion as _;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.name,
             &self._bitfield,
             1i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             1usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.insertion_point,
             &self._bitfield,
             2i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             2usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.content,
             &self._bitfield,
             15i32,
             out,
         )?;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::google::protobuf::GeneratedCodeInfo,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.generated_code_info,
             &self._bitfield,
             16i32,
@@ -351,22 +351,22 @@ impl self::_puroro::Message for File {
 impl ::std::clone::Clone for File {
     fn clone(&self) -> Self {
         Self {
-            name: <self::_pinternal::field_type::OptionalUnsizedField::<
+            name: <self::_pinternal::OptionalUnsizedField::<
                 ::std::string::String,
                 self::_pinternal::tags::String,
                 0usize,
             > as ::std::clone::Clone>::clone(&self.name),
-            insertion_point: <self::_pinternal::field_type::OptionalUnsizedField::<
+            insertion_point: <self::_pinternal::OptionalUnsizedField::<
                 ::std::string::String,
                 self::_pinternal::tags::String,
                 1usize,
             > as ::std::clone::Clone>::clone(&self.insertion_point),
-            content: <self::_pinternal::field_type::OptionalUnsizedField::<
+            content: <self::_pinternal::OptionalUnsizedField::<
                 ::std::string::String,
                 self::_pinternal::tags::String,
                 2usize,
             > as ::std::clone::Clone>::clone(&self.content),
-            generated_code_info: <self::_pinternal::field_type::SingularHeapMessageField::<
+            generated_code_info: <self::_pinternal::SingularHeapMessageField::<
                 self::_root::google::protobuf::GeneratedCodeInfo,
             > as ::std::clone::Clone>::clone(&self.generated_code_info),
             _bitfield: ::std::clone::Clone::clone(&self._bitfield),
@@ -376,7 +376,7 @@ impl ::std::clone::Clone for File {
 impl ::std::ops::Drop for File {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for File {
@@ -395,7 +395,7 @@ impl ::std::fmt::Debug for File {
 impl ::std::cmp::PartialEq for File {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         true && self.name_opt() == rhs.name_opt()
             && self.insertion_point_opt() == rhs.insertion_point_opt()
             && self.content_opt() == rhs.content_opt()

--- a/puroro-protobuf-compiled/src/google/protobuf/descriptor_proto.rs
+++ b/puroro-protobuf-compiled/src/google/protobuf/descriptor_proto.rs
@@ -12,25 +12,25 @@ mod _pinternal {
 }
 #[derive(::std::default::Default)]
 pub struct ExtensionRange {
-    start: self::_pinternal::field_type::OptionalNumericalField::<
+    start: self::_pinternal::OptionalNumericalField::<
         i32,
         self::_pinternal::tags::Int32,
         0usize,
     >,
-    end: self::_pinternal::field_type::OptionalNumericalField::<
+    end: self::_pinternal::OptionalNumericalField::<
         i32,
         self::_pinternal::tags::Int32,
         1usize,
     >,
-    options: self::_pinternal::field_type::SingularHeapMessageField::<
+    options: self::_pinternal::SingularHeapMessageField::<
         self::_root::google::protobuf::ExtensionRangeOptions,
     >,
-    _bitfield: self::_pinternal::bitvec::BitArray<1usize>,
+    _bitfield: self::_pinternal::BitArray<1usize>,
 }
 impl ExtensionRange {
     pub fn start(&self) -> i32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             0usize,
@@ -41,16 +41,16 @@ impl ExtensionRange {
         )
     }
     pub fn start_opt(&self) -> ::std::option::Option::<i32> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.start, &self._bitfield)
     }
     pub fn start_mut(&mut self) -> &mut i32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             0usize,
@@ -61,8 +61,8 @@ impl ExtensionRange {
         )
     }
     pub fn has_start(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             0usize,
@@ -70,16 +70,16 @@ impl ExtensionRange {
             .is_some()
     }
     pub fn clear_start(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             0usize,
         > as NonRepeatedFieldType>::clear(&mut self.start, &mut self._bitfield)
     }
     pub fn end(&self) -> i32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             1usize,
@@ -90,16 +90,16 @@ impl ExtensionRange {
         )
     }
     pub fn end_opt(&self) -> ::std::option::Option::<i32> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             1usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.end, &self._bitfield)
     }
     pub fn end_mut(&mut self) -> &mut i32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             1usize,
@@ -110,8 +110,8 @@ impl ExtensionRange {
         )
     }
     pub fn has_end(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             1usize,
@@ -119,8 +119,8 @@ impl ExtensionRange {
             .is_some()
     }
     pub fn clear_end(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             1usize,
@@ -129,8 +129,8 @@ impl ExtensionRange {
     pub fn options(
         &self,
     ) -> ::std::option::Option::<&self::_root::google::protobuf::ExtensionRangeOptions> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::google::protobuf::ExtensionRangeOptions,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.options,
@@ -141,16 +141,16 @@ impl ExtensionRange {
     pub fn options_opt(
         &self,
     ) -> ::std::option::Option::<&self::_root::google::protobuf::ExtensionRangeOptions> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::google::protobuf::ExtensionRangeOptions,
         > as NonRepeatedFieldType>::get_field_opt(&self.options, &self._bitfield)
     }
     pub fn options_mut(
         &mut self,
     ) -> &mut self::_root::google::protobuf::ExtensionRangeOptions {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::google::protobuf::ExtensionRangeOptions,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.options,
@@ -159,15 +159,15 @@ impl ExtensionRange {
         )
     }
     pub fn has_options(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::google::protobuf::ExtensionRangeOptions,
         > as NonRepeatedFieldType>::get_field_opt(&self.options, &self._bitfield)
             .is_some()
     }
     pub fn clear_options(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::google::protobuf::ExtensionRangeOptions,
         > as NonRepeatedFieldType>::clear(&mut self.options, &mut self._bitfield)
     }
@@ -186,36 +186,36 @@ impl self::_puroro::Message for ExtensionRange {
     ) -> self::_puroro::Result<()> {
         use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 1i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         i32,
                         self::_pinternal::tags::Int32,
                         0usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.start,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 2i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         i32,
                         self::_pinternal::tags::Int32,
                         1usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.end,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 3i32 => {
-                    <self::_pinternal::field_type::SingularHeapMessageField::<
+                    <self::_pinternal::SingularHeapMessageField::<
                         self::_root::google::protobuf::ExtensionRangeOptions,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.options,
                         &mut self._bitfield,
                         field_data,
@@ -232,30 +232,30 @@ impl self::_puroro::Message for ExtensionRange {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::OneofUnion as _;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             0usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.start,
             &self._bitfield,
             1i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             1usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.end,
             &self._bitfield,
             2i32,
             out,
         )?;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::google::protobuf::ExtensionRangeOptions,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.options,
             &self._bitfield,
             3i32,
@@ -267,17 +267,17 @@ impl self::_puroro::Message for ExtensionRange {
 impl ::std::clone::Clone for ExtensionRange {
     fn clone(&self) -> Self {
         Self {
-            start: <self::_pinternal::field_type::OptionalNumericalField::<
+            start: <self::_pinternal::OptionalNumericalField::<
                 i32,
                 self::_pinternal::tags::Int32,
                 0usize,
             > as ::std::clone::Clone>::clone(&self.start),
-            end: <self::_pinternal::field_type::OptionalNumericalField::<
+            end: <self::_pinternal::OptionalNumericalField::<
                 i32,
                 self::_pinternal::tags::Int32,
                 1usize,
             > as ::std::clone::Clone>::clone(&self.end),
-            options: <self::_pinternal::field_type::SingularHeapMessageField::<
+            options: <self::_pinternal::SingularHeapMessageField::<
                 self::_root::google::protobuf::ExtensionRangeOptions,
             > as ::std::clone::Clone>::clone(&self.options),
             _bitfield: ::std::clone::Clone::clone(&self._bitfield),
@@ -287,7 +287,7 @@ impl ::std::clone::Clone for ExtensionRange {
 impl ::std::ops::Drop for ExtensionRange {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for ExtensionRange {
@@ -305,29 +305,29 @@ impl ::std::fmt::Debug for ExtensionRange {
 impl ::std::cmp::PartialEq for ExtensionRange {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         true && self.start_opt() == rhs.start_opt() && self.end_opt() == rhs.end_opt()
             && self.options_opt() == rhs.options_opt()
     }
 }
 #[derive(::std::default::Default)]
 pub struct ReservedRange {
-    start: self::_pinternal::field_type::OptionalNumericalField::<
+    start: self::_pinternal::OptionalNumericalField::<
         i32,
         self::_pinternal::tags::Int32,
         0usize,
     >,
-    end: self::_pinternal::field_type::OptionalNumericalField::<
+    end: self::_pinternal::OptionalNumericalField::<
         i32,
         self::_pinternal::tags::Int32,
         1usize,
     >,
-    _bitfield: self::_pinternal::bitvec::BitArray<1usize>,
+    _bitfield: self::_pinternal::BitArray<1usize>,
 }
 impl ReservedRange {
     pub fn start(&self) -> i32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             0usize,
@@ -338,16 +338,16 @@ impl ReservedRange {
         )
     }
     pub fn start_opt(&self) -> ::std::option::Option::<i32> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.start, &self._bitfield)
     }
     pub fn start_mut(&mut self) -> &mut i32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             0usize,
@@ -358,8 +358,8 @@ impl ReservedRange {
         )
     }
     pub fn has_start(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             0usize,
@@ -367,16 +367,16 @@ impl ReservedRange {
             .is_some()
     }
     pub fn clear_start(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             0usize,
         > as NonRepeatedFieldType>::clear(&mut self.start, &mut self._bitfield)
     }
     pub fn end(&self) -> i32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             1usize,
@@ -387,16 +387,16 @@ impl ReservedRange {
         )
     }
     pub fn end_opt(&self) -> ::std::option::Option::<i32> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             1usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.end, &self._bitfield)
     }
     pub fn end_mut(&mut self) -> &mut i32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             1usize,
@@ -407,8 +407,8 @@ impl ReservedRange {
         )
     }
     pub fn has_end(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             1usize,
@@ -416,8 +416,8 @@ impl ReservedRange {
             .is_some()
     }
     pub fn clear_end(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             1usize,
@@ -438,27 +438,27 @@ impl self::_puroro::Message for ReservedRange {
     ) -> self::_puroro::Result<()> {
         use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 1i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         i32,
                         self::_pinternal::tags::Int32,
                         0usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.start,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 2i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         i32,
                         self::_pinternal::tags::Int32,
                         1usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.end,
                         &mut self._bitfield,
                         field_data,
@@ -475,22 +475,22 @@ impl self::_puroro::Message for ReservedRange {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::OneofUnion as _;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             0usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.start,
             &self._bitfield,
             1i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             1usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.end,
             &self._bitfield,
             2i32,
@@ -502,12 +502,12 @@ impl self::_puroro::Message for ReservedRange {
 impl ::std::clone::Clone for ReservedRange {
     fn clone(&self) -> Self {
         Self {
-            start: <self::_pinternal::field_type::OptionalNumericalField::<
+            start: <self::_pinternal::OptionalNumericalField::<
                 i32,
                 self::_pinternal::tags::Int32,
                 0usize,
             > as ::std::clone::Clone>::clone(&self.start),
-            end: <self::_pinternal::field_type::OptionalNumericalField::<
+            end: <self::_pinternal::OptionalNumericalField::<
                 i32,
                 self::_pinternal::tags::Int32,
                 1usize,
@@ -519,7 +519,7 @@ impl ::std::clone::Clone for ReservedRange {
 impl ::std::ops::Drop for ReservedRange {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for ReservedRange {
@@ -536,7 +536,7 @@ impl ::std::fmt::Debug for ReservedRange {
 impl ::std::cmp::PartialEq for ReservedRange {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         true && self.start_opt() == rhs.start_opt() && self.end_opt() == rhs.end_opt()
     }
 }

--- a/puroro-protobuf-compiled/src/google/protobuf/descriptor_proto.rs
+++ b/puroro-protobuf-compiled/src/google/protobuf/descriptor_proto.rs
@@ -1,34 +1,38 @@
-mod _puroro_root {
+mod _root {
     #[allow(unused)]
-    pub(crate) use super::super::_puroro_root::*;
+    pub(crate) use super::super::_root::*;
 }
 mod _puroro {
     #[allow(unused)]
     pub(crate) use ::puroro::*;
 }
+mod _pinternal {
+    #[allow(unused)]
+    pub(crate) use ::puroro::internal::*;
+}
 #[derive(::std::default::Default)]
 pub struct ExtensionRange {
-    start: self::_puroro::internal::field_type::OptionalNumericalField::<
+    start: self::_pinternal::field_type::OptionalNumericalField::<
         i32,
-        self::_puroro::internal::tags::Int32,
+        self::_pinternal::tags::Int32,
         0usize,
     >,
-    end: self::_puroro::internal::field_type::OptionalNumericalField::<
+    end: self::_pinternal::field_type::OptionalNumericalField::<
         i32,
-        self::_puroro::internal::tags::Int32,
+        self::_pinternal::tags::Int32,
         1usize,
     >,
-    options: self::_puroro::internal::field_type::SingularHeapMessageField::<
-        self::_puroro_root::google::protobuf::ExtensionRangeOptions,
+    options: self::_pinternal::field_type::SingularHeapMessageField::<
+        self::_root::google::protobuf::ExtensionRangeOptions,
     >,
-    _bitfield: self::_puroro::internal::bitvec::BitArray<1usize>,
+    _bitfield: self::_pinternal::bitvec::BitArray<1usize>,
 }
 impl ExtensionRange {
     pub fn start(&self) -> i32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             0usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.start,
@@ -37,18 +41,18 @@ impl ExtensionRange {
         )
     }
     pub fn start_opt(&self) -> ::std::option::Option::<i32> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.start, &self._bitfield)
     }
     pub fn start_mut(&mut self) -> &mut i32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             0usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.start,
@@ -57,27 +61,27 @@ impl ExtensionRange {
         )
     }
     pub fn has_start(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.start, &self._bitfield)
             .is_some()
     }
     pub fn clear_start(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             0usize,
         > as NonRepeatedFieldType>::clear(&mut self.start, &mut self._bitfield)
     }
     pub fn end(&self) -> i32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             1usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.end,
@@ -86,18 +90,18 @@ impl ExtensionRange {
         )
     }
     pub fn end_opt(&self) -> ::std::option::Option::<i32> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             1usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.end, &self._bitfield)
     }
     pub fn end_mut(&mut self) -> &mut i32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             1usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.end,
@@ -106,30 +110,28 @@ impl ExtensionRange {
         )
     }
     pub fn has_end(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             1usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.end, &self._bitfield)
             .is_some()
     }
     pub fn clear_end(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             1usize,
         > as NonRepeatedFieldType>::clear(&mut self.end, &mut self._bitfield)
     }
     pub fn options(
         &self,
-    ) -> ::std::option::Option::<
-        &self::_puroro_root::google::protobuf::ExtensionRangeOptions,
-    > {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::google::protobuf::ExtensionRangeOptions,
+    ) -> ::std::option::Option::<&self::_root::google::protobuf::ExtensionRangeOptions> {
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::google::protobuf::ExtensionRangeOptions,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.options,
             &self._bitfield,
@@ -138,20 +140,18 @@ impl ExtensionRange {
     }
     pub fn options_opt(
         &self,
-    ) -> ::std::option::Option::<
-        &self::_puroro_root::google::protobuf::ExtensionRangeOptions,
-    > {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::google::protobuf::ExtensionRangeOptions,
+    ) -> ::std::option::Option::<&self::_root::google::protobuf::ExtensionRangeOptions> {
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::google::protobuf::ExtensionRangeOptions,
         > as NonRepeatedFieldType>::get_field_opt(&self.options, &self._bitfield)
     }
     pub fn options_mut(
         &mut self,
-    ) -> &mut self::_puroro_root::google::protobuf::ExtensionRangeOptions {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::google::protobuf::ExtensionRangeOptions,
+    ) -> &mut self::_root::google::protobuf::ExtensionRangeOptions {
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::google::protobuf::ExtensionRangeOptions,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.options,
             &mut self._bitfield,
@@ -159,16 +159,16 @@ impl ExtensionRange {
         )
     }
     pub fn has_options(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::google::protobuf::ExtensionRangeOptions,
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::google::protobuf::ExtensionRangeOptions,
         > as NonRepeatedFieldType>::get_field_opt(&self.options, &self._bitfield)
             .is_some()
     }
     pub fn clear_options(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::google::protobuf::ExtensionRangeOptions,
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::google::protobuf::ExtensionRangeOptions,
         > as NonRepeatedFieldType>::clear(&mut self.options, &mut self._bitfield)
     }
 }
@@ -184,38 +184,38 @@ impl self::_puroro::Message for ExtensionRange {
         &mut self,
         mut iter: I,
     ) -> self::_puroro::Result<()> {
-        use self::_puroro::internal::ser::FieldData;
+        use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 1i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         i32,
-                        self::_puroro::internal::tags::Int32,
+                        self::_pinternal::tags::Int32,
                         0usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.start,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 2i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         i32,
-                        self::_puroro::internal::tags::Int32,
+                        self::_pinternal::tags::Int32,
                         1usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.end,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 3i32 => {
-                    <self::_puroro::internal::field_type::SingularHeapMessageField::<
-                        self::_puroro_root::google::protobuf::ExtensionRangeOptions,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    <self::_pinternal::field_type::SingularHeapMessageField::<
+                        self::_root::google::protobuf::ExtensionRangeOptions,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.options,
                         &mut self._bitfield,
                         field_data,
@@ -232,30 +232,30 @@ impl self::_puroro::Message for ExtensionRange {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::oneof_type::OneofUnion as _;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             0usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.start,
             &self._bitfield,
             1i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             1usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.end,
             &self._bitfield,
             2i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::google::protobuf::ExtensionRangeOptions,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::google::protobuf::ExtensionRangeOptions,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.options,
             &self._bitfield,
             3i32,
@@ -267,18 +267,18 @@ impl self::_puroro::Message for ExtensionRange {
 impl ::std::clone::Clone for ExtensionRange {
     fn clone(&self) -> Self {
         Self {
-            start: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            start: <self::_pinternal::field_type::OptionalNumericalField::<
                 i32,
-                self::_puroro::internal::tags::Int32,
+                self::_pinternal::tags::Int32,
                 0usize,
             > as ::std::clone::Clone>::clone(&self.start),
-            end: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            end: <self::_pinternal::field_type::OptionalNumericalField::<
                 i32,
-                self::_puroro::internal::tags::Int32,
+                self::_pinternal::tags::Int32,
                 1usize,
             > as ::std::clone::Clone>::clone(&self.end),
-            options: <self::_puroro::internal::field_type::SingularHeapMessageField::<
-                self::_puroro_root::google::protobuf::ExtensionRangeOptions,
+            options: <self::_pinternal::field_type::SingularHeapMessageField::<
+                self::_root::google::protobuf::ExtensionRangeOptions,
             > as ::std::clone::Clone>::clone(&self.options),
             _bitfield: ::std::clone::Clone::clone(&self._bitfield),
         }
@@ -287,7 +287,7 @@ impl ::std::clone::Clone for ExtensionRange {
 impl ::std::ops::Drop for ExtensionRange {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for ExtensionRange {
@@ -305,31 +305,31 @@ impl ::std::fmt::Debug for ExtensionRange {
 impl ::std::cmp::PartialEq for ExtensionRange {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         true && self.start_opt() == rhs.start_opt() && self.end_opt() == rhs.end_opt()
             && self.options_opt() == rhs.options_opt()
     }
 }
 #[derive(::std::default::Default)]
 pub struct ReservedRange {
-    start: self::_puroro::internal::field_type::OptionalNumericalField::<
+    start: self::_pinternal::field_type::OptionalNumericalField::<
         i32,
-        self::_puroro::internal::tags::Int32,
+        self::_pinternal::tags::Int32,
         0usize,
     >,
-    end: self::_puroro::internal::field_type::OptionalNumericalField::<
+    end: self::_pinternal::field_type::OptionalNumericalField::<
         i32,
-        self::_puroro::internal::tags::Int32,
+        self::_pinternal::tags::Int32,
         1usize,
     >,
-    _bitfield: self::_puroro::internal::bitvec::BitArray<1usize>,
+    _bitfield: self::_pinternal::bitvec::BitArray<1usize>,
 }
 impl ReservedRange {
     pub fn start(&self) -> i32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             0usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.start,
@@ -338,18 +338,18 @@ impl ReservedRange {
         )
     }
     pub fn start_opt(&self) -> ::std::option::Option::<i32> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.start, &self._bitfield)
     }
     pub fn start_mut(&mut self) -> &mut i32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             0usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.start,
@@ -358,27 +358,27 @@ impl ReservedRange {
         )
     }
     pub fn has_start(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.start, &self._bitfield)
             .is_some()
     }
     pub fn clear_start(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             0usize,
         > as NonRepeatedFieldType>::clear(&mut self.start, &mut self._bitfield)
     }
     pub fn end(&self) -> i32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             1usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.end,
@@ -387,18 +387,18 @@ impl ReservedRange {
         )
     }
     pub fn end_opt(&self) -> ::std::option::Option::<i32> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             1usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.end, &self._bitfield)
     }
     pub fn end_mut(&mut self) -> &mut i32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             1usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.end,
@@ -407,19 +407,19 @@ impl ReservedRange {
         )
     }
     pub fn has_end(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             1usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.end, &self._bitfield)
             .is_some()
     }
     pub fn clear_end(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             1usize,
         > as NonRepeatedFieldType>::clear(&mut self.end, &mut self._bitfield)
     }
@@ -436,29 +436,29 @@ impl self::_puroro::Message for ReservedRange {
         &mut self,
         mut iter: I,
     ) -> self::_puroro::Result<()> {
-        use self::_puroro::internal::ser::FieldData;
+        use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 1i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         i32,
-                        self::_puroro::internal::tags::Int32,
+                        self::_pinternal::tags::Int32,
                         0usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.start,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 2i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         i32,
-                        self::_puroro::internal::tags::Int32,
+                        self::_pinternal::tags::Int32,
                         1usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.end,
                         &mut self._bitfield,
                         field_data,
@@ -475,22 +475,22 @@ impl self::_puroro::Message for ReservedRange {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::oneof_type::OneofUnion as _;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             0usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.start,
             &self._bitfield,
             1i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             1usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.end,
             &self._bitfield,
             2i32,
@@ -502,14 +502,14 @@ impl self::_puroro::Message for ReservedRange {
 impl ::std::clone::Clone for ReservedRange {
     fn clone(&self) -> Self {
         Self {
-            start: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            start: <self::_pinternal::field_type::OptionalNumericalField::<
                 i32,
-                self::_puroro::internal::tags::Int32,
+                self::_pinternal::tags::Int32,
                 0usize,
             > as ::std::clone::Clone>::clone(&self.start),
-            end: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            end: <self::_pinternal::field_type::OptionalNumericalField::<
                 i32,
-                self::_puroro::internal::tags::Int32,
+                self::_pinternal::tags::Int32,
                 1usize,
             > as ::std::clone::Clone>::clone(&self.end),
             _bitfield: ::std::clone::Clone::clone(&self._bitfield),
@@ -519,7 +519,7 @@ impl ::std::clone::Clone for ReservedRange {
 impl ::std::ops::Drop for ReservedRange {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for ReservedRange {
@@ -536,7 +536,7 @@ impl ::std::fmt::Debug for ReservedRange {
 impl ::std::cmp::PartialEq for ReservedRange {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         true && self.start_opt() == rhs.start_opt() && self.end_opt() == rhs.end_opt()
     }
 }

--- a/puroro-protobuf-compiled/src/google/protobuf/enum_descriptor_proto.rs
+++ b/puroro-protobuf-compiled/src/google/protobuf/enum_descriptor_proto.rs
@@ -12,22 +12,22 @@ mod _pinternal {
 }
 #[derive(::std::default::Default)]
 pub struct EnumReservedRange {
-    start: self::_pinternal::field_type::OptionalNumericalField::<
+    start: self::_pinternal::OptionalNumericalField::<
         i32,
         self::_pinternal::tags::Int32,
         0usize,
     >,
-    end: self::_pinternal::field_type::OptionalNumericalField::<
+    end: self::_pinternal::OptionalNumericalField::<
         i32,
         self::_pinternal::tags::Int32,
         1usize,
     >,
-    _bitfield: self::_pinternal::bitvec::BitArray<1usize>,
+    _bitfield: self::_pinternal::BitArray<1usize>,
 }
 impl EnumReservedRange {
     pub fn start(&self) -> i32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             0usize,
@@ -38,16 +38,16 @@ impl EnumReservedRange {
         )
     }
     pub fn start_opt(&self) -> ::std::option::Option::<i32> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.start, &self._bitfield)
     }
     pub fn start_mut(&mut self) -> &mut i32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             0usize,
@@ -58,8 +58,8 @@ impl EnumReservedRange {
         )
     }
     pub fn has_start(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             0usize,
@@ -67,16 +67,16 @@ impl EnumReservedRange {
             .is_some()
     }
     pub fn clear_start(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             0usize,
         > as NonRepeatedFieldType>::clear(&mut self.start, &mut self._bitfield)
     }
     pub fn end(&self) -> i32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             1usize,
@@ -87,16 +87,16 @@ impl EnumReservedRange {
         )
     }
     pub fn end_opt(&self) -> ::std::option::Option::<i32> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             1usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.end, &self._bitfield)
     }
     pub fn end_mut(&mut self) -> &mut i32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             1usize,
@@ -107,8 +107,8 @@ impl EnumReservedRange {
         )
     }
     pub fn has_end(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             1usize,
@@ -116,8 +116,8 @@ impl EnumReservedRange {
             .is_some()
     }
     pub fn clear_end(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             1usize,
@@ -138,27 +138,27 @@ impl self::_puroro::Message for EnumReservedRange {
     ) -> self::_puroro::Result<()> {
         use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 1i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         i32,
                         self::_pinternal::tags::Int32,
                         0usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.start,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 2i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         i32,
                         self::_pinternal::tags::Int32,
                         1usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.end,
                         &mut self._bitfield,
                         field_data,
@@ -175,22 +175,22 @@ impl self::_puroro::Message for EnumReservedRange {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::OneofUnion as _;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             0usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.start,
             &self._bitfield,
             1i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             1usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.end,
             &self._bitfield,
             2i32,
@@ -202,12 +202,12 @@ impl self::_puroro::Message for EnumReservedRange {
 impl ::std::clone::Clone for EnumReservedRange {
     fn clone(&self) -> Self {
         Self {
-            start: <self::_pinternal::field_type::OptionalNumericalField::<
+            start: <self::_pinternal::OptionalNumericalField::<
                 i32,
                 self::_pinternal::tags::Int32,
                 0usize,
             > as ::std::clone::Clone>::clone(&self.start),
-            end: <self::_pinternal::field_type::OptionalNumericalField::<
+            end: <self::_pinternal::OptionalNumericalField::<
                 i32,
                 self::_pinternal::tags::Int32,
                 1usize,
@@ -219,7 +219,7 @@ impl ::std::clone::Clone for EnumReservedRange {
 impl ::std::ops::Drop for EnumReservedRange {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for EnumReservedRange {
@@ -236,7 +236,7 @@ impl ::std::fmt::Debug for EnumReservedRange {
 impl ::std::cmp::PartialEq for EnumReservedRange {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         true && self.start_opt() == rhs.start_opt() && self.end_opt() == rhs.end_opt()
     }
 }

--- a/puroro-protobuf-compiled/src/google/protobuf/enum_descriptor_proto.rs
+++ b/puroro-protobuf-compiled/src/google/protobuf/enum_descriptor_proto.rs
@@ -1,31 +1,35 @@
-mod _puroro_root {
+mod _root {
     #[allow(unused)]
-    pub(crate) use super::super::_puroro_root::*;
+    pub(crate) use super::super::_root::*;
 }
 mod _puroro {
     #[allow(unused)]
     pub(crate) use ::puroro::*;
 }
+mod _pinternal {
+    #[allow(unused)]
+    pub(crate) use ::puroro::internal::*;
+}
 #[derive(::std::default::Default)]
 pub struct EnumReservedRange {
-    start: self::_puroro::internal::field_type::OptionalNumericalField::<
+    start: self::_pinternal::field_type::OptionalNumericalField::<
         i32,
-        self::_puroro::internal::tags::Int32,
+        self::_pinternal::tags::Int32,
         0usize,
     >,
-    end: self::_puroro::internal::field_type::OptionalNumericalField::<
+    end: self::_pinternal::field_type::OptionalNumericalField::<
         i32,
-        self::_puroro::internal::tags::Int32,
+        self::_pinternal::tags::Int32,
         1usize,
     >,
-    _bitfield: self::_puroro::internal::bitvec::BitArray<1usize>,
+    _bitfield: self::_pinternal::bitvec::BitArray<1usize>,
 }
 impl EnumReservedRange {
     pub fn start(&self) -> i32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             0usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.start,
@@ -34,18 +38,18 @@ impl EnumReservedRange {
         )
     }
     pub fn start_opt(&self) -> ::std::option::Option::<i32> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.start, &self._bitfield)
     }
     pub fn start_mut(&mut self) -> &mut i32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             0usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.start,
@@ -54,27 +58,27 @@ impl EnumReservedRange {
         )
     }
     pub fn has_start(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.start, &self._bitfield)
             .is_some()
     }
     pub fn clear_start(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             0usize,
         > as NonRepeatedFieldType>::clear(&mut self.start, &mut self._bitfield)
     }
     pub fn end(&self) -> i32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             1usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.end,
@@ -83,18 +87,18 @@ impl EnumReservedRange {
         )
     }
     pub fn end_opt(&self) -> ::std::option::Option::<i32> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             1usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.end, &self._bitfield)
     }
     pub fn end_mut(&mut self) -> &mut i32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             1usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.end,
@@ -103,19 +107,19 @@ impl EnumReservedRange {
         )
     }
     pub fn has_end(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             1usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.end, &self._bitfield)
             .is_some()
     }
     pub fn clear_end(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             1usize,
         > as NonRepeatedFieldType>::clear(&mut self.end, &mut self._bitfield)
     }
@@ -132,29 +136,29 @@ impl self::_puroro::Message for EnumReservedRange {
         &mut self,
         mut iter: I,
     ) -> self::_puroro::Result<()> {
-        use self::_puroro::internal::ser::FieldData;
+        use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 1i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         i32,
-                        self::_puroro::internal::tags::Int32,
+                        self::_pinternal::tags::Int32,
                         0usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.start,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 2i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         i32,
-                        self::_puroro::internal::tags::Int32,
+                        self::_pinternal::tags::Int32,
                         1usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.end,
                         &mut self._bitfield,
                         field_data,
@@ -171,22 +175,22 @@ impl self::_puroro::Message for EnumReservedRange {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::oneof_type::OneofUnion as _;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             0usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.start,
             &self._bitfield,
             1i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             1usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.end,
             &self._bitfield,
             2i32,
@@ -198,14 +202,14 @@ impl self::_puroro::Message for EnumReservedRange {
 impl ::std::clone::Clone for EnumReservedRange {
     fn clone(&self) -> Self {
         Self {
-            start: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            start: <self::_pinternal::field_type::OptionalNumericalField::<
                 i32,
-                self::_puroro::internal::tags::Int32,
+                self::_pinternal::tags::Int32,
                 0usize,
             > as ::std::clone::Clone>::clone(&self.start),
-            end: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            end: <self::_pinternal::field_type::OptionalNumericalField::<
                 i32,
-                self::_puroro::internal::tags::Int32,
+                self::_pinternal::tags::Int32,
                 1usize,
             > as ::std::clone::Clone>::clone(&self.end),
             _bitfield: ::std::clone::Clone::clone(&self._bitfield),
@@ -215,7 +219,7 @@ impl ::std::clone::Clone for EnumReservedRange {
 impl ::std::ops::Drop for EnumReservedRange {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for EnumReservedRange {
@@ -232,7 +236,7 @@ impl ::std::fmt::Debug for EnumReservedRange {
 impl ::std::cmp::PartialEq for EnumReservedRange {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         true && self.start_opt() == rhs.start_opt() && self.end_opt() == rhs.end_opt()
     }
 }

--- a/puroro-protobuf-compiled/src/google/protobuf/field_descriptor_proto.rs
+++ b/puroro-protobuf-compiled/src/google/protobuf/field_descriptor_proto.rs
@@ -1,10 +1,14 @@
-mod _puroro_root {
+mod _root {
     #[allow(unused)]
-    pub(crate) use super::super::_puroro_root::*;
+    pub(crate) use super::super::_root::*;
 }
 mod _puroro {
     #[allow(unused)]
     pub(crate) use ::puroro::*;
+}
+mod _pinternal {
+    #[allow(unused)]
+    pub(crate) use ::puroro::internal::*;
 }
 #[derive(
     ::std::clone::Clone,

--- a/puroro-protobuf-compiled/src/google/protobuf/field_options.rs
+++ b/puroro-protobuf-compiled/src/google/protobuf/field_options.rs
@@ -1,10 +1,14 @@
-mod _puroro_root {
+mod _root {
     #[allow(unused)]
-    pub(crate) use super::super::_puroro_root::*;
+    pub(crate) use super::super::_root::*;
 }
 mod _puroro {
     #[allow(unused)]
     pub(crate) use ::puroro::*;
+}
+mod _pinternal {
+    #[allow(unused)]
+    pub(crate) use ::puroro::internal::*;
 }
 #[derive(
     ::std::clone::Clone,

--- a/puroro-protobuf-compiled/src/google/protobuf/file_options.rs
+++ b/puroro-protobuf-compiled/src/google/protobuf/file_options.rs
@@ -1,10 +1,14 @@
-mod _puroro_root {
+mod _root {
     #[allow(unused)]
-    pub(crate) use super::super::_puroro_root::*;
+    pub(crate) use super::super::_root::*;
 }
 mod _puroro {
     #[allow(unused)]
     pub(crate) use ::puroro::*;
+}
+mod _pinternal {
+    #[allow(unused)]
+    pub(crate) use ::puroro::internal::*;
 }
 #[derive(
     ::std::clone::Clone,

--- a/puroro-protobuf-compiled/src/google/protobuf/generated_code_info.rs
+++ b/puroro-protobuf-compiled/src/google/protobuf/generated_code_info.rs
@@ -12,52 +12,49 @@ mod _pinternal {
 }
 #[derive(::std::default::Default)]
 pub struct Annotation {
-    path: self::_pinternal::field_type::RepeatedNumericalField::<
-        i32,
-        self::_pinternal::tags::Int32,
-    >,
-    source_file: self::_pinternal::field_type::OptionalUnsizedField::<
+    path: self::_pinternal::RepeatedNumericalField::<i32, self::_pinternal::tags::Int32>,
+    source_file: self::_pinternal::OptionalUnsizedField::<
         ::std::string::String,
         self::_pinternal::tags::String,
         0usize,
     >,
-    begin: self::_pinternal::field_type::OptionalNumericalField::<
+    begin: self::_pinternal::OptionalNumericalField::<
         i32,
         self::_pinternal::tags::Int32,
         1usize,
     >,
-    end: self::_pinternal::field_type::OptionalNumericalField::<
+    end: self::_pinternal::OptionalNumericalField::<
         i32,
         self::_pinternal::tags::Int32,
         2usize,
     >,
-    _bitfield: self::_pinternal::bitvec::BitArray<1usize>,
+    _bitfield: self::_pinternal::BitArray<1usize>,
 }
 impl Annotation {
     pub fn path(&self) -> &[i32] {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
         > as RepeatedFieldType>::get_field(&self.path, &self._bitfield)
     }
     pub fn path_mut(&mut self) -> &mut ::std::vec::Vec::<i32> {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
         > as RepeatedFieldType>::get_field_mut(&mut self.path, &mut self._bitfield)
     }
     pub fn clear_path(&mut self) {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
         > as RepeatedFieldType>::clear(&mut self.path, &mut self._bitfield)
     }
     pub fn source_file(&self) -> &str {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
@@ -68,16 +65,16 @@ impl Annotation {
         )
     }
     pub fn source_file_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.source_file, &self._bitfield)
     }
     pub fn source_file_mut(&mut self) -> &mut ::std::string::String {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
@@ -88,8 +85,8 @@ impl Annotation {
         )
     }
     pub fn has_source_file(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
@@ -97,16 +94,16 @@ impl Annotation {
             .is_some()
     }
     pub fn clear_source_file(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::clear(&mut self.source_file, &mut self._bitfield)
     }
     pub fn begin(&self) -> i32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             1usize,
@@ -117,16 +114,16 @@ impl Annotation {
         )
     }
     pub fn begin_opt(&self) -> ::std::option::Option::<i32> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             1usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.begin, &self._bitfield)
     }
     pub fn begin_mut(&mut self) -> &mut i32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             1usize,
@@ -137,8 +134,8 @@ impl Annotation {
         )
     }
     pub fn has_begin(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             1usize,
@@ -146,16 +143,16 @@ impl Annotation {
             .is_some()
     }
     pub fn clear_begin(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             1usize,
         > as NonRepeatedFieldType>::clear(&mut self.begin, &mut self._bitfield)
     }
     pub fn end(&self) -> i32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             2usize,
@@ -166,16 +163,16 @@ impl Annotation {
         )
     }
     pub fn end_opt(&self) -> ::std::option::Option::<i32> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             2usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.end, &self._bitfield)
     }
     pub fn end_mut(&mut self) -> &mut i32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             2usize,
@@ -186,8 +183,8 @@ impl Annotation {
         )
     }
     pub fn has_end(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             2usize,
@@ -195,8 +192,8 @@ impl Annotation {
             .is_some()
     }
     pub fn clear_end(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             2usize,
@@ -217,48 +214,48 @@ impl self::_puroro::Message for Annotation {
     ) -> self::_puroro::Result<()> {
         use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 1i32 => {
-                    <self::_pinternal::field_type::RepeatedNumericalField::<
+                    <self::_pinternal::RepeatedNumericalField::<
                         i32,
                         self::_pinternal::tags::Int32,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.path,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 2i32 => {
-                    <self::_pinternal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::OptionalUnsizedField::<
                         ::std::string::String,
                         self::_pinternal::tags::String,
                         0usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.source_file,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 3i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         i32,
                         self::_pinternal::tags::Int32,
                         1usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.begin,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 4i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         i32,
                         self::_pinternal::tags::Int32,
                         2usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.end,
                         &mut self._bitfield,
                         field_data,
@@ -275,41 +272,41 @@ impl self::_puroro::Message for Annotation {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::OneofUnion as _;
+        <self::_pinternal::RepeatedNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.path,
             &self._bitfield,
             1i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.source_file,
             &self._bitfield,
             2i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             1usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.begin,
             &self._bitfield,
             3i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             2usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.end,
             &self._bitfield,
             4i32,
@@ -321,21 +318,21 @@ impl self::_puroro::Message for Annotation {
 impl ::std::clone::Clone for Annotation {
     fn clone(&self) -> Self {
         Self {
-            path: <self::_pinternal::field_type::RepeatedNumericalField::<
+            path: <self::_pinternal::RepeatedNumericalField::<
                 i32,
                 self::_pinternal::tags::Int32,
             > as ::std::clone::Clone>::clone(&self.path),
-            source_file: <self::_pinternal::field_type::OptionalUnsizedField::<
+            source_file: <self::_pinternal::OptionalUnsizedField::<
                 ::std::string::String,
                 self::_pinternal::tags::String,
                 0usize,
             > as ::std::clone::Clone>::clone(&self.source_file),
-            begin: <self::_pinternal::field_type::OptionalNumericalField::<
+            begin: <self::_pinternal::OptionalNumericalField::<
                 i32,
                 self::_pinternal::tags::Int32,
                 1usize,
             > as ::std::clone::Clone>::clone(&self.begin),
-            end: <self::_pinternal::field_type::OptionalNumericalField::<
+            end: <self::_pinternal::OptionalNumericalField::<
                 i32,
                 self::_pinternal::tags::Int32,
                 2usize,
@@ -347,7 +344,7 @@ impl ::std::clone::Clone for Annotation {
 impl ::std::ops::Drop for Annotation {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for Annotation {
@@ -366,7 +363,7 @@ impl ::std::fmt::Debug for Annotation {
 impl ::std::cmp::PartialEq for Annotation {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         true && self.path() == rhs.path()
             && self.source_file_opt() == rhs.source_file_opt()
             && self.begin_opt() == rhs.begin_opt() && self.end_opt() == rhs.end_opt()

--- a/puroro-protobuf-compiled/src/google/protobuf/generated_code_info.rs
+++ b/puroro-protobuf-compiled/src/google/protobuf/generated_code_info.rs
@@ -1,61 +1,65 @@
-mod _puroro_root {
+mod _root {
     #[allow(unused)]
-    pub(crate) use super::super::_puroro_root::*;
+    pub(crate) use super::super::_root::*;
 }
 mod _puroro {
     #[allow(unused)]
     pub(crate) use ::puroro::*;
 }
+mod _pinternal {
+    #[allow(unused)]
+    pub(crate) use ::puroro::internal::*;
+}
 #[derive(::std::default::Default)]
 pub struct Annotation {
-    path: self::_puroro::internal::field_type::RepeatedNumericalField::<
+    path: self::_pinternal::field_type::RepeatedNumericalField::<
         i32,
-        self::_puroro::internal::tags::Int32,
+        self::_pinternal::tags::Int32,
     >,
-    source_file: self::_puroro::internal::field_type::OptionalUnsizedField::<
+    source_file: self::_pinternal::field_type::OptionalUnsizedField::<
         ::std::string::String,
-        self::_puroro::internal::tags::String,
+        self::_pinternal::tags::String,
         0usize,
     >,
-    begin: self::_puroro::internal::field_type::OptionalNumericalField::<
+    begin: self::_pinternal::field_type::OptionalNumericalField::<
         i32,
-        self::_puroro::internal::tags::Int32,
+        self::_pinternal::tags::Int32,
         1usize,
     >,
-    end: self::_puroro::internal::field_type::OptionalNumericalField::<
+    end: self::_pinternal::field_type::OptionalNumericalField::<
         i32,
-        self::_puroro::internal::tags::Int32,
+        self::_pinternal::tags::Int32,
         2usize,
     >,
-    _bitfield: self::_puroro::internal::bitvec::BitArray<1usize>,
+    _bitfield: self::_pinternal::bitvec::BitArray<1usize>,
 }
 impl Annotation {
     pub fn path(&self) -> &[i32] {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
         > as RepeatedFieldType>::get_field(&self.path, &self._bitfield)
     }
     pub fn path_mut(&mut self) -> &mut ::std::vec::Vec::<i32> {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
         > as RepeatedFieldType>::get_field_mut(&mut self.path, &mut self._bitfield)
     }
     pub fn clear_path(&mut self) {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
         > as RepeatedFieldType>::clear(&mut self.path, &mut self._bitfield)
     }
     pub fn source_file(&self) -> &str {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.source_file,
@@ -64,18 +68,18 @@ impl Annotation {
         )
     }
     pub fn source_file_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.source_file, &self._bitfield)
     }
     pub fn source_file_mut(&mut self) -> &mut ::std::string::String {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.source_file,
@@ -84,27 +88,27 @@ impl Annotation {
         )
     }
     pub fn has_source_file(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.source_file, &self._bitfield)
             .is_some()
     }
     pub fn clear_source_file(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::clear(&mut self.source_file, &mut self._bitfield)
     }
     pub fn begin(&self) -> i32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             1usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.begin,
@@ -113,18 +117,18 @@ impl Annotation {
         )
     }
     pub fn begin_opt(&self) -> ::std::option::Option::<i32> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             1usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.begin, &self._bitfield)
     }
     pub fn begin_mut(&mut self) -> &mut i32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             1usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.begin,
@@ -133,27 +137,27 @@ impl Annotation {
         )
     }
     pub fn has_begin(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             1usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.begin, &self._bitfield)
             .is_some()
     }
     pub fn clear_begin(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             1usize,
         > as NonRepeatedFieldType>::clear(&mut self.begin, &mut self._bitfield)
     }
     pub fn end(&self) -> i32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             2usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.end,
@@ -162,18 +166,18 @@ impl Annotation {
         )
     }
     pub fn end_opt(&self) -> ::std::option::Option::<i32> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             2usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.end, &self._bitfield)
     }
     pub fn end_mut(&mut self) -> &mut i32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             2usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.end,
@@ -182,19 +186,19 @@ impl Annotation {
         )
     }
     pub fn has_end(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             2usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.end, &self._bitfield)
             .is_some()
     }
     pub fn clear_end(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             2usize,
         > as NonRepeatedFieldType>::clear(&mut self.end, &mut self._bitfield)
     }
@@ -211,50 +215,50 @@ impl self::_puroro::Message for Annotation {
         &mut self,
         mut iter: I,
     ) -> self::_puroro::Result<()> {
-        use self::_puroro::internal::ser::FieldData;
+        use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 1i32 => {
-                    <self::_puroro::internal::field_type::RepeatedNumericalField::<
+                    <self::_pinternal::field_type::RepeatedNumericalField::<
                         i32,
-                        self::_puroro::internal::tags::Int32,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                        self::_pinternal::tags::Int32,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.path,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 2i32 => {
-                    <self::_puroro::internal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::field_type::OptionalUnsizedField::<
                         ::std::string::String,
-                        self::_puroro::internal::tags::String,
+                        self::_pinternal::tags::String,
                         0usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.source_file,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 3i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         i32,
-                        self::_puroro::internal::tags::Int32,
+                        self::_pinternal::tags::Int32,
                         1usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.begin,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 4i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         i32,
-                        self::_puroro::internal::tags::Int32,
+                        self::_pinternal::tags::Int32,
                         2usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.end,
                         &mut self._bitfield,
                         field_data,
@@ -271,41 +275,41 @@ impl self::_puroro::Message for Annotation {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::oneof_type::OneofUnion as _;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+            self::_pinternal::tags::Int32,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.path,
             &self._bitfield,
             1i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.source_file,
             &self._bitfield,
             2i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             1usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.begin,
             &self._bitfield,
             3i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             2usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.end,
             &self._bitfield,
             4i32,
@@ -317,23 +321,23 @@ impl self::_puroro::Message for Annotation {
 impl ::std::clone::Clone for Annotation {
     fn clone(&self) -> Self {
         Self {
-            path: <self::_puroro::internal::field_type::RepeatedNumericalField::<
+            path: <self::_pinternal::field_type::RepeatedNumericalField::<
                 i32,
-                self::_puroro::internal::tags::Int32,
+                self::_pinternal::tags::Int32,
             > as ::std::clone::Clone>::clone(&self.path),
-            source_file: <self::_puroro::internal::field_type::OptionalUnsizedField::<
+            source_file: <self::_pinternal::field_type::OptionalUnsizedField::<
                 ::std::string::String,
-                self::_puroro::internal::tags::String,
+                self::_pinternal::tags::String,
                 0usize,
             > as ::std::clone::Clone>::clone(&self.source_file),
-            begin: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            begin: <self::_pinternal::field_type::OptionalNumericalField::<
                 i32,
-                self::_puroro::internal::tags::Int32,
+                self::_pinternal::tags::Int32,
                 1usize,
             > as ::std::clone::Clone>::clone(&self.begin),
-            end: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            end: <self::_pinternal::field_type::OptionalNumericalField::<
                 i32,
-                self::_puroro::internal::tags::Int32,
+                self::_pinternal::tags::Int32,
                 2usize,
             > as ::std::clone::Clone>::clone(&self.end),
             _bitfield: ::std::clone::Clone::clone(&self._bitfield),
@@ -343,7 +347,7 @@ impl ::std::clone::Clone for Annotation {
 impl ::std::ops::Drop for Annotation {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for Annotation {
@@ -362,7 +366,7 @@ impl ::std::fmt::Debug for Annotation {
 impl ::std::cmp::PartialEq for Annotation {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         true && self.path() == rhs.path()
             && self.source_file_opt() == rhs.source_file_opt()
             && self.begin_opt() == rhs.begin_opt() && self.end_opt() == rhs.end_opt()

--- a/puroro-protobuf-compiled/src/google/protobuf/method_options.rs
+++ b/puroro-protobuf-compiled/src/google/protobuf/method_options.rs
@@ -1,10 +1,14 @@
-mod _puroro_root {
+mod _root {
     #[allow(unused)]
-    pub(crate) use super::super::_puroro_root::*;
+    pub(crate) use super::super::_root::*;
 }
 mod _puroro {
     #[allow(unused)]
     pub(crate) use ::puroro::*;
+}
+mod _pinternal {
+    #[allow(unused)]
+    pub(crate) use ::puroro::internal::*;
 }
 #[derive(
     ::std::clone::Clone,

--- a/puroro-protobuf-compiled/src/google/protobuf/source_code_info.rs
+++ b/puroro-protobuf-compiled/src/google/protobuf/source_code_info.rs
@@ -1,85 +1,89 @@
-mod _puroro_root {
+mod _root {
     #[allow(unused)]
-    pub(crate) use super::super::_puroro_root::*;
+    pub(crate) use super::super::_root::*;
 }
 mod _puroro {
     #[allow(unused)]
     pub(crate) use ::puroro::*;
 }
+mod _pinternal {
+    #[allow(unused)]
+    pub(crate) use ::puroro::internal::*;
+}
 #[derive(::std::default::Default)]
 pub struct Location {
-    path: self::_puroro::internal::field_type::RepeatedNumericalField::<
+    path: self::_pinternal::field_type::RepeatedNumericalField::<
         i32,
-        self::_puroro::internal::tags::Int32,
+        self::_pinternal::tags::Int32,
     >,
-    span: self::_puroro::internal::field_type::RepeatedNumericalField::<
+    span: self::_pinternal::field_type::RepeatedNumericalField::<
         i32,
-        self::_puroro::internal::tags::Int32,
+        self::_pinternal::tags::Int32,
     >,
-    leading_comments: self::_puroro::internal::field_type::OptionalUnsizedField::<
+    leading_comments: self::_pinternal::field_type::OptionalUnsizedField::<
         ::std::string::String,
-        self::_puroro::internal::tags::String,
+        self::_pinternal::tags::String,
         0usize,
     >,
-    trailing_comments: self::_puroro::internal::field_type::OptionalUnsizedField::<
+    trailing_comments: self::_pinternal::field_type::OptionalUnsizedField::<
         ::std::string::String,
-        self::_puroro::internal::tags::String,
+        self::_pinternal::tags::String,
         1usize,
     >,
-    leading_detached_comments: self::_puroro::internal::field_type::RepeatedUnsizedField::<
+    leading_detached_comments: self::_pinternal::field_type::RepeatedUnsizedField::<
         ::std::string::String,
-        self::_puroro::internal::tags::String,
+        self::_pinternal::tags::String,
     >,
-    _bitfield: self::_puroro::internal::bitvec::BitArray<1usize>,
+    _bitfield: self::_pinternal::bitvec::BitArray<1usize>,
 }
 impl Location {
     pub fn path(&self) -> &[i32] {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
         > as RepeatedFieldType>::get_field(&self.path, &self._bitfield)
     }
     pub fn path_mut(&mut self) -> &mut ::std::vec::Vec::<i32> {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
         > as RepeatedFieldType>::get_field_mut(&mut self.path, &mut self._bitfield)
     }
     pub fn clear_path(&mut self) {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
         > as RepeatedFieldType>::clear(&mut self.path, &mut self._bitfield)
     }
     pub fn span(&self) -> &[i32] {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
         > as RepeatedFieldType>::get_field(&self.span, &self._bitfield)
     }
     pub fn span_mut(&mut self) -> &mut ::std::vec::Vec::<i32> {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
         > as RepeatedFieldType>::get_field_mut(&mut self.span, &mut self._bitfield)
     }
     pub fn clear_span(&mut self) {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
         > as RepeatedFieldType>::clear(&mut self.span, &mut self._bitfield)
     }
     pub fn leading_comments(&self) -> &str {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.leading_comments,
@@ -88,10 +92,10 @@ impl Location {
         )
     }
     pub fn leading_comments_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(
             &self.leading_comments,
@@ -99,10 +103,10 @@ impl Location {
         )
     }
     pub fn leading_comments_mut(&mut self) -> &mut ::std::string::String {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.leading_comments,
@@ -111,10 +115,10 @@ impl Location {
         )
     }
     pub fn has_leading_comments(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(
                 &self.leading_comments,
@@ -123,10 +127,10 @@ impl Location {
             .is_some()
     }
     pub fn clear_leading_comments(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::clear(
             &mut self.leading_comments,
@@ -134,10 +138,10 @@ impl Location {
         )
     }
     pub fn trailing_comments(&self) -> &str {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             1usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.trailing_comments,
@@ -146,10 +150,10 @@ impl Location {
         )
     }
     pub fn trailing_comments_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             1usize,
         > as NonRepeatedFieldType>::get_field_opt(
             &self.trailing_comments,
@@ -157,10 +161,10 @@ impl Location {
         )
     }
     pub fn trailing_comments_mut(&mut self) -> &mut ::std::string::String {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             1usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.trailing_comments,
@@ -169,10 +173,10 @@ impl Location {
         )
     }
     pub fn has_trailing_comments(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             1usize,
         > as NonRepeatedFieldType>::get_field_opt(
                 &self.trailing_comments,
@@ -181,10 +185,10 @@ impl Location {
             .is_some()
     }
     pub fn clear_trailing_comments(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             1usize,
         > as NonRepeatedFieldType>::clear(
             &mut self.trailing_comments,
@@ -196,10 +200,10 @@ impl Location {
     ) -> &[impl ::std::ops::Deref::<
         Target = str,
     > + ::std::fmt::Debug + ::std::cmp::PartialEq] {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedUnsizedField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
         > as RepeatedFieldType>::get_field(
             &self.leading_detached_comments,
             &self._bitfield,
@@ -208,20 +212,20 @@ impl Location {
     pub fn leading_detached_comments_mut(
         &mut self,
     ) -> &mut ::std::vec::Vec::<::std::string::String> {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedUnsizedField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
         > as RepeatedFieldType>::get_field_mut(
             &mut self.leading_detached_comments,
             &mut self._bitfield,
         )
     }
     pub fn clear_leading_detached_comments(&mut self) {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedUnsizedField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
         > as RepeatedFieldType>::clear(
             &mut self.leading_detached_comments,
             &mut self._bitfield,
@@ -240,59 +244,59 @@ impl self::_puroro::Message for Location {
         &mut self,
         mut iter: I,
     ) -> self::_puroro::Result<()> {
-        use self::_puroro::internal::ser::FieldData;
+        use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 1i32 => {
-                    <self::_puroro::internal::field_type::RepeatedNumericalField::<
+                    <self::_pinternal::field_type::RepeatedNumericalField::<
                         i32,
-                        self::_puroro::internal::tags::Int32,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                        self::_pinternal::tags::Int32,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.path,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 2i32 => {
-                    <self::_puroro::internal::field_type::RepeatedNumericalField::<
+                    <self::_pinternal::field_type::RepeatedNumericalField::<
                         i32,
-                        self::_puroro::internal::tags::Int32,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                        self::_pinternal::tags::Int32,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.span,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 3i32 => {
-                    <self::_puroro::internal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::field_type::OptionalUnsizedField::<
                         ::std::string::String,
-                        self::_puroro::internal::tags::String,
+                        self::_pinternal::tags::String,
                         0usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.leading_comments,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 4i32 => {
-                    <self::_puroro::internal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::field_type::OptionalUnsizedField::<
                         ::std::string::String,
-                        self::_puroro::internal::tags::String,
+                        self::_pinternal::tags::String,
                         1usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.trailing_comments,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 6i32 => {
-                    <self::_puroro::internal::field_type::RepeatedUnsizedField::<
+                    <self::_pinternal::field_type::RepeatedUnsizedField::<
                         ::std::string::String,
-                        self::_puroro::internal::tags::String,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                        self::_pinternal::tags::String,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.leading_detached_comments,
                         &mut self._bitfield,
                         field_data,
@@ -309,49 +313,49 @@ impl self::_puroro::Message for Location {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::oneof_type::OneofUnion as _;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+            self::_pinternal::tags::Int32,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.path,
             &self._bitfield,
             1i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+            self::_pinternal::tags::Int32,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.span,
             &self._bitfield,
             2i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.leading_comments,
             &self._bitfield,
             3i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             1usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.trailing_comments,
             &self._bitfield,
             4i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::RepeatedUnsizedField::<
+        <self::_pinternal::field_type::RepeatedUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+            self::_pinternal::tags::String,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.leading_detached_comments,
             &self._bitfield,
             6i32,
@@ -363,27 +367,27 @@ impl self::_puroro::Message for Location {
 impl ::std::clone::Clone for Location {
     fn clone(&self) -> Self {
         Self {
-            path: <self::_puroro::internal::field_type::RepeatedNumericalField::<
+            path: <self::_pinternal::field_type::RepeatedNumericalField::<
                 i32,
-                self::_puroro::internal::tags::Int32,
+                self::_pinternal::tags::Int32,
             > as ::std::clone::Clone>::clone(&self.path),
-            span: <self::_puroro::internal::field_type::RepeatedNumericalField::<
+            span: <self::_pinternal::field_type::RepeatedNumericalField::<
                 i32,
-                self::_puroro::internal::tags::Int32,
+                self::_pinternal::tags::Int32,
             > as ::std::clone::Clone>::clone(&self.span),
-            leading_comments: <self::_puroro::internal::field_type::OptionalUnsizedField::<
+            leading_comments: <self::_pinternal::field_type::OptionalUnsizedField::<
                 ::std::string::String,
-                self::_puroro::internal::tags::String,
+                self::_pinternal::tags::String,
                 0usize,
             > as ::std::clone::Clone>::clone(&self.leading_comments),
-            trailing_comments: <self::_puroro::internal::field_type::OptionalUnsizedField::<
+            trailing_comments: <self::_pinternal::field_type::OptionalUnsizedField::<
                 ::std::string::String,
-                self::_puroro::internal::tags::String,
+                self::_pinternal::tags::String,
                 1usize,
             > as ::std::clone::Clone>::clone(&self.trailing_comments),
-            leading_detached_comments: <self::_puroro::internal::field_type::RepeatedUnsizedField::<
+            leading_detached_comments: <self::_pinternal::field_type::RepeatedUnsizedField::<
                 ::std::string::String,
-                self::_puroro::internal::tags::String,
+                self::_pinternal::tags::String,
             > as ::std::clone::Clone>::clone(&self.leading_detached_comments),
             _bitfield: ::std::clone::Clone::clone(&self._bitfield),
         }
@@ -392,7 +396,7 @@ impl ::std::clone::Clone for Location {
 impl ::std::ops::Drop for Location {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for Location {
@@ -415,7 +419,7 @@ impl ::std::fmt::Debug for Location {
 impl ::std::cmp::PartialEq for Location {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         true && self.path() == rhs.path() && self.span() == rhs.span()
             && self.leading_comments_opt() == rhs.leading_comments_opt()
             && self.trailing_comments_opt() == rhs.trailing_comments_opt()

--- a/puroro-protobuf-compiled/src/google/protobuf/source_code_info.rs
+++ b/puroro-protobuf-compiled/src/google/protobuf/source_code_info.rs
@@ -12,76 +12,70 @@ mod _pinternal {
 }
 #[derive(::std::default::Default)]
 pub struct Location {
-    path: self::_pinternal::field_type::RepeatedNumericalField::<
-        i32,
-        self::_pinternal::tags::Int32,
-    >,
-    span: self::_pinternal::field_type::RepeatedNumericalField::<
-        i32,
-        self::_pinternal::tags::Int32,
-    >,
-    leading_comments: self::_pinternal::field_type::OptionalUnsizedField::<
+    path: self::_pinternal::RepeatedNumericalField::<i32, self::_pinternal::tags::Int32>,
+    span: self::_pinternal::RepeatedNumericalField::<i32, self::_pinternal::tags::Int32>,
+    leading_comments: self::_pinternal::OptionalUnsizedField::<
         ::std::string::String,
         self::_pinternal::tags::String,
         0usize,
     >,
-    trailing_comments: self::_pinternal::field_type::OptionalUnsizedField::<
+    trailing_comments: self::_pinternal::OptionalUnsizedField::<
         ::std::string::String,
         self::_pinternal::tags::String,
         1usize,
     >,
-    leading_detached_comments: self::_pinternal::field_type::RepeatedUnsizedField::<
+    leading_detached_comments: self::_pinternal::RepeatedUnsizedField::<
         ::std::string::String,
         self::_pinternal::tags::String,
     >,
-    _bitfield: self::_pinternal::bitvec::BitArray<1usize>,
+    _bitfield: self::_pinternal::BitArray<1usize>,
 }
 impl Location {
     pub fn path(&self) -> &[i32] {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
         > as RepeatedFieldType>::get_field(&self.path, &self._bitfield)
     }
     pub fn path_mut(&mut self) -> &mut ::std::vec::Vec::<i32> {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
         > as RepeatedFieldType>::get_field_mut(&mut self.path, &mut self._bitfield)
     }
     pub fn clear_path(&mut self) {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
         > as RepeatedFieldType>::clear(&mut self.path, &mut self._bitfield)
     }
     pub fn span(&self) -> &[i32] {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
         > as RepeatedFieldType>::get_field(&self.span, &self._bitfield)
     }
     pub fn span_mut(&mut self) -> &mut ::std::vec::Vec::<i32> {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
         > as RepeatedFieldType>::get_field_mut(&mut self.span, &mut self._bitfield)
     }
     pub fn clear_span(&mut self) {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
         > as RepeatedFieldType>::clear(&mut self.span, &mut self._bitfield)
     }
     pub fn leading_comments(&self) -> &str {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
@@ -92,8 +86,8 @@ impl Location {
         )
     }
     pub fn leading_comments_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
@@ -103,8 +97,8 @@ impl Location {
         )
     }
     pub fn leading_comments_mut(&mut self) -> &mut ::std::string::String {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
@@ -115,8 +109,8 @@ impl Location {
         )
     }
     pub fn has_leading_comments(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
@@ -127,8 +121,8 @@ impl Location {
             .is_some()
     }
     pub fn clear_leading_comments(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
@@ -138,8 +132,8 @@ impl Location {
         )
     }
     pub fn trailing_comments(&self) -> &str {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             1usize,
@@ -150,8 +144,8 @@ impl Location {
         )
     }
     pub fn trailing_comments_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             1usize,
@@ -161,8 +155,8 @@ impl Location {
         )
     }
     pub fn trailing_comments_mut(&mut self) -> &mut ::std::string::String {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             1usize,
@@ -173,8 +167,8 @@ impl Location {
         )
     }
     pub fn has_trailing_comments(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             1usize,
@@ -185,8 +179,8 @@ impl Location {
             .is_some()
     }
     pub fn clear_trailing_comments(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             1usize,
@@ -200,8 +194,8 @@ impl Location {
     ) -> &[impl ::std::ops::Deref::<
         Target = str,
     > + ::std::fmt::Debug + ::std::cmp::PartialEq] {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedUnsizedField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
         > as RepeatedFieldType>::get_field(
@@ -212,8 +206,8 @@ impl Location {
     pub fn leading_detached_comments_mut(
         &mut self,
     ) -> &mut ::std::vec::Vec::<::std::string::String> {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedUnsizedField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
         > as RepeatedFieldType>::get_field_mut(
@@ -222,8 +216,8 @@ impl Location {
         )
     }
     pub fn clear_leading_detached_comments(&mut self) {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedUnsizedField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
         > as RepeatedFieldType>::clear(
@@ -246,57 +240,57 @@ impl self::_puroro::Message for Location {
     ) -> self::_puroro::Result<()> {
         use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 1i32 => {
-                    <self::_pinternal::field_type::RepeatedNumericalField::<
+                    <self::_pinternal::RepeatedNumericalField::<
                         i32,
                         self::_pinternal::tags::Int32,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.path,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 2i32 => {
-                    <self::_pinternal::field_type::RepeatedNumericalField::<
+                    <self::_pinternal::RepeatedNumericalField::<
                         i32,
                         self::_pinternal::tags::Int32,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.span,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 3i32 => {
-                    <self::_pinternal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::OptionalUnsizedField::<
                         ::std::string::String,
                         self::_pinternal::tags::String,
                         0usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.leading_comments,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 4i32 => {
-                    <self::_pinternal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::OptionalUnsizedField::<
                         ::std::string::String,
                         self::_pinternal::tags::String,
                         1usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.trailing_comments,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 6i32 => {
-                    <self::_pinternal::field_type::RepeatedUnsizedField::<
+                    <self::_pinternal::RepeatedUnsizedField::<
                         ::std::string::String,
                         self::_pinternal::tags::String,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.leading_detached_comments,
                         &mut self._bitfield,
                         field_data,
@@ -313,49 +307,49 @@ impl self::_puroro::Message for Location {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::OneofUnion as _;
+        <self::_pinternal::RepeatedNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.path,
             &self._bitfield,
             1i32,
             out,
         )?;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        <self::_pinternal::RepeatedNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.span,
             &self._bitfield,
             2i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.leading_comments,
             &self._bitfield,
             3i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             1usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.trailing_comments,
             &self._bitfield,
             4i32,
             out,
         )?;
-        <self::_pinternal::field_type::RepeatedUnsizedField::<
+        <self::_pinternal::RepeatedUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.leading_detached_comments,
             &self._bitfield,
             6i32,
@@ -367,25 +361,25 @@ impl self::_puroro::Message for Location {
 impl ::std::clone::Clone for Location {
     fn clone(&self) -> Self {
         Self {
-            path: <self::_pinternal::field_type::RepeatedNumericalField::<
+            path: <self::_pinternal::RepeatedNumericalField::<
                 i32,
                 self::_pinternal::tags::Int32,
             > as ::std::clone::Clone>::clone(&self.path),
-            span: <self::_pinternal::field_type::RepeatedNumericalField::<
+            span: <self::_pinternal::RepeatedNumericalField::<
                 i32,
                 self::_pinternal::tags::Int32,
             > as ::std::clone::Clone>::clone(&self.span),
-            leading_comments: <self::_pinternal::field_type::OptionalUnsizedField::<
+            leading_comments: <self::_pinternal::OptionalUnsizedField::<
                 ::std::string::String,
                 self::_pinternal::tags::String,
                 0usize,
             > as ::std::clone::Clone>::clone(&self.leading_comments),
-            trailing_comments: <self::_pinternal::field_type::OptionalUnsizedField::<
+            trailing_comments: <self::_pinternal::OptionalUnsizedField::<
                 ::std::string::String,
                 self::_pinternal::tags::String,
                 1usize,
             > as ::std::clone::Clone>::clone(&self.trailing_comments),
-            leading_detached_comments: <self::_pinternal::field_type::RepeatedUnsizedField::<
+            leading_detached_comments: <self::_pinternal::RepeatedUnsizedField::<
                 ::std::string::String,
                 self::_pinternal::tags::String,
             > as ::std::clone::Clone>::clone(&self.leading_detached_comments),
@@ -396,7 +390,7 @@ impl ::std::clone::Clone for Location {
 impl ::std::ops::Drop for Location {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for Location {
@@ -419,7 +413,7 @@ impl ::std::fmt::Debug for Location {
 impl ::std::cmp::PartialEq for Location {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         true && self.path() == rhs.path() && self.span() == rhs.span()
             && self.leading_comments_opt() == rhs.leading_comments_opt()
             && self.trailing_comments_opt() == rhs.trailing_comments_opt()

--- a/puroro-protobuf-compiled/src/google/protobuf/uninterpreted_option.rs
+++ b/puroro-protobuf-compiled/src/google/protobuf/uninterpreted_option.rs
@@ -12,22 +12,22 @@ mod _pinternal {
 }
 #[derive(::std::default::Default)]
 pub struct NamePart {
-    name_part: self::_pinternal::field_type::OptionalUnsizedField::<
+    name_part: self::_pinternal::OptionalUnsizedField::<
         ::std::string::String,
         self::_pinternal::tags::String,
         0usize,
     >,
-    is_extension: self::_pinternal::field_type::OptionalNumericalField::<
+    is_extension: self::_pinternal::OptionalNumericalField::<
         bool,
         self::_pinternal::tags::Bool,
         1usize,
     >,
-    _bitfield: self::_pinternal::bitvec::BitArray<1usize>,
+    _bitfield: self::_pinternal::BitArray<1usize>,
 }
 impl NamePart {
     pub fn name_part(&self) -> &str {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
@@ -38,16 +38,16 @@ impl NamePart {
         )
     }
     pub fn name_part_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.name_part, &self._bitfield)
     }
     pub fn name_part_mut(&mut self) -> &mut ::std::string::String {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
@@ -58,8 +58,8 @@ impl NamePart {
         )
     }
     pub fn has_name_part(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
@@ -67,16 +67,16 @@ impl NamePart {
             .is_some()
     }
     pub fn clear_name_part(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::clear(&mut self.name_part, &mut self._bitfield)
     }
     pub fn is_extension(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             1usize,
@@ -87,16 +87,16 @@ impl NamePart {
         )
     }
     pub fn is_extension_opt(&self) -> ::std::option::Option::<bool> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             1usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.is_extension, &self._bitfield)
     }
     pub fn is_extension_mut(&mut self) -> &mut bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             1usize,
@@ -107,8 +107,8 @@ impl NamePart {
         )
     }
     pub fn has_is_extension(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             1usize,
@@ -116,8 +116,8 @@ impl NamePart {
             .is_some()
     }
     pub fn clear_is_extension(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             1usize,
@@ -138,27 +138,27 @@ impl self::_puroro::Message for NamePart {
     ) -> self::_puroro::Result<()> {
         use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 1i32 => {
-                    <self::_pinternal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::OptionalUnsizedField::<
                         ::std::string::String,
                         self::_pinternal::tags::String,
                         0usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.name_part,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 2i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         bool,
                         self::_pinternal::tags::Bool,
                         1usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.is_extension,
                         &mut self._bitfield,
                         field_data,
@@ -175,22 +175,22 @@ impl self::_puroro::Message for NamePart {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::OneofUnion as _;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             0usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.name_part,
             &self._bitfield,
             1i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        <self::_pinternal::OptionalNumericalField::<
             bool,
             self::_pinternal::tags::Bool,
             1usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.is_extension,
             &self._bitfield,
             2i32,
@@ -202,12 +202,12 @@ impl self::_puroro::Message for NamePart {
 impl ::std::clone::Clone for NamePart {
     fn clone(&self) -> Self {
         Self {
-            name_part: <self::_pinternal::field_type::OptionalUnsizedField::<
+            name_part: <self::_pinternal::OptionalUnsizedField::<
                 ::std::string::String,
                 self::_pinternal::tags::String,
                 0usize,
             > as ::std::clone::Clone>::clone(&self.name_part),
-            is_extension: <self::_pinternal::field_type::OptionalNumericalField::<
+            is_extension: <self::_pinternal::OptionalNumericalField::<
                 bool,
                 self::_pinternal::tags::Bool,
                 1usize,
@@ -219,7 +219,7 @@ impl ::std::clone::Clone for NamePart {
 impl ::std::ops::Drop for NamePart {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for NamePart {
@@ -236,7 +236,7 @@ impl ::std::fmt::Debug for NamePart {
 impl ::std::cmp::PartialEq for NamePart {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         true && self.name_part_opt() == rhs.name_part_opt()
             && self.is_extension_opt() == rhs.is_extension_opt()
     }

--- a/puroro-protobuf-compiled/src/google/protobuf/uninterpreted_option.rs
+++ b/puroro-protobuf-compiled/src/google/protobuf/uninterpreted_option.rs
@@ -1,31 +1,35 @@
-mod _puroro_root {
+mod _root {
     #[allow(unused)]
-    pub(crate) use super::super::_puroro_root::*;
+    pub(crate) use super::super::_root::*;
 }
 mod _puroro {
     #[allow(unused)]
     pub(crate) use ::puroro::*;
 }
+mod _pinternal {
+    #[allow(unused)]
+    pub(crate) use ::puroro::internal::*;
+}
 #[derive(::std::default::Default)]
 pub struct NamePart {
-    name_part: self::_puroro::internal::field_type::OptionalUnsizedField::<
+    name_part: self::_pinternal::field_type::OptionalUnsizedField::<
         ::std::string::String,
-        self::_puroro::internal::tags::String,
+        self::_pinternal::tags::String,
         0usize,
     >,
-    is_extension: self::_puroro::internal::field_type::OptionalNumericalField::<
+    is_extension: self::_pinternal::field_type::OptionalNumericalField::<
         bool,
-        self::_puroro::internal::tags::Bool,
+        self::_pinternal::tags::Bool,
         1usize,
     >,
-    _bitfield: self::_puroro::internal::bitvec::BitArray<1usize>,
+    _bitfield: self::_pinternal::bitvec::BitArray<1usize>,
 }
 impl NamePart {
     pub fn name_part(&self) -> &str {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.name_part,
@@ -34,18 +38,18 @@ impl NamePart {
         )
     }
     pub fn name_part_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.name_part, &self._bitfield)
     }
     pub fn name_part_mut(&mut self) -> &mut ::std::string::String {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.name_part,
@@ -54,27 +58,27 @@ impl NamePart {
         )
     }
     pub fn has_name_part(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.name_part, &self._bitfield)
             .is_some()
     }
     pub fn clear_name_part(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
         > as NonRepeatedFieldType>::clear(&mut self.name_part, &mut self._bitfield)
     }
     pub fn is_extension(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             1usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.is_extension,
@@ -83,18 +87,18 @@ impl NamePart {
         )
     }
     pub fn is_extension_opt(&self) -> ::std::option::Option::<bool> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             1usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.is_extension, &self._bitfield)
     }
     pub fn is_extension_mut(&mut self) -> &mut bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             1usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.is_extension,
@@ -103,19 +107,19 @@ impl NamePart {
         )
     }
     pub fn has_is_extension(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             1usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.is_extension, &self._bitfield)
             .is_some()
     }
     pub fn clear_is_extension(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             1usize,
         > as NonRepeatedFieldType>::clear(&mut self.is_extension, &mut self._bitfield)
     }
@@ -132,29 +136,29 @@ impl self::_puroro::Message for NamePart {
         &mut self,
         mut iter: I,
     ) -> self::_puroro::Result<()> {
-        use self::_puroro::internal::ser::FieldData;
+        use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 1i32 => {
-                    <self::_puroro::internal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::field_type::OptionalUnsizedField::<
                         ::std::string::String,
-                        self::_puroro::internal::tags::String,
+                        self::_pinternal::tags::String,
                         0usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.name_part,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 2i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         bool,
-                        self::_puroro::internal::tags::Bool,
+                        self::_pinternal::tags::Bool,
                         1usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.is_extension,
                         &mut self._bitfield,
                         field_data,
@@ -171,22 +175,22 @@ impl self::_puroro::Message for NamePart {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::oneof_type::OneofUnion as _;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             0usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.name_part,
             &self._bitfield,
             1i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        <self::_pinternal::field_type::OptionalNumericalField::<
             bool,
-            self::_puroro::internal::tags::Bool,
+            self::_pinternal::tags::Bool,
             1usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.is_extension,
             &self._bitfield,
             2i32,
@@ -198,14 +202,14 @@ impl self::_puroro::Message for NamePart {
 impl ::std::clone::Clone for NamePart {
     fn clone(&self) -> Self {
         Self {
-            name_part: <self::_puroro::internal::field_type::OptionalUnsizedField::<
+            name_part: <self::_pinternal::field_type::OptionalUnsizedField::<
                 ::std::string::String,
-                self::_puroro::internal::tags::String,
+                self::_pinternal::tags::String,
                 0usize,
             > as ::std::clone::Clone>::clone(&self.name_part),
-            is_extension: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            is_extension: <self::_pinternal::field_type::OptionalNumericalField::<
                 bool,
-                self::_puroro::internal::tags::Bool,
+                self::_pinternal::tags::Bool,
                 1usize,
             > as ::std::clone::Clone>::clone(&self.is_extension),
             _bitfield: ::std::clone::Clone::clone(&self._bitfield),
@@ -215,7 +219,7 @@ impl ::std::clone::Clone for NamePart {
 impl ::std::ops::Drop for NamePart {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for NamePart {
@@ -232,7 +236,7 @@ impl ::std::fmt::Debug for NamePart {
 impl ::std::cmp::PartialEq for NamePart {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         true && self.name_part_opt() == rhs.name_part_opt()
             && self.is_extension_opt() == rhs.is_extension_opt()
     }

--- a/puroro-protobuf-compiled/src/lib.rs
+++ b/puroro-protobuf-compiled/src/lib.rs
@@ -3,12 +3,16 @@ pub use ::puroro;
 /// re-export the primitive types in puroro namespace.
 /// by using the "*", it can be hidden by the same typename explicitly defined in this file.
 pub use ::puroro::*;
-mod _puroro_root {
+mod _root {
     #[allow(unused)]
     pub(crate) use super::*;
 }
 mod _puroro {
     #[allow(unused)]
     pub(crate) use ::puroro::*;
+}
+mod _pinternal {
+    #[allow(unused)]
+    pub(crate) use ::puroro::internal::*;
 }
 pub mod google;

--- a/puroro/src/internal.rs
+++ b/puroro/src/internal.rs
@@ -20,3 +20,12 @@ pub mod ser;
 pub mod tags;
 pub mod utils;
 pub mod variant;
+
+pub use self::bitvec::{BitArray, BitSlice};
+pub use self::field_type::{
+    FieldType, NonRepeatedFieldType, OptionalNumericalField, OptionalUnsizedField,
+    RepeatedFieldType, RepeatedMessageField, RepeatedNumericalField, RepeatedUnsizedField,
+    SingularHeapMessageField, SingularNumericalField, SingularUnsizedField,
+};
+pub use self::oneof_field_type::{HeapMessageField, NumericalField, OneofFieldType, UnsizedField};
+pub use self::oneof_type::{OneofCase, OneofUnion};

--- a/tests-pb/src/full_coverage2.rs
+++ b/tests-pb/src/full_coverage2.rs
@@ -13,231 +13,231 @@ mod _pinternal {
 pub mod msg;
 #[derive(::std::default::Default)]
 pub struct Msg {
-    i32_required: self::_pinternal::field_type::OptionalNumericalField::<
+    i32_required: self::_pinternal::OptionalNumericalField::<
         i32,
         self::_pinternal::tags::Int32,
         0usize,
     >,
-    i32_optional: self::_pinternal::field_type::OptionalNumericalField::<
+    i32_optional: self::_pinternal::OptionalNumericalField::<
         i32,
         self::_pinternal::tags::Int32,
         1usize,
     >,
-    i32_repeated: self::_pinternal::field_type::RepeatedNumericalField::<
+    i32_repeated: self::_pinternal::RepeatedNumericalField::<
         i32,
         self::_pinternal::tags::Int32,
     >,
-    float_required: self::_pinternal::field_type::OptionalNumericalField::<
+    float_required: self::_pinternal::OptionalNumericalField::<
         f32,
         self::_pinternal::tags::Float,
         2usize,
     >,
-    float_optional: self::_pinternal::field_type::OptionalNumericalField::<
+    float_optional: self::_pinternal::OptionalNumericalField::<
         f32,
         self::_pinternal::tags::Float,
         3usize,
     >,
-    float_repeated: self::_pinternal::field_type::RepeatedNumericalField::<
+    float_repeated: self::_pinternal::RepeatedNumericalField::<
         f32,
         self::_pinternal::tags::Float,
     >,
-    bytes_required: self::_pinternal::field_type::OptionalUnsizedField::<
+    bytes_required: self::_pinternal::OptionalUnsizedField::<
         ::std::vec::Vec<u8>,
         self::_pinternal::tags::Bytes,
         4usize,
     >,
-    bytes_optional: self::_pinternal::field_type::OptionalUnsizedField::<
+    bytes_optional: self::_pinternal::OptionalUnsizedField::<
         ::std::vec::Vec<u8>,
         self::_pinternal::tags::Bytes,
         5usize,
     >,
-    bytes_repeated: self::_pinternal::field_type::RepeatedUnsizedField::<
+    bytes_repeated: self::_pinternal::RepeatedUnsizedField::<
         ::std::vec::Vec<u8>,
         self::_pinternal::tags::Bytes,
     >,
-    string_required: self::_pinternal::field_type::OptionalUnsizedField::<
+    string_required: self::_pinternal::OptionalUnsizedField::<
         ::std::string::String,
         self::_pinternal::tags::String,
         6usize,
     >,
-    string_optional: self::_pinternal::field_type::OptionalUnsizedField::<
+    string_optional: self::_pinternal::OptionalUnsizedField::<
         ::std::string::String,
         self::_pinternal::tags::String,
         7usize,
     >,
-    string_repeated: self::_pinternal::field_type::RepeatedUnsizedField::<
+    string_repeated: self::_pinternal::RepeatedUnsizedField::<
         ::std::string::String,
         self::_pinternal::tags::String,
     >,
-    enum_required: self::_pinternal::field_type::OptionalNumericalField::<
+    enum_required: self::_pinternal::OptionalNumericalField::<
         self::_root::full_coverage2::Enum,
         self::_pinternal::tags::Enum2::<self::_root::full_coverage2::Enum>,
         8usize,
     >,
-    enum_optional: self::_pinternal::field_type::OptionalNumericalField::<
+    enum_optional: self::_pinternal::OptionalNumericalField::<
         self::_root::full_coverage2::Enum,
         self::_pinternal::tags::Enum2::<self::_root::full_coverage2::Enum>,
         9usize,
     >,
-    enum_repeated: self::_pinternal::field_type::RepeatedNumericalField::<
+    enum_repeated: self::_pinternal::RepeatedNumericalField::<
         self::_root::full_coverage2::Enum,
         self::_pinternal::tags::Enum2::<self::_root::full_coverage2::Enum>,
     >,
-    submsg_required: self::_pinternal::field_type::SingularHeapMessageField::<
+    submsg_required: self::_pinternal::SingularHeapMessageField::<
         self::_root::full_coverage2::msg::Submsg,
     >,
-    submsg_optional: self::_pinternal::field_type::SingularHeapMessageField::<
+    submsg_optional: self::_pinternal::SingularHeapMessageField::<
         self::_root::full_coverage2::msg::Submsg,
     >,
-    submsg_repeated: self::_pinternal::field_type::RepeatedMessageField::<
+    submsg_repeated: self::_pinternal::RepeatedMessageField::<
         self::_root::full_coverage2::msg::Submsg,
     >,
-    i64_required: self::_pinternal::field_type::OptionalNumericalField::<
+    i64_required: self::_pinternal::OptionalNumericalField::<
         i64,
         self::_pinternal::tags::Int64,
         10usize,
     >,
-    i64_optional: self::_pinternal::field_type::OptionalNumericalField::<
+    i64_optional: self::_pinternal::OptionalNumericalField::<
         i64,
         self::_pinternal::tags::Int64,
         11usize,
     >,
-    i64_repeated: self::_pinternal::field_type::RepeatedNumericalField::<
+    i64_repeated: self::_pinternal::RepeatedNumericalField::<
         i64,
         self::_pinternal::tags::Int64,
     >,
-    u32_required: self::_pinternal::field_type::OptionalNumericalField::<
+    u32_required: self::_pinternal::OptionalNumericalField::<
         u32,
         self::_pinternal::tags::UInt32,
         12usize,
     >,
-    u32_optional: self::_pinternal::field_type::OptionalNumericalField::<
+    u32_optional: self::_pinternal::OptionalNumericalField::<
         u32,
         self::_pinternal::tags::UInt32,
         13usize,
     >,
-    u32_repeated: self::_pinternal::field_type::RepeatedNumericalField::<
+    u32_repeated: self::_pinternal::RepeatedNumericalField::<
         u32,
         self::_pinternal::tags::UInt32,
     >,
-    u64_required: self::_pinternal::field_type::OptionalNumericalField::<
+    u64_required: self::_pinternal::OptionalNumericalField::<
         u64,
         self::_pinternal::tags::UInt64,
         14usize,
     >,
-    u64_optional: self::_pinternal::field_type::OptionalNumericalField::<
+    u64_optional: self::_pinternal::OptionalNumericalField::<
         u64,
         self::_pinternal::tags::UInt64,
         15usize,
     >,
-    u64_repeated: self::_pinternal::field_type::RepeatedNumericalField::<
+    u64_repeated: self::_pinternal::RepeatedNumericalField::<
         u64,
         self::_pinternal::tags::UInt64,
     >,
-    s32_required: self::_pinternal::field_type::OptionalNumericalField::<
+    s32_required: self::_pinternal::OptionalNumericalField::<
         i32,
         self::_pinternal::tags::SInt32,
         16usize,
     >,
-    s32_optional: self::_pinternal::field_type::OptionalNumericalField::<
+    s32_optional: self::_pinternal::OptionalNumericalField::<
         i32,
         self::_pinternal::tags::SInt32,
         17usize,
     >,
-    s32_repeated: self::_pinternal::field_type::RepeatedNumericalField::<
+    s32_repeated: self::_pinternal::RepeatedNumericalField::<
         i32,
         self::_pinternal::tags::SInt32,
     >,
-    s64_required: self::_pinternal::field_type::OptionalNumericalField::<
+    s64_required: self::_pinternal::OptionalNumericalField::<
         i64,
         self::_pinternal::tags::SInt64,
         18usize,
     >,
-    s64_optional: self::_pinternal::field_type::OptionalNumericalField::<
+    s64_optional: self::_pinternal::OptionalNumericalField::<
         i64,
         self::_pinternal::tags::SInt64,
         19usize,
     >,
-    s64_repeated: self::_pinternal::field_type::RepeatedNumericalField::<
+    s64_repeated: self::_pinternal::RepeatedNumericalField::<
         i64,
         self::_pinternal::tags::SInt64,
     >,
-    fixed32_required: self::_pinternal::field_type::OptionalNumericalField::<
+    fixed32_required: self::_pinternal::OptionalNumericalField::<
         u32,
         self::_pinternal::tags::Fixed32,
         20usize,
     >,
-    fixed32_optional: self::_pinternal::field_type::OptionalNumericalField::<
+    fixed32_optional: self::_pinternal::OptionalNumericalField::<
         u32,
         self::_pinternal::tags::Fixed32,
         21usize,
     >,
-    fixed32_repeated: self::_pinternal::field_type::RepeatedNumericalField::<
+    fixed32_repeated: self::_pinternal::RepeatedNumericalField::<
         u32,
         self::_pinternal::tags::Fixed32,
     >,
-    fixed64_required: self::_pinternal::field_type::OptionalNumericalField::<
+    fixed64_required: self::_pinternal::OptionalNumericalField::<
         u64,
         self::_pinternal::tags::Fixed64,
         22usize,
     >,
-    fixed64_optional: self::_pinternal::field_type::OptionalNumericalField::<
+    fixed64_optional: self::_pinternal::OptionalNumericalField::<
         u64,
         self::_pinternal::tags::Fixed64,
         23usize,
     >,
-    fixed64_repeated: self::_pinternal::field_type::RepeatedNumericalField::<
+    fixed64_repeated: self::_pinternal::RepeatedNumericalField::<
         u64,
         self::_pinternal::tags::Fixed64,
     >,
-    sfixed32_required: self::_pinternal::field_type::OptionalNumericalField::<
+    sfixed32_required: self::_pinternal::OptionalNumericalField::<
         i32,
         self::_pinternal::tags::SFixed32,
         24usize,
     >,
-    sfixed32_optional: self::_pinternal::field_type::OptionalNumericalField::<
+    sfixed32_optional: self::_pinternal::OptionalNumericalField::<
         i32,
         self::_pinternal::tags::SFixed32,
         25usize,
     >,
-    sfixed32_repeated: self::_pinternal::field_type::RepeatedNumericalField::<
+    sfixed32_repeated: self::_pinternal::RepeatedNumericalField::<
         i32,
         self::_pinternal::tags::SFixed32,
     >,
-    sfixed64_required: self::_pinternal::field_type::OptionalNumericalField::<
+    sfixed64_required: self::_pinternal::OptionalNumericalField::<
         i64,
         self::_pinternal::tags::SFixed64,
         26usize,
     >,
-    sfixed64_optional: self::_pinternal::field_type::OptionalNumericalField::<
+    sfixed64_optional: self::_pinternal::OptionalNumericalField::<
         i64,
         self::_pinternal::tags::SFixed64,
         27usize,
     >,
-    sfixed64_repeated: self::_pinternal::field_type::RepeatedNumericalField::<
+    sfixed64_repeated: self::_pinternal::RepeatedNumericalField::<
         i64,
         self::_pinternal::tags::SFixed64,
     >,
-    f64_required: self::_pinternal::field_type::OptionalNumericalField::<
+    f64_required: self::_pinternal::OptionalNumericalField::<
         f64,
         self::_pinternal::tags::Double,
         28usize,
     >,
-    f64_optional: self::_pinternal::field_type::OptionalNumericalField::<
+    f64_optional: self::_pinternal::OptionalNumericalField::<
         f64,
         self::_pinternal::tags::Double,
         29usize,
     >,
-    f64_repeated: self::_pinternal::field_type::RepeatedNumericalField::<
+    f64_repeated: self::_pinternal::RepeatedNumericalField::<
         f64,
         self::_pinternal::tags::Double,
     >,
-    _bitfield: self::_pinternal::bitvec::BitArray<1usize>,
+    _bitfield: self::_pinternal::BitArray<1usize>,
 }
 impl Msg {
     pub fn i32_required(&self) -> i32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             0usize,
@@ -248,16 +248,16 @@ impl Msg {
         )
     }
     pub fn i32_required_opt(&self) -> ::std::option::Option::<i32> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.i32_required, &self._bitfield)
     }
     pub fn i32_required_mut(&mut self) -> &mut i32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             0usize,
@@ -268,8 +268,8 @@ impl Msg {
         )
     }
     pub fn has_i32_required(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             0usize,
@@ -277,16 +277,16 @@ impl Msg {
             .is_some()
     }
     pub fn clear_i32_required(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             0usize,
         > as NonRepeatedFieldType>::clear(&mut self.i32_required, &mut self._bitfield)
     }
     pub fn i32_optional(&self) -> i32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             1usize,
@@ -297,16 +297,16 @@ impl Msg {
         )
     }
     pub fn i32_optional_opt(&self) -> ::std::option::Option::<i32> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             1usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.i32_optional, &self._bitfield)
     }
     pub fn i32_optional_mut(&mut self) -> &mut i32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             1usize,
@@ -317,8 +317,8 @@ impl Msg {
         )
     }
     pub fn has_i32_optional(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             1usize,
@@ -326,23 +326,23 @@ impl Msg {
             .is_some()
     }
     pub fn clear_i32_optional(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             1usize,
         > as NonRepeatedFieldType>::clear(&mut self.i32_optional, &mut self._bitfield)
     }
     pub fn i32_repeated(&self) -> &[i32] {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
         > as RepeatedFieldType>::get_field(&self.i32_repeated, &self._bitfield)
     }
     pub fn i32_repeated_mut(&mut self) -> &mut ::std::vec::Vec::<i32> {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
         > as RepeatedFieldType>::get_field_mut(
@@ -351,15 +351,15 @@ impl Msg {
         )
     }
     pub fn clear_i32_repeated(&mut self) {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
         > as RepeatedFieldType>::clear(&mut self.i32_repeated, &mut self._bitfield)
     }
     pub fn float_required(&self) -> f32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             f32,
             self::_pinternal::tags::Float,
             2usize,
@@ -370,16 +370,16 @@ impl Msg {
         )
     }
     pub fn float_required_opt(&self) -> ::std::option::Option::<f32> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             f32,
             self::_pinternal::tags::Float,
             2usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.float_required, &self._bitfield)
     }
     pub fn float_required_mut(&mut self) -> &mut f32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             f32,
             self::_pinternal::tags::Float,
             2usize,
@@ -390,8 +390,8 @@ impl Msg {
         )
     }
     pub fn has_float_required(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             f32,
             self::_pinternal::tags::Float,
             2usize,
@@ -399,16 +399,16 @@ impl Msg {
             .is_some()
     }
     pub fn clear_float_required(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             f32,
             self::_pinternal::tags::Float,
             2usize,
         > as NonRepeatedFieldType>::clear(&mut self.float_required, &mut self._bitfield)
     }
     pub fn float_optional(&self) -> f32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             f32,
             self::_pinternal::tags::Float,
             3usize,
@@ -419,16 +419,16 @@ impl Msg {
         )
     }
     pub fn float_optional_opt(&self) -> ::std::option::Option::<f32> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             f32,
             self::_pinternal::tags::Float,
             3usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.float_optional, &self._bitfield)
     }
     pub fn float_optional_mut(&mut self) -> &mut f32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             f32,
             self::_pinternal::tags::Float,
             3usize,
@@ -439,8 +439,8 @@ impl Msg {
         )
     }
     pub fn has_float_optional(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             f32,
             self::_pinternal::tags::Float,
             3usize,
@@ -448,23 +448,23 @@ impl Msg {
             .is_some()
     }
     pub fn clear_float_optional(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             f32,
             self::_pinternal::tags::Float,
             3usize,
         > as NonRepeatedFieldType>::clear(&mut self.float_optional, &mut self._bitfield)
     }
     pub fn float_repeated(&self) -> &[f32] {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             f32,
             self::_pinternal::tags::Float,
         > as RepeatedFieldType>::get_field(&self.float_repeated, &self._bitfield)
     }
     pub fn float_repeated_mut(&mut self) -> &mut ::std::vec::Vec::<f32> {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             f32,
             self::_pinternal::tags::Float,
         > as RepeatedFieldType>::get_field_mut(
@@ -473,15 +473,15 @@ impl Msg {
         )
     }
     pub fn clear_float_repeated(&mut self) {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             f32,
             self::_pinternal::tags::Float,
         > as RepeatedFieldType>::clear(&mut self.float_repeated, &mut self._bitfield)
     }
     pub fn bytes_required(&self) -> &[u8] {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::vec::Vec<u8>,
             self::_pinternal::tags::Bytes,
             4usize,
@@ -492,16 +492,16 @@ impl Msg {
         )
     }
     pub fn bytes_required_opt(&self) -> ::std::option::Option::<&[u8]> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::vec::Vec<u8>,
             self::_pinternal::tags::Bytes,
             4usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.bytes_required, &self._bitfield)
     }
     pub fn bytes_required_mut(&mut self) -> &mut ::std::vec::Vec::<u8> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::vec::Vec<u8>,
             self::_pinternal::tags::Bytes,
             4usize,
@@ -512,8 +512,8 @@ impl Msg {
         )
     }
     pub fn has_bytes_required(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::vec::Vec<u8>,
             self::_pinternal::tags::Bytes,
             4usize,
@@ -521,16 +521,16 @@ impl Msg {
             .is_some()
     }
     pub fn clear_bytes_required(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::vec::Vec<u8>,
             self::_pinternal::tags::Bytes,
             4usize,
         > as NonRepeatedFieldType>::clear(&mut self.bytes_required, &mut self._bitfield)
     }
     pub fn bytes_optional(&self) -> &[u8] {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::vec::Vec<u8>,
             self::_pinternal::tags::Bytes,
             5usize,
@@ -541,16 +541,16 @@ impl Msg {
         )
     }
     pub fn bytes_optional_opt(&self) -> ::std::option::Option::<&[u8]> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::vec::Vec<u8>,
             self::_pinternal::tags::Bytes,
             5usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.bytes_optional, &self._bitfield)
     }
     pub fn bytes_optional_mut(&mut self) -> &mut ::std::vec::Vec::<u8> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::vec::Vec<u8>,
             self::_pinternal::tags::Bytes,
             5usize,
@@ -561,8 +561,8 @@ impl Msg {
         )
     }
     pub fn has_bytes_optional(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::vec::Vec<u8>,
             self::_pinternal::tags::Bytes,
             5usize,
@@ -570,8 +570,8 @@ impl Msg {
             .is_some()
     }
     pub fn clear_bytes_optional(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::vec::Vec<u8>,
             self::_pinternal::tags::Bytes,
             5usize,
@@ -582,15 +582,15 @@ impl Msg {
     ) -> &[impl ::std::ops::Deref::<
         Target = [u8],
     > + ::std::fmt::Debug + ::std::cmp::PartialEq] {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedUnsizedField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedUnsizedField::<
             ::std::vec::Vec<u8>,
             self::_pinternal::tags::Bytes,
         > as RepeatedFieldType>::get_field(&self.bytes_repeated, &self._bitfield)
     }
     pub fn bytes_repeated_mut(&mut self) -> &mut ::std::vec::Vec::<::std::vec::Vec<u8>> {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedUnsizedField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedUnsizedField::<
             ::std::vec::Vec<u8>,
             self::_pinternal::tags::Bytes,
         > as RepeatedFieldType>::get_field_mut(
@@ -599,15 +599,15 @@ impl Msg {
         )
     }
     pub fn clear_bytes_repeated(&mut self) {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedUnsizedField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedUnsizedField::<
             ::std::vec::Vec<u8>,
             self::_pinternal::tags::Bytes,
         > as RepeatedFieldType>::clear(&mut self.bytes_repeated, &mut self._bitfield)
     }
     pub fn string_required(&self) -> &str {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             6usize,
@@ -618,16 +618,16 @@ impl Msg {
         )
     }
     pub fn string_required_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             6usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.string_required, &self._bitfield)
     }
     pub fn string_required_mut(&mut self) -> &mut ::std::string::String {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             6usize,
@@ -638,8 +638,8 @@ impl Msg {
         )
     }
     pub fn has_string_required(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             6usize,
@@ -647,16 +647,16 @@ impl Msg {
             .is_some()
     }
     pub fn clear_string_required(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             6usize,
         > as NonRepeatedFieldType>::clear(&mut self.string_required, &mut self._bitfield)
     }
     pub fn string_optional(&self) -> &str {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             7usize,
@@ -667,16 +667,16 @@ impl Msg {
         )
     }
     pub fn string_optional_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             7usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.string_optional, &self._bitfield)
     }
     pub fn string_optional_mut(&mut self) -> &mut ::std::string::String {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             7usize,
@@ -687,8 +687,8 @@ impl Msg {
         )
     }
     pub fn has_string_optional(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             7usize,
@@ -696,8 +696,8 @@ impl Msg {
             .is_some()
     }
     pub fn clear_string_optional(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             7usize,
@@ -708,8 +708,8 @@ impl Msg {
     ) -> &[impl ::std::ops::Deref::<
         Target = str,
     > + ::std::fmt::Debug + ::std::cmp::PartialEq] {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedUnsizedField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
         > as RepeatedFieldType>::get_field(&self.string_repeated, &self._bitfield)
@@ -717,8 +717,8 @@ impl Msg {
     pub fn string_repeated_mut(
         &mut self,
     ) -> &mut ::std::vec::Vec::<::std::string::String> {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedUnsizedField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
         > as RepeatedFieldType>::get_field_mut(
@@ -727,15 +727,15 @@ impl Msg {
         )
     }
     pub fn clear_string_repeated(&mut self) {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedUnsizedField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
         > as RepeatedFieldType>::clear(&mut self.string_repeated, &mut self._bitfield)
     }
     pub fn enum_required(&self) -> self::_root::full_coverage2::Enum {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             self::_root::full_coverage2::Enum,
             self::_pinternal::tags::Enum2::<self::_root::full_coverage2::Enum>,
             8usize,
@@ -748,16 +748,16 @@ impl Msg {
     pub fn enum_required_opt(
         &self,
     ) -> ::std::option::Option::<self::_root::full_coverage2::Enum> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             self::_root::full_coverage2::Enum,
             self::_pinternal::tags::Enum2::<self::_root::full_coverage2::Enum>,
             8usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.enum_required, &self._bitfield)
     }
     pub fn enum_required_mut(&mut self) -> &mut self::_root::full_coverage2::Enum {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             self::_root::full_coverage2::Enum,
             self::_pinternal::tags::Enum2::<self::_root::full_coverage2::Enum>,
             8usize,
@@ -768,8 +768,8 @@ impl Msg {
         )
     }
     pub fn has_enum_required(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             self::_root::full_coverage2::Enum,
             self::_pinternal::tags::Enum2::<self::_root::full_coverage2::Enum>,
             8usize,
@@ -777,16 +777,16 @@ impl Msg {
             .is_some()
     }
     pub fn clear_enum_required(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             self::_root::full_coverage2::Enum,
             self::_pinternal::tags::Enum2::<self::_root::full_coverage2::Enum>,
             8usize,
         > as NonRepeatedFieldType>::clear(&mut self.enum_required, &mut self._bitfield)
     }
     pub fn enum_optional(&self) -> self::_root::full_coverage2::Enum {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             self::_root::full_coverage2::Enum,
             self::_pinternal::tags::Enum2::<self::_root::full_coverage2::Enum>,
             9usize,
@@ -799,16 +799,16 @@ impl Msg {
     pub fn enum_optional_opt(
         &self,
     ) -> ::std::option::Option::<self::_root::full_coverage2::Enum> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             self::_root::full_coverage2::Enum,
             self::_pinternal::tags::Enum2::<self::_root::full_coverage2::Enum>,
             9usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.enum_optional, &self._bitfield)
     }
     pub fn enum_optional_mut(&mut self) -> &mut self::_root::full_coverage2::Enum {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             self::_root::full_coverage2::Enum,
             self::_pinternal::tags::Enum2::<self::_root::full_coverage2::Enum>,
             9usize,
@@ -819,8 +819,8 @@ impl Msg {
         )
     }
     pub fn has_enum_optional(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             self::_root::full_coverage2::Enum,
             self::_pinternal::tags::Enum2::<self::_root::full_coverage2::Enum>,
             9usize,
@@ -828,16 +828,16 @@ impl Msg {
             .is_some()
     }
     pub fn clear_enum_optional(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             self::_root::full_coverage2::Enum,
             self::_pinternal::tags::Enum2::<self::_root::full_coverage2::Enum>,
             9usize,
         > as NonRepeatedFieldType>::clear(&mut self.enum_optional, &mut self._bitfield)
     }
     pub fn enum_repeated(&self) -> &[self::_root::full_coverage2::Enum] {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             self::_root::full_coverage2::Enum,
             self::_pinternal::tags::Enum2::<self::_root::full_coverage2::Enum>,
         > as RepeatedFieldType>::get_field(&self.enum_repeated, &self._bitfield)
@@ -845,8 +845,8 @@ impl Msg {
     pub fn enum_repeated_mut(
         &mut self,
     ) -> &mut ::std::vec::Vec::<self::_root::full_coverage2::Enum> {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             self::_root::full_coverage2::Enum,
             self::_pinternal::tags::Enum2::<self::_root::full_coverage2::Enum>,
         > as RepeatedFieldType>::get_field_mut(
@@ -855,8 +855,8 @@ impl Msg {
         )
     }
     pub fn clear_enum_repeated(&mut self) {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             self::_root::full_coverage2::Enum,
             self::_pinternal::tags::Enum2::<self::_root::full_coverage2::Enum>,
         > as RepeatedFieldType>::clear(&mut self.enum_repeated, &mut self._bitfield)
@@ -864,8 +864,8 @@ impl Msg {
     pub fn submsg_required(
         &self,
     ) -> ::std::option::Option::<&self::_root::full_coverage2::msg::Submsg> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::full_coverage2::msg::Submsg,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.submsg_required,
@@ -876,16 +876,16 @@ impl Msg {
     pub fn submsg_required_opt(
         &self,
     ) -> ::std::option::Option::<&self::_root::full_coverage2::msg::Submsg> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::full_coverage2::msg::Submsg,
         > as NonRepeatedFieldType>::get_field_opt(&self.submsg_required, &self._bitfield)
     }
     pub fn submsg_required_mut(
         &mut self,
     ) -> &mut self::_root::full_coverage2::msg::Submsg {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::full_coverage2::msg::Submsg,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.submsg_required,
@@ -894,23 +894,23 @@ impl Msg {
         )
     }
     pub fn has_submsg_required(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::full_coverage2::msg::Submsg,
         > as NonRepeatedFieldType>::get_field_opt(&self.submsg_required, &self._bitfield)
             .is_some()
     }
     pub fn clear_submsg_required(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::full_coverage2::msg::Submsg,
         > as NonRepeatedFieldType>::clear(&mut self.submsg_required, &mut self._bitfield)
     }
     pub fn submsg_optional(
         &self,
     ) -> ::std::option::Option::<&self::_root::full_coverage2::msg::Submsg> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::full_coverage2::msg::Submsg,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.submsg_optional,
@@ -921,16 +921,16 @@ impl Msg {
     pub fn submsg_optional_opt(
         &self,
     ) -> ::std::option::Option::<&self::_root::full_coverage2::msg::Submsg> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::full_coverage2::msg::Submsg,
         > as NonRepeatedFieldType>::get_field_opt(&self.submsg_optional, &self._bitfield)
     }
     pub fn submsg_optional_mut(
         &mut self,
     ) -> &mut self::_root::full_coverage2::msg::Submsg {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::full_coverage2::msg::Submsg,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.submsg_optional,
@@ -939,29 +939,29 @@ impl Msg {
         )
     }
     pub fn has_submsg_optional(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::full_coverage2::msg::Submsg,
         > as NonRepeatedFieldType>::get_field_opt(&self.submsg_optional, &self._bitfield)
             .is_some()
     }
     pub fn clear_submsg_optional(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::full_coverage2::msg::Submsg,
         > as NonRepeatedFieldType>::clear(&mut self.submsg_optional, &mut self._bitfield)
     }
     pub fn submsg_repeated(&self) -> &[self::_root::full_coverage2::msg::Submsg] {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::full_coverage2::msg::Submsg,
         > as RepeatedFieldType>::get_field(&self.submsg_repeated, &self._bitfield)
     }
     pub fn submsg_repeated_mut(
         &mut self,
     ) -> &mut ::std::vec::Vec::<self::_root::full_coverage2::msg::Submsg> {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::full_coverage2::msg::Submsg,
         > as RepeatedFieldType>::get_field_mut(
             &mut self.submsg_repeated,
@@ -969,14 +969,14 @@ impl Msg {
         )
     }
     pub fn clear_submsg_repeated(&mut self) {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::full_coverage2::msg::Submsg,
         > as RepeatedFieldType>::clear(&mut self.submsg_repeated, &mut self._bitfield)
     }
     pub fn i64_required(&self) -> i64 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i64,
             self::_pinternal::tags::Int64,
             10usize,
@@ -987,16 +987,16 @@ impl Msg {
         )
     }
     pub fn i64_required_opt(&self) -> ::std::option::Option::<i64> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i64,
             self::_pinternal::tags::Int64,
             10usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.i64_required, &self._bitfield)
     }
     pub fn i64_required_mut(&mut self) -> &mut i64 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i64,
             self::_pinternal::tags::Int64,
             10usize,
@@ -1007,8 +1007,8 @@ impl Msg {
         )
     }
     pub fn has_i64_required(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i64,
             self::_pinternal::tags::Int64,
             10usize,
@@ -1016,16 +1016,16 @@ impl Msg {
             .is_some()
     }
     pub fn clear_i64_required(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i64,
             self::_pinternal::tags::Int64,
             10usize,
         > as NonRepeatedFieldType>::clear(&mut self.i64_required, &mut self._bitfield)
     }
     pub fn i64_optional(&self) -> i64 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i64,
             self::_pinternal::tags::Int64,
             11usize,
@@ -1036,16 +1036,16 @@ impl Msg {
         )
     }
     pub fn i64_optional_opt(&self) -> ::std::option::Option::<i64> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i64,
             self::_pinternal::tags::Int64,
             11usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.i64_optional, &self._bitfield)
     }
     pub fn i64_optional_mut(&mut self) -> &mut i64 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i64,
             self::_pinternal::tags::Int64,
             11usize,
@@ -1056,8 +1056,8 @@ impl Msg {
         )
     }
     pub fn has_i64_optional(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i64,
             self::_pinternal::tags::Int64,
             11usize,
@@ -1065,23 +1065,23 @@ impl Msg {
             .is_some()
     }
     pub fn clear_i64_optional(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i64,
             self::_pinternal::tags::Int64,
             11usize,
         > as NonRepeatedFieldType>::clear(&mut self.i64_optional, &mut self._bitfield)
     }
     pub fn i64_repeated(&self) -> &[i64] {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             i64,
             self::_pinternal::tags::Int64,
         > as RepeatedFieldType>::get_field(&self.i64_repeated, &self._bitfield)
     }
     pub fn i64_repeated_mut(&mut self) -> &mut ::std::vec::Vec::<i64> {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             i64,
             self::_pinternal::tags::Int64,
         > as RepeatedFieldType>::get_field_mut(
@@ -1090,15 +1090,15 @@ impl Msg {
         )
     }
     pub fn clear_i64_repeated(&mut self) {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             i64,
             self::_pinternal::tags::Int64,
         > as RepeatedFieldType>::clear(&mut self.i64_repeated, &mut self._bitfield)
     }
     pub fn u32_required(&self) -> u32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             u32,
             self::_pinternal::tags::UInt32,
             12usize,
@@ -1109,16 +1109,16 @@ impl Msg {
         )
     }
     pub fn u32_required_opt(&self) -> ::std::option::Option::<u32> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             u32,
             self::_pinternal::tags::UInt32,
             12usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.u32_required, &self._bitfield)
     }
     pub fn u32_required_mut(&mut self) -> &mut u32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             u32,
             self::_pinternal::tags::UInt32,
             12usize,
@@ -1129,8 +1129,8 @@ impl Msg {
         )
     }
     pub fn has_u32_required(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             u32,
             self::_pinternal::tags::UInt32,
             12usize,
@@ -1138,16 +1138,16 @@ impl Msg {
             .is_some()
     }
     pub fn clear_u32_required(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             u32,
             self::_pinternal::tags::UInt32,
             12usize,
         > as NonRepeatedFieldType>::clear(&mut self.u32_required, &mut self._bitfield)
     }
     pub fn u32_optional(&self) -> u32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             u32,
             self::_pinternal::tags::UInt32,
             13usize,
@@ -1158,16 +1158,16 @@ impl Msg {
         )
     }
     pub fn u32_optional_opt(&self) -> ::std::option::Option::<u32> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             u32,
             self::_pinternal::tags::UInt32,
             13usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.u32_optional, &self._bitfield)
     }
     pub fn u32_optional_mut(&mut self) -> &mut u32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             u32,
             self::_pinternal::tags::UInt32,
             13usize,
@@ -1178,8 +1178,8 @@ impl Msg {
         )
     }
     pub fn has_u32_optional(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             u32,
             self::_pinternal::tags::UInt32,
             13usize,
@@ -1187,23 +1187,23 @@ impl Msg {
             .is_some()
     }
     pub fn clear_u32_optional(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             u32,
             self::_pinternal::tags::UInt32,
             13usize,
         > as NonRepeatedFieldType>::clear(&mut self.u32_optional, &mut self._bitfield)
     }
     pub fn u32_repeated(&self) -> &[u32] {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             u32,
             self::_pinternal::tags::UInt32,
         > as RepeatedFieldType>::get_field(&self.u32_repeated, &self._bitfield)
     }
     pub fn u32_repeated_mut(&mut self) -> &mut ::std::vec::Vec::<u32> {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             u32,
             self::_pinternal::tags::UInt32,
         > as RepeatedFieldType>::get_field_mut(
@@ -1212,15 +1212,15 @@ impl Msg {
         )
     }
     pub fn clear_u32_repeated(&mut self) {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             u32,
             self::_pinternal::tags::UInt32,
         > as RepeatedFieldType>::clear(&mut self.u32_repeated, &mut self._bitfield)
     }
     pub fn u64_required(&self) -> u64 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             u64,
             self::_pinternal::tags::UInt64,
             14usize,
@@ -1231,16 +1231,16 @@ impl Msg {
         )
     }
     pub fn u64_required_opt(&self) -> ::std::option::Option::<u64> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             u64,
             self::_pinternal::tags::UInt64,
             14usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.u64_required, &self._bitfield)
     }
     pub fn u64_required_mut(&mut self) -> &mut u64 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             u64,
             self::_pinternal::tags::UInt64,
             14usize,
@@ -1251,8 +1251,8 @@ impl Msg {
         )
     }
     pub fn has_u64_required(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             u64,
             self::_pinternal::tags::UInt64,
             14usize,
@@ -1260,16 +1260,16 @@ impl Msg {
             .is_some()
     }
     pub fn clear_u64_required(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             u64,
             self::_pinternal::tags::UInt64,
             14usize,
         > as NonRepeatedFieldType>::clear(&mut self.u64_required, &mut self._bitfield)
     }
     pub fn u64_optional(&self) -> u64 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             u64,
             self::_pinternal::tags::UInt64,
             15usize,
@@ -1280,16 +1280,16 @@ impl Msg {
         )
     }
     pub fn u64_optional_opt(&self) -> ::std::option::Option::<u64> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             u64,
             self::_pinternal::tags::UInt64,
             15usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.u64_optional, &self._bitfield)
     }
     pub fn u64_optional_mut(&mut self) -> &mut u64 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             u64,
             self::_pinternal::tags::UInt64,
             15usize,
@@ -1300,8 +1300,8 @@ impl Msg {
         )
     }
     pub fn has_u64_optional(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             u64,
             self::_pinternal::tags::UInt64,
             15usize,
@@ -1309,23 +1309,23 @@ impl Msg {
             .is_some()
     }
     pub fn clear_u64_optional(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             u64,
             self::_pinternal::tags::UInt64,
             15usize,
         > as NonRepeatedFieldType>::clear(&mut self.u64_optional, &mut self._bitfield)
     }
     pub fn u64_repeated(&self) -> &[u64] {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             u64,
             self::_pinternal::tags::UInt64,
         > as RepeatedFieldType>::get_field(&self.u64_repeated, &self._bitfield)
     }
     pub fn u64_repeated_mut(&mut self) -> &mut ::std::vec::Vec::<u64> {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             u64,
             self::_pinternal::tags::UInt64,
         > as RepeatedFieldType>::get_field_mut(
@@ -1334,15 +1334,15 @@ impl Msg {
         )
     }
     pub fn clear_u64_repeated(&mut self) {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             u64,
             self::_pinternal::tags::UInt64,
         > as RepeatedFieldType>::clear(&mut self.u64_repeated, &mut self._bitfield)
     }
     pub fn s32_required(&self) -> i32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::SInt32,
             16usize,
@@ -1353,16 +1353,16 @@ impl Msg {
         )
     }
     pub fn s32_required_opt(&self) -> ::std::option::Option::<i32> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::SInt32,
             16usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.s32_required, &self._bitfield)
     }
     pub fn s32_required_mut(&mut self) -> &mut i32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::SInt32,
             16usize,
@@ -1373,8 +1373,8 @@ impl Msg {
         )
     }
     pub fn has_s32_required(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::SInt32,
             16usize,
@@ -1382,16 +1382,16 @@ impl Msg {
             .is_some()
     }
     pub fn clear_s32_required(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::SInt32,
             16usize,
         > as NonRepeatedFieldType>::clear(&mut self.s32_required, &mut self._bitfield)
     }
     pub fn s32_optional(&self) -> i32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::SInt32,
             17usize,
@@ -1402,16 +1402,16 @@ impl Msg {
         )
     }
     pub fn s32_optional_opt(&self) -> ::std::option::Option::<i32> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::SInt32,
             17usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.s32_optional, &self._bitfield)
     }
     pub fn s32_optional_mut(&mut self) -> &mut i32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::SInt32,
             17usize,
@@ -1422,8 +1422,8 @@ impl Msg {
         )
     }
     pub fn has_s32_optional(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::SInt32,
             17usize,
@@ -1431,23 +1431,23 @@ impl Msg {
             .is_some()
     }
     pub fn clear_s32_optional(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::SInt32,
             17usize,
         > as NonRepeatedFieldType>::clear(&mut self.s32_optional, &mut self._bitfield)
     }
     pub fn s32_repeated(&self) -> &[i32] {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             i32,
             self::_pinternal::tags::SInt32,
         > as RepeatedFieldType>::get_field(&self.s32_repeated, &self._bitfield)
     }
     pub fn s32_repeated_mut(&mut self) -> &mut ::std::vec::Vec::<i32> {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             i32,
             self::_pinternal::tags::SInt32,
         > as RepeatedFieldType>::get_field_mut(
@@ -1456,15 +1456,15 @@ impl Msg {
         )
     }
     pub fn clear_s32_repeated(&mut self) {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             i32,
             self::_pinternal::tags::SInt32,
         > as RepeatedFieldType>::clear(&mut self.s32_repeated, &mut self._bitfield)
     }
     pub fn s64_required(&self) -> i64 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i64,
             self::_pinternal::tags::SInt64,
             18usize,
@@ -1475,16 +1475,16 @@ impl Msg {
         )
     }
     pub fn s64_required_opt(&self) -> ::std::option::Option::<i64> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i64,
             self::_pinternal::tags::SInt64,
             18usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.s64_required, &self._bitfield)
     }
     pub fn s64_required_mut(&mut self) -> &mut i64 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i64,
             self::_pinternal::tags::SInt64,
             18usize,
@@ -1495,8 +1495,8 @@ impl Msg {
         )
     }
     pub fn has_s64_required(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i64,
             self::_pinternal::tags::SInt64,
             18usize,
@@ -1504,16 +1504,16 @@ impl Msg {
             .is_some()
     }
     pub fn clear_s64_required(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i64,
             self::_pinternal::tags::SInt64,
             18usize,
         > as NonRepeatedFieldType>::clear(&mut self.s64_required, &mut self._bitfield)
     }
     pub fn s64_optional(&self) -> i64 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i64,
             self::_pinternal::tags::SInt64,
             19usize,
@@ -1524,16 +1524,16 @@ impl Msg {
         )
     }
     pub fn s64_optional_opt(&self) -> ::std::option::Option::<i64> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i64,
             self::_pinternal::tags::SInt64,
             19usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.s64_optional, &self._bitfield)
     }
     pub fn s64_optional_mut(&mut self) -> &mut i64 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i64,
             self::_pinternal::tags::SInt64,
             19usize,
@@ -1544,8 +1544,8 @@ impl Msg {
         )
     }
     pub fn has_s64_optional(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i64,
             self::_pinternal::tags::SInt64,
             19usize,
@@ -1553,23 +1553,23 @@ impl Msg {
             .is_some()
     }
     pub fn clear_s64_optional(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i64,
             self::_pinternal::tags::SInt64,
             19usize,
         > as NonRepeatedFieldType>::clear(&mut self.s64_optional, &mut self._bitfield)
     }
     pub fn s64_repeated(&self) -> &[i64] {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             i64,
             self::_pinternal::tags::SInt64,
         > as RepeatedFieldType>::get_field(&self.s64_repeated, &self._bitfield)
     }
     pub fn s64_repeated_mut(&mut self) -> &mut ::std::vec::Vec::<i64> {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             i64,
             self::_pinternal::tags::SInt64,
         > as RepeatedFieldType>::get_field_mut(
@@ -1578,15 +1578,15 @@ impl Msg {
         )
     }
     pub fn clear_s64_repeated(&mut self) {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             i64,
             self::_pinternal::tags::SInt64,
         > as RepeatedFieldType>::clear(&mut self.s64_repeated, &mut self._bitfield)
     }
     pub fn fixed32_required(&self) -> u32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             u32,
             self::_pinternal::tags::Fixed32,
             20usize,
@@ -1597,8 +1597,8 @@ impl Msg {
         )
     }
     pub fn fixed32_required_opt(&self) -> ::std::option::Option::<u32> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             u32,
             self::_pinternal::tags::Fixed32,
             20usize,
@@ -1608,8 +1608,8 @@ impl Msg {
         )
     }
     pub fn fixed32_required_mut(&mut self) -> &mut u32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             u32,
             self::_pinternal::tags::Fixed32,
             20usize,
@@ -1620,8 +1620,8 @@ impl Msg {
         )
     }
     pub fn has_fixed32_required(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             u32,
             self::_pinternal::tags::Fixed32,
             20usize,
@@ -1632,8 +1632,8 @@ impl Msg {
             .is_some()
     }
     pub fn clear_fixed32_required(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             u32,
             self::_pinternal::tags::Fixed32,
             20usize,
@@ -1643,8 +1643,8 @@ impl Msg {
         )
     }
     pub fn fixed32_optional(&self) -> u32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             u32,
             self::_pinternal::tags::Fixed32,
             21usize,
@@ -1655,8 +1655,8 @@ impl Msg {
         )
     }
     pub fn fixed32_optional_opt(&self) -> ::std::option::Option::<u32> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             u32,
             self::_pinternal::tags::Fixed32,
             21usize,
@@ -1666,8 +1666,8 @@ impl Msg {
         )
     }
     pub fn fixed32_optional_mut(&mut self) -> &mut u32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             u32,
             self::_pinternal::tags::Fixed32,
             21usize,
@@ -1678,8 +1678,8 @@ impl Msg {
         )
     }
     pub fn has_fixed32_optional(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             u32,
             self::_pinternal::tags::Fixed32,
             21usize,
@@ -1690,8 +1690,8 @@ impl Msg {
             .is_some()
     }
     pub fn clear_fixed32_optional(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             u32,
             self::_pinternal::tags::Fixed32,
             21usize,
@@ -1701,15 +1701,15 @@ impl Msg {
         )
     }
     pub fn fixed32_repeated(&self) -> &[u32] {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             u32,
             self::_pinternal::tags::Fixed32,
         > as RepeatedFieldType>::get_field(&self.fixed32_repeated, &self._bitfield)
     }
     pub fn fixed32_repeated_mut(&mut self) -> &mut ::std::vec::Vec::<u32> {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             u32,
             self::_pinternal::tags::Fixed32,
         > as RepeatedFieldType>::get_field_mut(
@@ -1718,15 +1718,15 @@ impl Msg {
         )
     }
     pub fn clear_fixed32_repeated(&mut self) {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             u32,
             self::_pinternal::tags::Fixed32,
         > as RepeatedFieldType>::clear(&mut self.fixed32_repeated, &mut self._bitfield)
     }
     pub fn fixed64_required(&self) -> u64 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             u64,
             self::_pinternal::tags::Fixed64,
             22usize,
@@ -1737,8 +1737,8 @@ impl Msg {
         )
     }
     pub fn fixed64_required_opt(&self) -> ::std::option::Option::<u64> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             u64,
             self::_pinternal::tags::Fixed64,
             22usize,
@@ -1748,8 +1748,8 @@ impl Msg {
         )
     }
     pub fn fixed64_required_mut(&mut self) -> &mut u64 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             u64,
             self::_pinternal::tags::Fixed64,
             22usize,
@@ -1760,8 +1760,8 @@ impl Msg {
         )
     }
     pub fn has_fixed64_required(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             u64,
             self::_pinternal::tags::Fixed64,
             22usize,
@@ -1772,8 +1772,8 @@ impl Msg {
             .is_some()
     }
     pub fn clear_fixed64_required(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             u64,
             self::_pinternal::tags::Fixed64,
             22usize,
@@ -1783,8 +1783,8 @@ impl Msg {
         )
     }
     pub fn fixed64_optional(&self) -> u64 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             u64,
             self::_pinternal::tags::Fixed64,
             23usize,
@@ -1795,8 +1795,8 @@ impl Msg {
         )
     }
     pub fn fixed64_optional_opt(&self) -> ::std::option::Option::<u64> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             u64,
             self::_pinternal::tags::Fixed64,
             23usize,
@@ -1806,8 +1806,8 @@ impl Msg {
         )
     }
     pub fn fixed64_optional_mut(&mut self) -> &mut u64 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             u64,
             self::_pinternal::tags::Fixed64,
             23usize,
@@ -1818,8 +1818,8 @@ impl Msg {
         )
     }
     pub fn has_fixed64_optional(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             u64,
             self::_pinternal::tags::Fixed64,
             23usize,
@@ -1830,8 +1830,8 @@ impl Msg {
             .is_some()
     }
     pub fn clear_fixed64_optional(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             u64,
             self::_pinternal::tags::Fixed64,
             23usize,
@@ -1841,15 +1841,15 @@ impl Msg {
         )
     }
     pub fn fixed64_repeated(&self) -> &[u64] {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             u64,
             self::_pinternal::tags::Fixed64,
         > as RepeatedFieldType>::get_field(&self.fixed64_repeated, &self._bitfield)
     }
     pub fn fixed64_repeated_mut(&mut self) -> &mut ::std::vec::Vec::<u64> {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             u64,
             self::_pinternal::tags::Fixed64,
         > as RepeatedFieldType>::get_field_mut(
@@ -1858,15 +1858,15 @@ impl Msg {
         )
     }
     pub fn clear_fixed64_repeated(&mut self) {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             u64,
             self::_pinternal::tags::Fixed64,
         > as RepeatedFieldType>::clear(&mut self.fixed64_repeated, &mut self._bitfield)
     }
     pub fn sfixed32_required(&self) -> i32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::SFixed32,
             24usize,
@@ -1877,8 +1877,8 @@ impl Msg {
         )
     }
     pub fn sfixed32_required_opt(&self) -> ::std::option::Option::<i32> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::SFixed32,
             24usize,
@@ -1888,8 +1888,8 @@ impl Msg {
         )
     }
     pub fn sfixed32_required_mut(&mut self) -> &mut i32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::SFixed32,
             24usize,
@@ -1900,8 +1900,8 @@ impl Msg {
         )
     }
     pub fn has_sfixed32_required(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::SFixed32,
             24usize,
@@ -1912,8 +1912,8 @@ impl Msg {
             .is_some()
     }
     pub fn clear_sfixed32_required(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::SFixed32,
             24usize,
@@ -1923,8 +1923,8 @@ impl Msg {
         )
     }
     pub fn sfixed32_optional(&self) -> i32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::SFixed32,
             25usize,
@@ -1935,8 +1935,8 @@ impl Msg {
         )
     }
     pub fn sfixed32_optional_opt(&self) -> ::std::option::Option::<i32> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::SFixed32,
             25usize,
@@ -1946,8 +1946,8 @@ impl Msg {
         )
     }
     pub fn sfixed32_optional_mut(&mut self) -> &mut i32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::SFixed32,
             25usize,
@@ -1958,8 +1958,8 @@ impl Msg {
         )
     }
     pub fn has_sfixed32_optional(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::SFixed32,
             25usize,
@@ -1970,8 +1970,8 @@ impl Msg {
             .is_some()
     }
     pub fn clear_sfixed32_optional(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::SFixed32,
             25usize,
@@ -1981,15 +1981,15 @@ impl Msg {
         )
     }
     pub fn sfixed32_repeated(&self) -> &[i32] {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             i32,
             self::_pinternal::tags::SFixed32,
         > as RepeatedFieldType>::get_field(&self.sfixed32_repeated, &self._bitfield)
     }
     pub fn sfixed32_repeated_mut(&mut self) -> &mut ::std::vec::Vec::<i32> {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             i32,
             self::_pinternal::tags::SFixed32,
         > as RepeatedFieldType>::get_field_mut(
@@ -1998,15 +1998,15 @@ impl Msg {
         )
     }
     pub fn clear_sfixed32_repeated(&mut self) {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             i32,
             self::_pinternal::tags::SFixed32,
         > as RepeatedFieldType>::clear(&mut self.sfixed32_repeated, &mut self._bitfield)
     }
     pub fn sfixed64_required(&self) -> i64 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i64,
             self::_pinternal::tags::SFixed64,
             26usize,
@@ -2017,8 +2017,8 @@ impl Msg {
         )
     }
     pub fn sfixed64_required_opt(&self) -> ::std::option::Option::<i64> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i64,
             self::_pinternal::tags::SFixed64,
             26usize,
@@ -2028,8 +2028,8 @@ impl Msg {
         )
     }
     pub fn sfixed64_required_mut(&mut self) -> &mut i64 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i64,
             self::_pinternal::tags::SFixed64,
             26usize,
@@ -2040,8 +2040,8 @@ impl Msg {
         )
     }
     pub fn has_sfixed64_required(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i64,
             self::_pinternal::tags::SFixed64,
             26usize,
@@ -2052,8 +2052,8 @@ impl Msg {
             .is_some()
     }
     pub fn clear_sfixed64_required(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i64,
             self::_pinternal::tags::SFixed64,
             26usize,
@@ -2063,8 +2063,8 @@ impl Msg {
         )
     }
     pub fn sfixed64_optional(&self) -> i64 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i64,
             self::_pinternal::tags::SFixed64,
             27usize,
@@ -2075,8 +2075,8 @@ impl Msg {
         )
     }
     pub fn sfixed64_optional_opt(&self) -> ::std::option::Option::<i64> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i64,
             self::_pinternal::tags::SFixed64,
             27usize,
@@ -2086,8 +2086,8 @@ impl Msg {
         )
     }
     pub fn sfixed64_optional_mut(&mut self) -> &mut i64 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i64,
             self::_pinternal::tags::SFixed64,
             27usize,
@@ -2098,8 +2098,8 @@ impl Msg {
         )
     }
     pub fn has_sfixed64_optional(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i64,
             self::_pinternal::tags::SFixed64,
             27usize,
@@ -2110,8 +2110,8 @@ impl Msg {
             .is_some()
     }
     pub fn clear_sfixed64_optional(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i64,
             self::_pinternal::tags::SFixed64,
             27usize,
@@ -2121,15 +2121,15 @@ impl Msg {
         )
     }
     pub fn sfixed64_repeated(&self) -> &[i64] {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             i64,
             self::_pinternal::tags::SFixed64,
         > as RepeatedFieldType>::get_field(&self.sfixed64_repeated, &self._bitfield)
     }
     pub fn sfixed64_repeated_mut(&mut self) -> &mut ::std::vec::Vec::<i64> {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             i64,
             self::_pinternal::tags::SFixed64,
         > as RepeatedFieldType>::get_field_mut(
@@ -2138,15 +2138,15 @@ impl Msg {
         )
     }
     pub fn clear_sfixed64_repeated(&mut self) {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             i64,
             self::_pinternal::tags::SFixed64,
         > as RepeatedFieldType>::clear(&mut self.sfixed64_repeated, &mut self._bitfield)
     }
     pub fn f64_required(&self) -> f64 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             f64,
             self::_pinternal::tags::Double,
             28usize,
@@ -2157,16 +2157,16 @@ impl Msg {
         )
     }
     pub fn f64_required_opt(&self) -> ::std::option::Option::<f64> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             f64,
             self::_pinternal::tags::Double,
             28usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.f64_required, &self._bitfield)
     }
     pub fn f64_required_mut(&mut self) -> &mut f64 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             f64,
             self::_pinternal::tags::Double,
             28usize,
@@ -2177,8 +2177,8 @@ impl Msg {
         )
     }
     pub fn has_f64_required(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             f64,
             self::_pinternal::tags::Double,
             28usize,
@@ -2186,16 +2186,16 @@ impl Msg {
             .is_some()
     }
     pub fn clear_f64_required(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             f64,
             self::_pinternal::tags::Double,
             28usize,
         > as NonRepeatedFieldType>::clear(&mut self.f64_required, &mut self._bitfield)
     }
     pub fn f64_optional(&self) -> f64 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             f64,
             self::_pinternal::tags::Double,
             29usize,
@@ -2206,16 +2206,16 @@ impl Msg {
         )
     }
     pub fn f64_optional_opt(&self) -> ::std::option::Option::<f64> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             f64,
             self::_pinternal::tags::Double,
             29usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.f64_optional, &self._bitfield)
     }
     pub fn f64_optional_mut(&mut self) -> &mut f64 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             f64,
             self::_pinternal::tags::Double,
             29usize,
@@ -2226,8 +2226,8 @@ impl Msg {
         )
     }
     pub fn has_f64_optional(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             f64,
             self::_pinternal::tags::Double,
             29usize,
@@ -2235,23 +2235,23 @@ impl Msg {
             .is_some()
     }
     pub fn clear_f64_optional(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             f64,
             self::_pinternal::tags::Double,
             29usize,
         > as NonRepeatedFieldType>::clear(&mut self.f64_optional, &mut self._bitfield)
     }
     pub fn f64_repeated(&self) -> &[f64] {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             f64,
             self::_pinternal::tags::Double,
         > as RepeatedFieldType>::get_field(&self.f64_repeated, &self._bitfield)
     }
     pub fn f64_repeated_mut(&mut self) -> &mut ::std::vec::Vec::<f64> {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             f64,
             self::_pinternal::tags::Double,
         > as RepeatedFieldType>::get_field_mut(
@@ -2260,8 +2260,8 @@ impl Msg {
         )
     }
     pub fn clear_f64_repeated(&mut self) {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             f64,
             self::_pinternal::tags::Double,
         > as RepeatedFieldType>::clear(&mut self.f64_repeated, &mut self._bitfield)
@@ -2281,518 +2281,518 @@ impl self::_puroro::Message for Msg {
     ) -> self::_puroro::Result<()> {
         use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 1i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         i32,
                         self::_pinternal::tags::Int32,
                         0usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.i32_required,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 2i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         i32,
                         self::_pinternal::tags::Int32,
                         1usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.i32_optional,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 3i32 => {
-                    <self::_pinternal::field_type::RepeatedNumericalField::<
+                    <self::_pinternal::RepeatedNumericalField::<
                         i32,
                         self::_pinternal::tags::Int32,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.i32_repeated,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 11i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         f32,
                         self::_pinternal::tags::Float,
                         2usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.float_required,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 12i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         f32,
                         self::_pinternal::tags::Float,
                         3usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.float_optional,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 13i32 => {
-                    <self::_pinternal::field_type::RepeatedNumericalField::<
+                    <self::_pinternal::RepeatedNumericalField::<
                         f32,
                         self::_pinternal::tags::Float,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.float_repeated,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 21i32 => {
-                    <self::_pinternal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::OptionalUnsizedField::<
                         ::std::vec::Vec<u8>,
                         self::_pinternal::tags::Bytes,
                         4usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.bytes_required,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 22i32 => {
-                    <self::_pinternal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::OptionalUnsizedField::<
                         ::std::vec::Vec<u8>,
                         self::_pinternal::tags::Bytes,
                         5usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.bytes_optional,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 23i32 => {
-                    <self::_pinternal::field_type::RepeatedUnsizedField::<
+                    <self::_pinternal::RepeatedUnsizedField::<
                         ::std::vec::Vec<u8>,
                         self::_pinternal::tags::Bytes,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.bytes_repeated,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 31i32 => {
-                    <self::_pinternal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::OptionalUnsizedField::<
                         ::std::string::String,
                         self::_pinternal::tags::String,
                         6usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.string_required,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 32i32 => {
-                    <self::_pinternal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::OptionalUnsizedField::<
                         ::std::string::String,
                         self::_pinternal::tags::String,
                         7usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.string_optional,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 33i32 => {
-                    <self::_pinternal::field_type::RepeatedUnsizedField::<
+                    <self::_pinternal::RepeatedUnsizedField::<
                         ::std::string::String,
                         self::_pinternal::tags::String,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.string_repeated,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 41i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         self::_root::full_coverage2::Enum,
                         self::_pinternal::tags::Enum2::<
                             self::_root::full_coverage2::Enum,
                         >,
                         8usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.enum_required,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 42i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         self::_root::full_coverage2::Enum,
                         self::_pinternal::tags::Enum2::<
                             self::_root::full_coverage2::Enum,
                         >,
                         9usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.enum_optional,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 43i32 => {
-                    <self::_pinternal::field_type::RepeatedNumericalField::<
+                    <self::_pinternal::RepeatedNumericalField::<
                         self::_root::full_coverage2::Enum,
                         self::_pinternal::tags::Enum2::<
                             self::_root::full_coverage2::Enum,
                         >,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.enum_repeated,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 51i32 => {
-                    <self::_pinternal::field_type::SingularHeapMessageField::<
+                    <self::_pinternal::SingularHeapMessageField::<
                         self::_root::full_coverage2::msg::Submsg,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.submsg_required,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 52i32 => {
-                    <self::_pinternal::field_type::SingularHeapMessageField::<
+                    <self::_pinternal::SingularHeapMessageField::<
                         self::_root::full_coverage2::msg::Submsg,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.submsg_optional,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 53i32 => {
-                    <self::_pinternal::field_type::RepeatedMessageField::<
+                    <self::_pinternal::RepeatedMessageField::<
                         self::_root::full_coverage2::msg::Submsg,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.submsg_repeated,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 101i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         i64,
                         self::_pinternal::tags::Int64,
                         10usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.i64_required,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 102i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         i64,
                         self::_pinternal::tags::Int64,
                         11usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.i64_optional,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 103i32 => {
-                    <self::_pinternal::field_type::RepeatedNumericalField::<
+                    <self::_pinternal::RepeatedNumericalField::<
                         i64,
                         self::_pinternal::tags::Int64,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.i64_repeated,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 111i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         u32,
                         self::_pinternal::tags::UInt32,
                         12usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.u32_required,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 112i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         u32,
                         self::_pinternal::tags::UInt32,
                         13usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.u32_optional,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 113i32 => {
-                    <self::_pinternal::field_type::RepeatedNumericalField::<
+                    <self::_pinternal::RepeatedNumericalField::<
                         u32,
                         self::_pinternal::tags::UInt32,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.u32_repeated,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 121i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         u64,
                         self::_pinternal::tags::UInt64,
                         14usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.u64_required,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 122i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         u64,
                         self::_pinternal::tags::UInt64,
                         15usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.u64_optional,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 123i32 => {
-                    <self::_pinternal::field_type::RepeatedNumericalField::<
+                    <self::_pinternal::RepeatedNumericalField::<
                         u64,
                         self::_pinternal::tags::UInt64,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.u64_repeated,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 131i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         i32,
                         self::_pinternal::tags::SInt32,
                         16usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.s32_required,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 132i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         i32,
                         self::_pinternal::tags::SInt32,
                         17usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.s32_optional,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 133i32 => {
-                    <self::_pinternal::field_type::RepeatedNumericalField::<
+                    <self::_pinternal::RepeatedNumericalField::<
                         i32,
                         self::_pinternal::tags::SInt32,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.s32_repeated,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 141i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         i64,
                         self::_pinternal::tags::SInt64,
                         18usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.s64_required,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 142i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         i64,
                         self::_pinternal::tags::SInt64,
                         19usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.s64_optional,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 143i32 => {
-                    <self::_pinternal::field_type::RepeatedNumericalField::<
+                    <self::_pinternal::RepeatedNumericalField::<
                         i64,
                         self::_pinternal::tags::SInt64,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.s64_repeated,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 151i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         u32,
                         self::_pinternal::tags::Fixed32,
                         20usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.fixed32_required,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 152i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         u32,
                         self::_pinternal::tags::Fixed32,
                         21usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.fixed32_optional,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 153i32 => {
-                    <self::_pinternal::field_type::RepeatedNumericalField::<
+                    <self::_pinternal::RepeatedNumericalField::<
                         u32,
                         self::_pinternal::tags::Fixed32,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.fixed32_repeated,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 161i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         u64,
                         self::_pinternal::tags::Fixed64,
                         22usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.fixed64_required,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 162i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         u64,
                         self::_pinternal::tags::Fixed64,
                         23usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.fixed64_optional,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 163i32 => {
-                    <self::_pinternal::field_type::RepeatedNumericalField::<
+                    <self::_pinternal::RepeatedNumericalField::<
                         u64,
                         self::_pinternal::tags::Fixed64,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.fixed64_repeated,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 171i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         i32,
                         self::_pinternal::tags::SFixed32,
                         24usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.sfixed32_required,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 172i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         i32,
                         self::_pinternal::tags::SFixed32,
                         25usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.sfixed32_optional,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 173i32 => {
-                    <self::_pinternal::field_type::RepeatedNumericalField::<
+                    <self::_pinternal::RepeatedNumericalField::<
                         i32,
                         self::_pinternal::tags::SFixed32,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.sfixed32_repeated,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 181i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         i64,
                         self::_pinternal::tags::SFixed64,
                         26usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.sfixed64_required,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 182i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         i64,
                         self::_pinternal::tags::SFixed64,
                         27usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.sfixed64_optional,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 183i32 => {
-                    <self::_pinternal::field_type::RepeatedNumericalField::<
+                    <self::_pinternal::RepeatedNumericalField::<
                         i64,
                         self::_pinternal::tags::SFixed64,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.sfixed64_repeated,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 191i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         f64,
                         self::_pinternal::tags::Double,
                         28usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.f64_required,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 192i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         f64,
                         self::_pinternal::tags::Double,
                         29usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.f64_optional,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 193i32 => {
-                    <self::_pinternal::field_type::RepeatedNumericalField::<
+                    <self::_pinternal::RepeatedNumericalField::<
                         f64,
                         self::_pinternal::tags::Double,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.f64_repeated,
                         &mut self._bitfield,
                         field_data,
@@ -2809,461 +2809,461 @@ impl self::_puroro::Message for Msg {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::OneofUnion as _;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             0usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.i32_required,
             &self._bitfield,
             1i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             1usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.i32_optional,
             &self._bitfield,
             2i32,
             out,
         )?;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        <self::_pinternal::RepeatedNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.i32_repeated,
             &self._bitfield,
             3i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        <self::_pinternal::OptionalNumericalField::<
             f32,
             self::_pinternal::tags::Float,
             2usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.float_required,
             &self._bitfield,
             11i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        <self::_pinternal::OptionalNumericalField::<
             f32,
             self::_pinternal::tags::Float,
             3usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.float_optional,
             &self._bitfield,
             12i32,
             out,
         )?;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        <self::_pinternal::RepeatedNumericalField::<
             f32,
             self::_pinternal::tags::Float,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.float_repeated,
             &self._bitfield,
             13i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::vec::Vec<u8>,
             self::_pinternal::tags::Bytes,
             4usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.bytes_required,
             &self._bitfield,
             21i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::vec::Vec<u8>,
             self::_pinternal::tags::Bytes,
             5usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.bytes_optional,
             &self._bitfield,
             22i32,
             out,
         )?;
-        <self::_pinternal::field_type::RepeatedUnsizedField::<
+        <self::_pinternal::RepeatedUnsizedField::<
             ::std::vec::Vec<u8>,
             self::_pinternal::tags::Bytes,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.bytes_repeated,
             &self._bitfield,
             23i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             6usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.string_required,
             &self._bitfield,
             31i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             7usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.string_optional,
             &self._bitfield,
             32i32,
             out,
         )?;
-        <self::_pinternal::field_type::RepeatedUnsizedField::<
+        <self::_pinternal::RepeatedUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.string_repeated,
             &self._bitfield,
             33i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        <self::_pinternal::OptionalNumericalField::<
             self::_root::full_coverage2::Enum,
             self::_pinternal::tags::Enum2::<self::_root::full_coverage2::Enum>,
             8usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.enum_required,
             &self._bitfield,
             41i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        <self::_pinternal::OptionalNumericalField::<
             self::_root::full_coverage2::Enum,
             self::_pinternal::tags::Enum2::<self::_root::full_coverage2::Enum>,
             9usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.enum_optional,
             &self._bitfield,
             42i32,
             out,
         )?;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        <self::_pinternal::RepeatedNumericalField::<
             self::_root::full_coverage2::Enum,
             self::_pinternal::tags::Enum2::<self::_root::full_coverage2::Enum>,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.enum_repeated,
             &self._bitfield,
             43i32,
             out,
         )?;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::full_coverage2::msg::Submsg,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.submsg_required,
             &self._bitfield,
             51i32,
             out,
         )?;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::full_coverage2::msg::Submsg,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.submsg_optional,
             &self._bitfield,
             52i32,
             out,
         )?;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::full_coverage2::msg::Submsg,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.submsg_repeated,
             &self._bitfield,
             53i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        <self::_pinternal::OptionalNumericalField::<
             i64,
             self::_pinternal::tags::Int64,
             10usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.i64_required,
             &self._bitfield,
             101i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        <self::_pinternal::OptionalNumericalField::<
             i64,
             self::_pinternal::tags::Int64,
             11usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.i64_optional,
             &self._bitfield,
             102i32,
             out,
         )?;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        <self::_pinternal::RepeatedNumericalField::<
             i64,
             self::_pinternal::tags::Int64,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.i64_repeated,
             &self._bitfield,
             103i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        <self::_pinternal::OptionalNumericalField::<
             u32,
             self::_pinternal::tags::UInt32,
             12usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.u32_required,
             &self._bitfield,
             111i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        <self::_pinternal::OptionalNumericalField::<
             u32,
             self::_pinternal::tags::UInt32,
             13usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.u32_optional,
             &self._bitfield,
             112i32,
             out,
         )?;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        <self::_pinternal::RepeatedNumericalField::<
             u32,
             self::_pinternal::tags::UInt32,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.u32_repeated,
             &self._bitfield,
             113i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        <self::_pinternal::OptionalNumericalField::<
             u64,
             self::_pinternal::tags::UInt64,
             14usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.u64_required,
             &self._bitfield,
             121i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        <self::_pinternal::OptionalNumericalField::<
             u64,
             self::_pinternal::tags::UInt64,
             15usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.u64_optional,
             &self._bitfield,
             122i32,
             out,
         )?;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        <self::_pinternal::RepeatedNumericalField::<
             u64,
             self::_pinternal::tags::UInt64,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.u64_repeated,
             &self._bitfield,
             123i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::SInt32,
             16usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.s32_required,
             &self._bitfield,
             131i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::SInt32,
             17usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.s32_optional,
             &self._bitfield,
             132i32,
             out,
         )?;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        <self::_pinternal::RepeatedNumericalField::<
             i32,
             self::_pinternal::tags::SInt32,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.s32_repeated,
             &self._bitfield,
             133i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        <self::_pinternal::OptionalNumericalField::<
             i64,
             self::_pinternal::tags::SInt64,
             18usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.s64_required,
             &self._bitfield,
             141i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        <self::_pinternal::OptionalNumericalField::<
             i64,
             self::_pinternal::tags::SInt64,
             19usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.s64_optional,
             &self._bitfield,
             142i32,
             out,
         )?;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        <self::_pinternal::RepeatedNumericalField::<
             i64,
             self::_pinternal::tags::SInt64,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.s64_repeated,
             &self._bitfield,
             143i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        <self::_pinternal::OptionalNumericalField::<
             u32,
             self::_pinternal::tags::Fixed32,
             20usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.fixed32_required,
             &self._bitfield,
             151i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        <self::_pinternal::OptionalNumericalField::<
             u32,
             self::_pinternal::tags::Fixed32,
             21usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.fixed32_optional,
             &self._bitfield,
             152i32,
             out,
         )?;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        <self::_pinternal::RepeatedNumericalField::<
             u32,
             self::_pinternal::tags::Fixed32,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.fixed32_repeated,
             &self._bitfield,
             153i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        <self::_pinternal::OptionalNumericalField::<
             u64,
             self::_pinternal::tags::Fixed64,
             22usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.fixed64_required,
             &self._bitfield,
             161i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        <self::_pinternal::OptionalNumericalField::<
             u64,
             self::_pinternal::tags::Fixed64,
             23usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.fixed64_optional,
             &self._bitfield,
             162i32,
             out,
         )?;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        <self::_pinternal::RepeatedNumericalField::<
             u64,
             self::_pinternal::tags::Fixed64,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.fixed64_repeated,
             &self._bitfield,
             163i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::SFixed32,
             24usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.sfixed32_required,
             &self._bitfield,
             171i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::SFixed32,
             25usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.sfixed32_optional,
             &self._bitfield,
             172i32,
             out,
         )?;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        <self::_pinternal::RepeatedNumericalField::<
             i32,
             self::_pinternal::tags::SFixed32,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.sfixed32_repeated,
             &self._bitfield,
             173i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        <self::_pinternal::OptionalNumericalField::<
             i64,
             self::_pinternal::tags::SFixed64,
             26usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.sfixed64_required,
             &self._bitfield,
             181i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        <self::_pinternal::OptionalNumericalField::<
             i64,
             self::_pinternal::tags::SFixed64,
             27usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.sfixed64_optional,
             &self._bitfield,
             182i32,
             out,
         )?;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        <self::_pinternal::RepeatedNumericalField::<
             i64,
             self::_pinternal::tags::SFixed64,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.sfixed64_repeated,
             &self._bitfield,
             183i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        <self::_pinternal::OptionalNumericalField::<
             f64,
             self::_pinternal::tags::Double,
             28usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.f64_required,
             &self._bitfield,
             191i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        <self::_pinternal::OptionalNumericalField::<
             f64,
             self::_pinternal::tags::Double,
             29usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.f64_optional,
             &self._bitfield,
             192i32,
             out,
         )?;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        <self::_pinternal::RepeatedNumericalField::<
             f64,
             self::_pinternal::tags::Double,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.f64_repeated,
             &self._bitfield,
             193i32,
@@ -3275,222 +3275,222 @@ impl self::_puroro::Message for Msg {
 impl ::std::clone::Clone for Msg {
     fn clone(&self) -> Self {
         Self {
-            i32_required: <self::_pinternal::field_type::OptionalNumericalField::<
+            i32_required: <self::_pinternal::OptionalNumericalField::<
                 i32,
                 self::_pinternal::tags::Int32,
                 0usize,
             > as ::std::clone::Clone>::clone(&self.i32_required),
-            i32_optional: <self::_pinternal::field_type::OptionalNumericalField::<
+            i32_optional: <self::_pinternal::OptionalNumericalField::<
                 i32,
                 self::_pinternal::tags::Int32,
                 1usize,
             > as ::std::clone::Clone>::clone(&self.i32_optional),
-            i32_repeated: <self::_pinternal::field_type::RepeatedNumericalField::<
+            i32_repeated: <self::_pinternal::RepeatedNumericalField::<
                 i32,
                 self::_pinternal::tags::Int32,
             > as ::std::clone::Clone>::clone(&self.i32_repeated),
-            float_required: <self::_pinternal::field_type::OptionalNumericalField::<
+            float_required: <self::_pinternal::OptionalNumericalField::<
                 f32,
                 self::_pinternal::tags::Float,
                 2usize,
             > as ::std::clone::Clone>::clone(&self.float_required),
-            float_optional: <self::_pinternal::field_type::OptionalNumericalField::<
+            float_optional: <self::_pinternal::OptionalNumericalField::<
                 f32,
                 self::_pinternal::tags::Float,
                 3usize,
             > as ::std::clone::Clone>::clone(&self.float_optional),
-            float_repeated: <self::_pinternal::field_type::RepeatedNumericalField::<
+            float_repeated: <self::_pinternal::RepeatedNumericalField::<
                 f32,
                 self::_pinternal::tags::Float,
             > as ::std::clone::Clone>::clone(&self.float_repeated),
-            bytes_required: <self::_pinternal::field_type::OptionalUnsizedField::<
+            bytes_required: <self::_pinternal::OptionalUnsizedField::<
                 ::std::vec::Vec<u8>,
                 self::_pinternal::tags::Bytes,
                 4usize,
             > as ::std::clone::Clone>::clone(&self.bytes_required),
-            bytes_optional: <self::_pinternal::field_type::OptionalUnsizedField::<
+            bytes_optional: <self::_pinternal::OptionalUnsizedField::<
                 ::std::vec::Vec<u8>,
                 self::_pinternal::tags::Bytes,
                 5usize,
             > as ::std::clone::Clone>::clone(&self.bytes_optional),
-            bytes_repeated: <self::_pinternal::field_type::RepeatedUnsizedField::<
+            bytes_repeated: <self::_pinternal::RepeatedUnsizedField::<
                 ::std::vec::Vec<u8>,
                 self::_pinternal::tags::Bytes,
             > as ::std::clone::Clone>::clone(&self.bytes_repeated),
-            string_required: <self::_pinternal::field_type::OptionalUnsizedField::<
+            string_required: <self::_pinternal::OptionalUnsizedField::<
                 ::std::string::String,
                 self::_pinternal::tags::String,
                 6usize,
             > as ::std::clone::Clone>::clone(&self.string_required),
-            string_optional: <self::_pinternal::field_type::OptionalUnsizedField::<
+            string_optional: <self::_pinternal::OptionalUnsizedField::<
                 ::std::string::String,
                 self::_pinternal::tags::String,
                 7usize,
             > as ::std::clone::Clone>::clone(&self.string_optional),
-            string_repeated: <self::_pinternal::field_type::RepeatedUnsizedField::<
+            string_repeated: <self::_pinternal::RepeatedUnsizedField::<
                 ::std::string::String,
                 self::_pinternal::tags::String,
             > as ::std::clone::Clone>::clone(&self.string_repeated),
-            enum_required: <self::_pinternal::field_type::OptionalNumericalField::<
+            enum_required: <self::_pinternal::OptionalNumericalField::<
                 self::_root::full_coverage2::Enum,
                 self::_pinternal::tags::Enum2::<self::_root::full_coverage2::Enum>,
                 8usize,
             > as ::std::clone::Clone>::clone(&self.enum_required),
-            enum_optional: <self::_pinternal::field_type::OptionalNumericalField::<
+            enum_optional: <self::_pinternal::OptionalNumericalField::<
                 self::_root::full_coverage2::Enum,
                 self::_pinternal::tags::Enum2::<self::_root::full_coverage2::Enum>,
                 9usize,
             > as ::std::clone::Clone>::clone(&self.enum_optional),
-            enum_repeated: <self::_pinternal::field_type::RepeatedNumericalField::<
+            enum_repeated: <self::_pinternal::RepeatedNumericalField::<
                 self::_root::full_coverage2::Enum,
                 self::_pinternal::tags::Enum2::<self::_root::full_coverage2::Enum>,
             > as ::std::clone::Clone>::clone(&self.enum_repeated),
-            submsg_required: <self::_pinternal::field_type::SingularHeapMessageField::<
+            submsg_required: <self::_pinternal::SingularHeapMessageField::<
                 self::_root::full_coverage2::msg::Submsg,
             > as ::std::clone::Clone>::clone(&self.submsg_required),
-            submsg_optional: <self::_pinternal::field_type::SingularHeapMessageField::<
+            submsg_optional: <self::_pinternal::SingularHeapMessageField::<
                 self::_root::full_coverage2::msg::Submsg,
             > as ::std::clone::Clone>::clone(&self.submsg_optional),
-            submsg_repeated: <self::_pinternal::field_type::RepeatedMessageField::<
+            submsg_repeated: <self::_pinternal::RepeatedMessageField::<
                 self::_root::full_coverage2::msg::Submsg,
             > as ::std::clone::Clone>::clone(&self.submsg_repeated),
-            i64_required: <self::_pinternal::field_type::OptionalNumericalField::<
+            i64_required: <self::_pinternal::OptionalNumericalField::<
                 i64,
                 self::_pinternal::tags::Int64,
                 10usize,
             > as ::std::clone::Clone>::clone(&self.i64_required),
-            i64_optional: <self::_pinternal::field_type::OptionalNumericalField::<
+            i64_optional: <self::_pinternal::OptionalNumericalField::<
                 i64,
                 self::_pinternal::tags::Int64,
                 11usize,
             > as ::std::clone::Clone>::clone(&self.i64_optional),
-            i64_repeated: <self::_pinternal::field_type::RepeatedNumericalField::<
+            i64_repeated: <self::_pinternal::RepeatedNumericalField::<
                 i64,
                 self::_pinternal::tags::Int64,
             > as ::std::clone::Clone>::clone(&self.i64_repeated),
-            u32_required: <self::_pinternal::field_type::OptionalNumericalField::<
+            u32_required: <self::_pinternal::OptionalNumericalField::<
                 u32,
                 self::_pinternal::tags::UInt32,
                 12usize,
             > as ::std::clone::Clone>::clone(&self.u32_required),
-            u32_optional: <self::_pinternal::field_type::OptionalNumericalField::<
+            u32_optional: <self::_pinternal::OptionalNumericalField::<
                 u32,
                 self::_pinternal::tags::UInt32,
                 13usize,
             > as ::std::clone::Clone>::clone(&self.u32_optional),
-            u32_repeated: <self::_pinternal::field_type::RepeatedNumericalField::<
+            u32_repeated: <self::_pinternal::RepeatedNumericalField::<
                 u32,
                 self::_pinternal::tags::UInt32,
             > as ::std::clone::Clone>::clone(&self.u32_repeated),
-            u64_required: <self::_pinternal::field_type::OptionalNumericalField::<
+            u64_required: <self::_pinternal::OptionalNumericalField::<
                 u64,
                 self::_pinternal::tags::UInt64,
                 14usize,
             > as ::std::clone::Clone>::clone(&self.u64_required),
-            u64_optional: <self::_pinternal::field_type::OptionalNumericalField::<
+            u64_optional: <self::_pinternal::OptionalNumericalField::<
                 u64,
                 self::_pinternal::tags::UInt64,
                 15usize,
             > as ::std::clone::Clone>::clone(&self.u64_optional),
-            u64_repeated: <self::_pinternal::field_type::RepeatedNumericalField::<
+            u64_repeated: <self::_pinternal::RepeatedNumericalField::<
                 u64,
                 self::_pinternal::tags::UInt64,
             > as ::std::clone::Clone>::clone(&self.u64_repeated),
-            s32_required: <self::_pinternal::field_type::OptionalNumericalField::<
+            s32_required: <self::_pinternal::OptionalNumericalField::<
                 i32,
                 self::_pinternal::tags::SInt32,
                 16usize,
             > as ::std::clone::Clone>::clone(&self.s32_required),
-            s32_optional: <self::_pinternal::field_type::OptionalNumericalField::<
+            s32_optional: <self::_pinternal::OptionalNumericalField::<
                 i32,
                 self::_pinternal::tags::SInt32,
                 17usize,
             > as ::std::clone::Clone>::clone(&self.s32_optional),
-            s32_repeated: <self::_pinternal::field_type::RepeatedNumericalField::<
+            s32_repeated: <self::_pinternal::RepeatedNumericalField::<
                 i32,
                 self::_pinternal::tags::SInt32,
             > as ::std::clone::Clone>::clone(&self.s32_repeated),
-            s64_required: <self::_pinternal::field_type::OptionalNumericalField::<
+            s64_required: <self::_pinternal::OptionalNumericalField::<
                 i64,
                 self::_pinternal::tags::SInt64,
                 18usize,
             > as ::std::clone::Clone>::clone(&self.s64_required),
-            s64_optional: <self::_pinternal::field_type::OptionalNumericalField::<
+            s64_optional: <self::_pinternal::OptionalNumericalField::<
                 i64,
                 self::_pinternal::tags::SInt64,
                 19usize,
             > as ::std::clone::Clone>::clone(&self.s64_optional),
-            s64_repeated: <self::_pinternal::field_type::RepeatedNumericalField::<
+            s64_repeated: <self::_pinternal::RepeatedNumericalField::<
                 i64,
                 self::_pinternal::tags::SInt64,
             > as ::std::clone::Clone>::clone(&self.s64_repeated),
-            fixed32_required: <self::_pinternal::field_type::OptionalNumericalField::<
+            fixed32_required: <self::_pinternal::OptionalNumericalField::<
                 u32,
                 self::_pinternal::tags::Fixed32,
                 20usize,
             > as ::std::clone::Clone>::clone(&self.fixed32_required),
-            fixed32_optional: <self::_pinternal::field_type::OptionalNumericalField::<
+            fixed32_optional: <self::_pinternal::OptionalNumericalField::<
                 u32,
                 self::_pinternal::tags::Fixed32,
                 21usize,
             > as ::std::clone::Clone>::clone(&self.fixed32_optional),
-            fixed32_repeated: <self::_pinternal::field_type::RepeatedNumericalField::<
+            fixed32_repeated: <self::_pinternal::RepeatedNumericalField::<
                 u32,
                 self::_pinternal::tags::Fixed32,
             > as ::std::clone::Clone>::clone(&self.fixed32_repeated),
-            fixed64_required: <self::_pinternal::field_type::OptionalNumericalField::<
+            fixed64_required: <self::_pinternal::OptionalNumericalField::<
                 u64,
                 self::_pinternal::tags::Fixed64,
                 22usize,
             > as ::std::clone::Clone>::clone(&self.fixed64_required),
-            fixed64_optional: <self::_pinternal::field_type::OptionalNumericalField::<
+            fixed64_optional: <self::_pinternal::OptionalNumericalField::<
                 u64,
                 self::_pinternal::tags::Fixed64,
                 23usize,
             > as ::std::clone::Clone>::clone(&self.fixed64_optional),
-            fixed64_repeated: <self::_pinternal::field_type::RepeatedNumericalField::<
+            fixed64_repeated: <self::_pinternal::RepeatedNumericalField::<
                 u64,
                 self::_pinternal::tags::Fixed64,
             > as ::std::clone::Clone>::clone(&self.fixed64_repeated),
-            sfixed32_required: <self::_pinternal::field_type::OptionalNumericalField::<
+            sfixed32_required: <self::_pinternal::OptionalNumericalField::<
                 i32,
                 self::_pinternal::tags::SFixed32,
                 24usize,
             > as ::std::clone::Clone>::clone(&self.sfixed32_required),
-            sfixed32_optional: <self::_pinternal::field_type::OptionalNumericalField::<
+            sfixed32_optional: <self::_pinternal::OptionalNumericalField::<
                 i32,
                 self::_pinternal::tags::SFixed32,
                 25usize,
             > as ::std::clone::Clone>::clone(&self.sfixed32_optional),
-            sfixed32_repeated: <self::_pinternal::field_type::RepeatedNumericalField::<
+            sfixed32_repeated: <self::_pinternal::RepeatedNumericalField::<
                 i32,
                 self::_pinternal::tags::SFixed32,
             > as ::std::clone::Clone>::clone(&self.sfixed32_repeated),
-            sfixed64_required: <self::_pinternal::field_type::OptionalNumericalField::<
+            sfixed64_required: <self::_pinternal::OptionalNumericalField::<
                 i64,
                 self::_pinternal::tags::SFixed64,
                 26usize,
             > as ::std::clone::Clone>::clone(&self.sfixed64_required),
-            sfixed64_optional: <self::_pinternal::field_type::OptionalNumericalField::<
+            sfixed64_optional: <self::_pinternal::OptionalNumericalField::<
                 i64,
                 self::_pinternal::tags::SFixed64,
                 27usize,
             > as ::std::clone::Clone>::clone(&self.sfixed64_optional),
-            sfixed64_repeated: <self::_pinternal::field_type::RepeatedNumericalField::<
+            sfixed64_repeated: <self::_pinternal::RepeatedNumericalField::<
                 i64,
                 self::_pinternal::tags::SFixed64,
             > as ::std::clone::Clone>::clone(&self.sfixed64_repeated),
-            f64_required: <self::_pinternal::field_type::OptionalNumericalField::<
+            f64_required: <self::_pinternal::OptionalNumericalField::<
                 f64,
                 self::_pinternal::tags::Double,
                 28usize,
             > as ::std::clone::Clone>::clone(&self.f64_required),
-            f64_optional: <self::_pinternal::field_type::OptionalNumericalField::<
+            f64_optional: <self::_pinternal::OptionalNumericalField::<
                 f64,
                 self::_pinternal::tags::Double,
                 29usize,
             > as ::std::clone::Clone>::clone(&self.f64_optional),
-            f64_repeated: <self::_pinternal::field_type::RepeatedNumericalField::<
+            f64_repeated: <self::_pinternal::RepeatedNumericalField::<
                 f64,
                 self::_pinternal::tags::Double,
             > as ::std::clone::Clone>::clone(&self.f64_repeated),
@@ -3501,7 +3501,7 @@ impl ::std::clone::Clone for Msg {
 impl ::std::ops::Drop for Msg {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for Msg {
@@ -3564,7 +3564,7 @@ impl ::std::fmt::Debug for Msg {
 impl ::std::cmp::PartialEq for Msg {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         true && self.i32_required_opt() == rhs.i32_required_opt()
             && self.i32_optional_opt() == rhs.i32_optional_opt()
             && self.i32_repeated() == rhs.i32_repeated()

--- a/tests-pb/src/full_coverage2.rs
+++ b/tests-pb/src/full_coverage2.rs
@@ -1,241 +1,245 @@
-mod _puroro_root {
+mod _root {
     #[allow(unused)]
-    pub(crate) use super::super::_puroro_root::*;
+    pub(crate) use super::super::_root::*;
 }
 mod _puroro {
     #[allow(unused)]
     pub(crate) use ::puroro::*;
 }
+mod _pinternal {
+    #[allow(unused)]
+    pub(crate) use ::puroro::internal::*;
+}
 pub mod msg;
 #[derive(::std::default::Default)]
 pub struct Msg {
-    i32_required: self::_puroro::internal::field_type::OptionalNumericalField::<
+    i32_required: self::_pinternal::field_type::OptionalNumericalField::<
         i32,
-        self::_puroro::internal::tags::Int32,
+        self::_pinternal::tags::Int32,
         0usize,
     >,
-    i32_optional: self::_puroro::internal::field_type::OptionalNumericalField::<
+    i32_optional: self::_pinternal::field_type::OptionalNumericalField::<
         i32,
-        self::_puroro::internal::tags::Int32,
+        self::_pinternal::tags::Int32,
         1usize,
     >,
-    i32_repeated: self::_puroro::internal::field_type::RepeatedNumericalField::<
+    i32_repeated: self::_pinternal::field_type::RepeatedNumericalField::<
         i32,
-        self::_puroro::internal::tags::Int32,
+        self::_pinternal::tags::Int32,
     >,
-    float_required: self::_puroro::internal::field_type::OptionalNumericalField::<
+    float_required: self::_pinternal::field_type::OptionalNumericalField::<
         f32,
-        self::_puroro::internal::tags::Float,
+        self::_pinternal::tags::Float,
         2usize,
     >,
-    float_optional: self::_puroro::internal::field_type::OptionalNumericalField::<
+    float_optional: self::_pinternal::field_type::OptionalNumericalField::<
         f32,
-        self::_puroro::internal::tags::Float,
+        self::_pinternal::tags::Float,
         3usize,
     >,
-    float_repeated: self::_puroro::internal::field_type::RepeatedNumericalField::<
+    float_repeated: self::_pinternal::field_type::RepeatedNumericalField::<
         f32,
-        self::_puroro::internal::tags::Float,
+        self::_pinternal::tags::Float,
     >,
-    bytes_required: self::_puroro::internal::field_type::OptionalUnsizedField::<
+    bytes_required: self::_pinternal::field_type::OptionalUnsizedField::<
         ::std::vec::Vec<u8>,
-        self::_puroro::internal::tags::Bytes,
+        self::_pinternal::tags::Bytes,
         4usize,
     >,
-    bytes_optional: self::_puroro::internal::field_type::OptionalUnsizedField::<
+    bytes_optional: self::_pinternal::field_type::OptionalUnsizedField::<
         ::std::vec::Vec<u8>,
-        self::_puroro::internal::tags::Bytes,
+        self::_pinternal::tags::Bytes,
         5usize,
     >,
-    bytes_repeated: self::_puroro::internal::field_type::RepeatedUnsizedField::<
+    bytes_repeated: self::_pinternal::field_type::RepeatedUnsizedField::<
         ::std::vec::Vec<u8>,
-        self::_puroro::internal::tags::Bytes,
+        self::_pinternal::tags::Bytes,
     >,
-    string_required: self::_puroro::internal::field_type::OptionalUnsizedField::<
+    string_required: self::_pinternal::field_type::OptionalUnsizedField::<
         ::std::string::String,
-        self::_puroro::internal::tags::String,
+        self::_pinternal::tags::String,
         6usize,
     >,
-    string_optional: self::_puroro::internal::field_type::OptionalUnsizedField::<
+    string_optional: self::_pinternal::field_type::OptionalUnsizedField::<
         ::std::string::String,
-        self::_puroro::internal::tags::String,
+        self::_pinternal::tags::String,
         7usize,
     >,
-    string_repeated: self::_puroro::internal::field_type::RepeatedUnsizedField::<
+    string_repeated: self::_pinternal::field_type::RepeatedUnsizedField::<
         ::std::string::String,
-        self::_puroro::internal::tags::String,
+        self::_pinternal::tags::String,
     >,
-    enum_required: self::_puroro::internal::field_type::OptionalNumericalField::<
-        self::_puroro_root::full_coverage2::Enum,
-        self::_puroro::internal::tags::Enum2::<self::_puroro_root::full_coverage2::Enum>,
+    enum_required: self::_pinternal::field_type::OptionalNumericalField::<
+        self::_root::full_coverage2::Enum,
+        self::_pinternal::tags::Enum2::<self::_root::full_coverage2::Enum>,
         8usize,
     >,
-    enum_optional: self::_puroro::internal::field_type::OptionalNumericalField::<
-        self::_puroro_root::full_coverage2::Enum,
-        self::_puroro::internal::tags::Enum2::<self::_puroro_root::full_coverage2::Enum>,
+    enum_optional: self::_pinternal::field_type::OptionalNumericalField::<
+        self::_root::full_coverage2::Enum,
+        self::_pinternal::tags::Enum2::<self::_root::full_coverage2::Enum>,
         9usize,
     >,
-    enum_repeated: self::_puroro::internal::field_type::RepeatedNumericalField::<
-        self::_puroro_root::full_coverage2::Enum,
-        self::_puroro::internal::tags::Enum2::<self::_puroro_root::full_coverage2::Enum>,
+    enum_repeated: self::_pinternal::field_type::RepeatedNumericalField::<
+        self::_root::full_coverage2::Enum,
+        self::_pinternal::tags::Enum2::<self::_root::full_coverage2::Enum>,
     >,
-    submsg_required: self::_puroro::internal::field_type::SingularHeapMessageField::<
-        self::_puroro_root::full_coverage2::msg::Submsg,
+    submsg_required: self::_pinternal::field_type::SingularHeapMessageField::<
+        self::_root::full_coverage2::msg::Submsg,
     >,
-    submsg_optional: self::_puroro::internal::field_type::SingularHeapMessageField::<
-        self::_puroro_root::full_coverage2::msg::Submsg,
+    submsg_optional: self::_pinternal::field_type::SingularHeapMessageField::<
+        self::_root::full_coverage2::msg::Submsg,
     >,
-    submsg_repeated: self::_puroro::internal::field_type::RepeatedMessageField::<
-        self::_puroro_root::full_coverage2::msg::Submsg,
+    submsg_repeated: self::_pinternal::field_type::RepeatedMessageField::<
+        self::_root::full_coverage2::msg::Submsg,
     >,
-    i64_required: self::_puroro::internal::field_type::OptionalNumericalField::<
+    i64_required: self::_pinternal::field_type::OptionalNumericalField::<
         i64,
-        self::_puroro::internal::tags::Int64,
+        self::_pinternal::tags::Int64,
         10usize,
     >,
-    i64_optional: self::_puroro::internal::field_type::OptionalNumericalField::<
+    i64_optional: self::_pinternal::field_type::OptionalNumericalField::<
         i64,
-        self::_puroro::internal::tags::Int64,
+        self::_pinternal::tags::Int64,
         11usize,
     >,
-    i64_repeated: self::_puroro::internal::field_type::RepeatedNumericalField::<
+    i64_repeated: self::_pinternal::field_type::RepeatedNumericalField::<
         i64,
-        self::_puroro::internal::tags::Int64,
+        self::_pinternal::tags::Int64,
     >,
-    u32_required: self::_puroro::internal::field_type::OptionalNumericalField::<
+    u32_required: self::_pinternal::field_type::OptionalNumericalField::<
         u32,
-        self::_puroro::internal::tags::UInt32,
+        self::_pinternal::tags::UInt32,
         12usize,
     >,
-    u32_optional: self::_puroro::internal::field_type::OptionalNumericalField::<
+    u32_optional: self::_pinternal::field_type::OptionalNumericalField::<
         u32,
-        self::_puroro::internal::tags::UInt32,
+        self::_pinternal::tags::UInt32,
         13usize,
     >,
-    u32_repeated: self::_puroro::internal::field_type::RepeatedNumericalField::<
+    u32_repeated: self::_pinternal::field_type::RepeatedNumericalField::<
         u32,
-        self::_puroro::internal::tags::UInt32,
+        self::_pinternal::tags::UInt32,
     >,
-    u64_required: self::_puroro::internal::field_type::OptionalNumericalField::<
+    u64_required: self::_pinternal::field_type::OptionalNumericalField::<
         u64,
-        self::_puroro::internal::tags::UInt64,
+        self::_pinternal::tags::UInt64,
         14usize,
     >,
-    u64_optional: self::_puroro::internal::field_type::OptionalNumericalField::<
+    u64_optional: self::_pinternal::field_type::OptionalNumericalField::<
         u64,
-        self::_puroro::internal::tags::UInt64,
+        self::_pinternal::tags::UInt64,
         15usize,
     >,
-    u64_repeated: self::_puroro::internal::field_type::RepeatedNumericalField::<
+    u64_repeated: self::_pinternal::field_type::RepeatedNumericalField::<
         u64,
-        self::_puroro::internal::tags::UInt64,
+        self::_pinternal::tags::UInt64,
     >,
-    s32_required: self::_puroro::internal::field_type::OptionalNumericalField::<
+    s32_required: self::_pinternal::field_type::OptionalNumericalField::<
         i32,
-        self::_puroro::internal::tags::SInt32,
+        self::_pinternal::tags::SInt32,
         16usize,
     >,
-    s32_optional: self::_puroro::internal::field_type::OptionalNumericalField::<
+    s32_optional: self::_pinternal::field_type::OptionalNumericalField::<
         i32,
-        self::_puroro::internal::tags::SInt32,
+        self::_pinternal::tags::SInt32,
         17usize,
     >,
-    s32_repeated: self::_puroro::internal::field_type::RepeatedNumericalField::<
+    s32_repeated: self::_pinternal::field_type::RepeatedNumericalField::<
         i32,
-        self::_puroro::internal::tags::SInt32,
+        self::_pinternal::tags::SInt32,
     >,
-    s64_required: self::_puroro::internal::field_type::OptionalNumericalField::<
+    s64_required: self::_pinternal::field_type::OptionalNumericalField::<
         i64,
-        self::_puroro::internal::tags::SInt64,
+        self::_pinternal::tags::SInt64,
         18usize,
     >,
-    s64_optional: self::_puroro::internal::field_type::OptionalNumericalField::<
+    s64_optional: self::_pinternal::field_type::OptionalNumericalField::<
         i64,
-        self::_puroro::internal::tags::SInt64,
+        self::_pinternal::tags::SInt64,
         19usize,
     >,
-    s64_repeated: self::_puroro::internal::field_type::RepeatedNumericalField::<
+    s64_repeated: self::_pinternal::field_type::RepeatedNumericalField::<
         i64,
-        self::_puroro::internal::tags::SInt64,
+        self::_pinternal::tags::SInt64,
     >,
-    fixed32_required: self::_puroro::internal::field_type::OptionalNumericalField::<
+    fixed32_required: self::_pinternal::field_type::OptionalNumericalField::<
         u32,
-        self::_puroro::internal::tags::Fixed32,
+        self::_pinternal::tags::Fixed32,
         20usize,
     >,
-    fixed32_optional: self::_puroro::internal::field_type::OptionalNumericalField::<
+    fixed32_optional: self::_pinternal::field_type::OptionalNumericalField::<
         u32,
-        self::_puroro::internal::tags::Fixed32,
+        self::_pinternal::tags::Fixed32,
         21usize,
     >,
-    fixed32_repeated: self::_puroro::internal::field_type::RepeatedNumericalField::<
+    fixed32_repeated: self::_pinternal::field_type::RepeatedNumericalField::<
         u32,
-        self::_puroro::internal::tags::Fixed32,
+        self::_pinternal::tags::Fixed32,
     >,
-    fixed64_required: self::_puroro::internal::field_type::OptionalNumericalField::<
+    fixed64_required: self::_pinternal::field_type::OptionalNumericalField::<
         u64,
-        self::_puroro::internal::tags::Fixed64,
+        self::_pinternal::tags::Fixed64,
         22usize,
     >,
-    fixed64_optional: self::_puroro::internal::field_type::OptionalNumericalField::<
+    fixed64_optional: self::_pinternal::field_type::OptionalNumericalField::<
         u64,
-        self::_puroro::internal::tags::Fixed64,
+        self::_pinternal::tags::Fixed64,
         23usize,
     >,
-    fixed64_repeated: self::_puroro::internal::field_type::RepeatedNumericalField::<
+    fixed64_repeated: self::_pinternal::field_type::RepeatedNumericalField::<
         u64,
-        self::_puroro::internal::tags::Fixed64,
+        self::_pinternal::tags::Fixed64,
     >,
-    sfixed32_required: self::_puroro::internal::field_type::OptionalNumericalField::<
+    sfixed32_required: self::_pinternal::field_type::OptionalNumericalField::<
         i32,
-        self::_puroro::internal::tags::SFixed32,
+        self::_pinternal::tags::SFixed32,
         24usize,
     >,
-    sfixed32_optional: self::_puroro::internal::field_type::OptionalNumericalField::<
+    sfixed32_optional: self::_pinternal::field_type::OptionalNumericalField::<
         i32,
-        self::_puroro::internal::tags::SFixed32,
+        self::_pinternal::tags::SFixed32,
         25usize,
     >,
-    sfixed32_repeated: self::_puroro::internal::field_type::RepeatedNumericalField::<
+    sfixed32_repeated: self::_pinternal::field_type::RepeatedNumericalField::<
         i32,
-        self::_puroro::internal::tags::SFixed32,
+        self::_pinternal::tags::SFixed32,
     >,
-    sfixed64_required: self::_puroro::internal::field_type::OptionalNumericalField::<
+    sfixed64_required: self::_pinternal::field_type::OptionalNumericalField::<
         i64,
-        self::_puroro::internal::tags::SFixed64,
+        self::_pinternal::tags::SFixed64,
         26usize,
     >,
-    sfixed64_optional: self::_puroro::internal::field_type::OptionalNumericalField::<
+    sfixed64_optional: self::_pinternal::field_type::OptionalNumericalField::<
         i64,
-        self::_puroro::internal::tags::SFixed64,
+        self::_pinternal::tags::SFixed64,
         27usize,
     >,
-    sfixed64_repeated: self::_puroro::internal::field_type::RepeatedNumericalField::<
+    sfixed64_repeated: self::_pinternal::field_type::RepeatedNumericalField::<
         i64,
-        self::_puroro::internal::tags::SFixed64,
+        self::_pinternal::tags::SFixed64,
     >,
-    f64_required: self::_puroro::internal::field_type::OptionalNumericalField::<
+    f64_required: self::_pinternal::field_type::OptionalNumericalField::<
         f64,
-        self::_puroro::internal::tags::Double,
+        self::_pinternal::tags::Double,
         28usize,
     >,
-    f64_optional: self::_puroro::internal::field_type::OptionalNumericalField::<
+    f64_optional: self::_pinternal::field_type::OptionalNumericalField::<
         f64,
-        self::_puroro::internal::tags::Double,
+        self::_pinternal::tags::Double,
         29usize,
     >,
-    f64_repeated: self::_puroro::internal::field_type::RepeatedNumericalField::<
+    f64_repeated: self::_pinternal::field_type::RepeatedNumericalField::<
         f64,
-        self::_puroro::internal::tags::Double,
+        self::_pinternal::tags::Double,
     >,
-    _bitfield: self::_puroro::internal::bitvec::BitArray<1usize>,
+    _bitfield: self::_pinternal::bitvec::BitArray<1usize>,
 }
 impl Msg {
     pub fn i32_required(&self) -> i32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             0usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.i32_required,
@@ -244,18 +248,18 @@ impl Msg {
         )
     }
     pub fn i32_required_opt(&self) -> ::std::option::Option::<i32> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.i32_required, &self._bitfield)
     }
     pub fn i32_required_mut(&mut self) -> &mut i32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             0usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.i32_required,
@@ -264,27 +268,27 @@ impl Msg {
         )
     }
     pub fn has_i32_required(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.i32_required, &self._bitfield)
             .is_some()
     }
     pub fn clear_i32_required(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             0usize,
         > as NonRepeatedFieldType>::clear(&mut self.i32_required, &mut self._bitfield)
     }
     pub fn i32_optional(&self) -> i32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             1usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.i32_optional,
@@ -293,18 +297,18 @@ impl Msg {
         )
     }
     pub fn i32_optional_opt(&self) -> ::std::option::Option::<i32> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             1usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.i32_optional, &self._bitfield)
     }
     pub fn i32_optional_mut(&mut self) -> &mut i32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             1usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.i32_optional,
@@ -313,51 +317,51 @@ impl Msg {
         )
     }
     pub fn has_i32_optional(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             1usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.i32_optional, &self._bitfield)
             .is_some()
     }
     pub fn clear_i32_optional(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             1usize,
         > as NonRepeatedFieldType>::clear(&mut self.i32_optional, &mut self._bitfield)
     }
     pub fn i32_repeated(&self) -> &[i32] {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
         > as RepeatedFieldType>::get_field(&self.i32_repeated, &self._bitfield)
     }
     pub fn i32_repeated_mut(&mut self) -> &mut ::std::vec::Vec::<i32> {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
         > as RepeatedFieldType>::get_field_mut(
             &mut self.i32_repeated,
             &mut self._bitfield,
         )
     }
     pub fn clear_i32_repeated(&mut self) {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
         > as RepeatedFieldType>::clear(&mut self.i32_repeated, &mut self._bitfield)
     }
     pub fn float_required(&self) -> f32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             f32,
-            self::_puroro::internal::tags::Float,
+            self::_pinternal::tags::Float,
             2usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.float_required,
@@ -366,18 +370,18 @@ impl Msg {
         )
     }
     pub fn float_required_opt(&self) -> ::std::option::Option::<f32> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             f32,
-            self::_puroro::internal::tags::Float,
+            self::_pinternal::tags::Float,
             2usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.float_required, &self._bitfield)
     }
     pub fn float_required_mut(&mut self) -> &mut f32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             f32,
-            self::_puroro::internal::tags::Float,
+            self::_pinternal::tags::Float,
             2usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.float_required,
@@ -386,27 +390,27 @@ impl Msg {
         )
     }
     pub fn has_float_required(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             f32,
-            self::_puroro::internal::tags::Float,
+            self::_pinternal::tags::Float,
             2usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.float_required, &self._bitfield)
             .is_some()
     }
     pub fn clear_float_required(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             f32,
-            self::_puroro::internal::tags::Float,
+            self::_pinternal::tags::Float,
             2usize,
         > as NonRepeatedFieldType>::clear(&mut self.float_required, &mut self._bitfield)
     }
     pub fn float_optional(&self) -> f32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             f32,
-            self::_puroro::internal::tags::Float,
+            self::_pinternal::tags::Float,
             3usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.float_optional,
@@ -415,18 +419,18 @@ impl Msg {
         )
     }
     pub fn float_optional_opt(&self) -> ::std::option::Option::<f32> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             f32,
-            self::_puroro::internal::tags::Float,
+            self::_pinternal::tags::Float,
             3usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.float_optional, &self._bitfield)
     }
     pub fn float_optional_mut(&mut self) -> &mut f32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             f32,
-            self::_puroro::internal::tags::Float,
+            self::_pinternal::tags::Float,
             3usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.float_optional,
@@ -435,51 +439,51 @@ impl Msg {
         )
     }
     pub fn has_float_optional(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             f32,
-            self::_puroro::internal::tags::Float,
+            self::_pinternal::tags::Float,
             3usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.float_optional, &self._bitfield)
             .is_some()
     }
     pub fn clear_float_optional(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             f32,
-            self::_puroro::internal::tags::Float,
+            self::_pinternal::tags::Float,
             3usize,
         > as NonRepeatedFieldType>::clear(&mut self.float_optional, &mut self._bitfield)
     }
     pub fn float_repeated(&self) -> &[f32] {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             f32,
-            self::_puroro::internal::tags::Float,
+            self::_pinternal::tags::Float,
         > as RepeatedFieldType>::get_field(&self.float_repeated, &self._bitfield)
     }
     pub fn float_repeated_mut(&mut self) -> &mut ::std::vec::Vec::<f32> {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             f32,
-            self::_puroro::internal::tags::Float,
+            self::_pinternal::tags::Float,
         > as RepeatedFieldType>::get_field_mut(
             &mut self.float_repeated,
             &mut self._bitfield,
         )
     }
     pub fn clear_float_repeated(&mut self) {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             f32,
-            self::_puroro::internal::tags::Float,
+            self::_pinternal::tags::Float,
         > as RepeatedFieldType>::clear(&mut self.float_repeated, &mut self._bitfield)
     }
     pub fn bytes_required(&self) -> &[u8] {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::vec::Vec<u8>,
-            self::_puroro::internal::tags::Bytes,
+            self::_pinternal::tags::Bytes,
             4usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.bytes_required,
@@ -488,18 +492,18 @@ impl Msg {
         )
     }
     pub fn bytes_required_opt(&self) -> ::std::option::Option::<&[u8]> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::vec::Vec<u8>,
-            self::_puroro::internal::tags::Bytes,
+            self::_pinternal::tags::Bytes,
             4usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.bytes_required, &self._bitfield)
     }
     pub fn bytes_required_mut(&mut self) -> &mut ::std::vec::Vec::<u8> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::vec::Vec<u8>,
-            self::_puroro::internal::tags::Bytes,
+            self::_pinternal::tags::Bytes,
             4usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.bytes_required,
@@ -508,27 +512,27 @@ impl Msg {
         )
     }
     pub fn has_bytes_required(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::vec::Vec<u8>,
-            self::_puroro::internal::tags::Bytes,
+            self::_pinternal::tags::Bytes,
             4usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.bytes_required, &self._bitfield)
             .is_some()
     }
     pub fn clear_bytes_required(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::vec::Vec<u8>,
-            self::_puroro::internal::tags::Bytes,
+            self::_pinternal::tags::Bytes,
             4usize,
         > as NonRepeatedFieldType>::clear(&mut self.bytes_required, &mut self._bitfield)
     }
     pub fn bytes_optional(&self) -> &[u8] {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::vec::Vec<u8>,
-            self::_puroro::internal::tags::Bytes,
+            self::_pinternal::tags::Bytes,
             5usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.bytes_optional,
@@ -537,18 +541,18 @@ impl Msg {
         )
     }
     pub fn bytes_optional_opt(&self) -> ::std::option::Option::<&[u8]> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::vec::Vec<u8>,
-            self::_puroro::internal::tags::Bytes,
+            self::_pinternal::tags::Bytes,
             5usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.bytes_optional, &self._bitfield)
     }
     pub fn bytes_optional_mut(&mut self) -> &mut ::std::vec::Vec::<u8> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::vec::Vec<u8>,
-            self::_puroro::internal::tags::Bytes,
+            self::_pinternal::tags::Bytes,
             5usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.bytes_optional,
@@ -557,19 +561,19 @@ impl Msg {
         )
     }
     pub fn has_bytes_optional(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::vec::Vec<u8>,
-            self::_puroro::internal::tags::Bytes,
+            self::_pinternal::tags::Bytes,
             5usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.bytes_optional, &self._bitfield)
             .is_some()
     }
     pub fn clear_bytes_optional(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::vec::Vec<u8>,
-            self::_puroro::internal::tags::Bytes,
+            self::_pinternal::tags::Bytes,
             5usize,
         > as NonRepeatedFieldType>::clear(&mut self.bytes_optional, &mut self._bitfield)
     }
@@ -578,34 +582,34 @@ impl Msg {
     ) -> &[impl ::std::ops::Deref::<
         Target = [u8],
     > + ::std::fmt::Debug + ::std::cmp::PartialEq] {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedUnsizedField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedUnsizedField::<
             ::std::vec::Vec<u8>,
-            self::_puroro::internal::tags::Bytes,
+            self::_pinternal::tags::Bytes,
         > as RepeatedFieldType>::get_field(&self.bytes_repeated, &self._bitfield)
     }
     pub fn bytes_repeated_mut(&mut self) -> &mut ::std::vec::Vec::<::std::vec::Vec<u8>> {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedUnsizedField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedUnsizedField::<
             ::std::vec::Vec<u8>,
-            self::_puroro::internal::tags::Bytes,
+            self::_pinternal::tags::Bytes,
         > as RepeatedFieldType>::get_field_mut(
             &mut self.bytes_repeated,
             &mut self._bitfield,
         )
     }
     pub fn clear_bytes_repeated(&mut self) {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedUnsizedField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedUnsizedField::<
             ::std::vec::Vec<u8>,
-            self::_puroro::internal::tags::Bytes,
+            self::_pinternal::tags::Bytes,
         > as RepeatedFieldType>::clear(&mut self.bytes_repeated, &mut self._bitfield)
     }
     pub fn string_required(&self) -> &str {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             6usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.string_required,
@@ -614,18 +618,18 @@ impl Msg {
         )
     }
     pub fn string_required_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             6usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.string_required, &self._bitfield)
     }
     pub fn string_required_mut(&mut self) -> &mut ::std::string::String {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             6usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.string_required,
@@ -634,27 +638,27 @@ impl Msg {
         )
     }
     pub fn has_string_required(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             6usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.string_required, &self._bitfield)
             .is_some()
     }
     pub fn clear_string_required(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             6usize,
         > as NonRepeatedFieldType>::clear(&mut self.string_required, &mut self._bitfield)
     }
     pub fn string_optional(&self) -> &str {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             7usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.string_optional,
@@ -663,18 +667,18 @@ impl Msg {
         )
     }
     pub fn string_optional_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             7usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.string_optional, &self._bitfield)
     }
     pub fn string_optional_mut(&mut self) -> &mut ::std::string::String {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             7usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.string_optional,
@@ -683,19 +687,19 @@ impl Msg {
         )
     }
     pub fn has_string_optional(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             7usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.string_optional, &self._bitfield)
             .is_some()
     }
     pub fn clear_string_optional(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             7usize,
         > as NonRepeatedFieldType>::clear(&mut self.string_optional, &mut self._bitfield)
     }
@@ -704,38 +708,36 @@ impl Msg {
     ) -> &[impl ::std::ops::Deref::<
         Target = str,
     > + ::std::fmt::Debug + ::std::cmp::PartialEq] {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedUnsizedField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
         > as RepeatedFieldType>::get_field(&self.string_repeated, &self._bitfield)
     }
     pub fn string_repeated_mut(
         &mut self,
     ) -> &mut ::std::vec::Vec::<::std::string::String> {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedUnsizedField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
         > as RepeatedFieldType>::get_field_mut(
             &mut self.string_repeated,
             &mut self._bitfield,
         )
     }
     pub fn clear_string_repeated(&mut self) {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedUnsizedField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
         > as RepeatedFieldType>::clear(&mut self.string_repeated, &mut self._bitfield)
     }
-    pub fn enum_required(&self) -> self::_puroro_root::full_coverage2::Enum {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
-            self::_puroro_root::full_coverage2::Enum,
-            self::_puroro::internal::tags::Enum2::<
-                self::_puroro_root::full_coverage2::Enum,
-            >,
+    pub fn enum_required(&self) -> self::_root::full_coverage2::Enum {
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
+            self::_root::full_coverage2::Enum,
+            self::_pinternal::tags::Enum2::<self::_root::full_coverage2::Enum>,
             8usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.enum_required,
@@ -745,25 +747,19 @@ impl Msg {
     }
     pub fn enum_required_opt(
         &self,
-    ) -> ::std::option::Option::<self::_puroro_root::full_coverage2::Enum> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
-            self::_puroro_root::full_coverage2::Enum,
-            self::_puroro::internal::tags::Enum2::<
-                self::_puroro_root::full_coverage2::Enum,
-            >,
+    ) -> ::std::option::Option::<self::_root::full_coverage2::Enum> {
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
+            self::_root::full_coverage2::Enum,
+            self::_pinternal::tags::Enum2::<self::_root::full_coverage2::Enum>,
             8usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.enum_required, &self._bitfield)
     }
-    pub fn enum_required_mut(
-        &mut self,
-    ) -> &mut self::_puroro_root::full_coverage2::Enum {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
-            self::_puroro_root::full_coverage2::Enum,
-            self::_puroro::internal::tags::Enum2::<
-                self::_puroro_root::full_coverage2::Enum,
-            >,
+    pub fn enum_required_mut(&mut self) -> &mut self::_root::full_coverage2::Enum {
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
+            self::_root::full_coverage2::Enum,
+            self::_pinternal::tags::Enum2::<self::_root::full_coverage2::Enum>,
             8usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.enum_required,
@@ -772,33 +768,27 @@ impl Msg {
         )
     }
     pub fn has_enum_required(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
-            self::_puroro_root::full_coverage2::Enum,
-            self::_puroro::internal::tags::Enum2::<
-                self::_puroro_root::full_coverage2::Enum,
-            >,
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
+            self::_root::full_coverage2::Enum,
+            self::_pinternal::tags::Enum2::<self::_root::full_coverage2::Enum>,
             8usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.enum_required, &self._bitfield)
             .is_some()
     }
     pub fn clear_enum_required(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
-            self::_puroro_root::full_coverage2::Enum,
-            self::_puroro::internal::tags::Enum2::<
-                self::_puroro_root::full_coverage2::Enum,
-            >,
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
+            self::_root::full_coverage2::Enum,
+            self::_pinternal::tags::Enum2::<self::_root::full_coverage2::Enum>,
             8usize,
         > as NonRepeatedFieldType>::clear(&mut self.enum_required, &mut self._bitfield)
     }
-    pub fn enum_optional(&self) -> self::_puroro_root::full_coverage2::Enum {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
-            self::_puroro_root::full_coverage2::Enum,
-            self::_puroro::internal::tags::Enum2::<
-                self::_puroro_root::full_coverage2::Enum,
-            >,
+    pub fn enum_optional(&self) -> self::_root::full_coverage2::Enum {
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
+            self::_root::full_coverage2::Enum,
+            self::_pinternal::tags::Enum2::<self::_root::full_coverage2::Enum>,
             9usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.enum_optional,
@@ -808,25 +798,19 @@ impl Msg {
     }
     pub fn enum_optional_opt(
         &self,
-    ) -> ::std::option::Option::<self::_puroro_root::full_coverage2::Enum> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
-            self::_puroro_root::full_coverage2::Enum,
-            self::_puroro::internal::tags::Enum2::<
-                self::_puroro_root::full_coverage2::Enum,
-            >,
+    ) -> ::std::option::Option::<self::_root::full_coverage2::Enum> {
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
+            self::_root::full_coverage2::Enum,
+            self::_pinternal::tags::Enum2::<self::_root::full_coverage2::Enum>,
             9usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.enum_optional, &self._bitfield)
     }
-    pub fn enum_optional_mut(
-        &mut self,
-    ) -> &mut self::_puroro_root::full_coverage2::Enum {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
-            self::_puroro_root::full_coverage2::Enum,
-            self::_puroro::internal::tags::Enum2::<
-                self::_puroro_root::full_coverage2::Enum,
-            >,
+    pub fn enum_optional_mut(&mut self) -> &mut self::_root::full_coverage2::Enum {
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
+            self::_root::full_coverage2::Enum,
+            self::_pinternal::tags::Enum2::<self::_root::full_coverage2::Enum>,
             9usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.enum_optional,
@@ -835,64 +819,54 @@ impl Msg {
         )
     }
     pub fn has_enum_optional(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
-            self::_puroro_root::full_coverage2::Enum,
-            self::_puroro::internal::tags::Enum2::<
-                self::_puroro_root::full_coverage2::Enum,
-            >,
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
+            self::_root::full_coverage2::Enum,
+            self::_pinternal::tags::Enum2::<self::_root::full_coverage2::Enum>,
             9usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.enum_optional, &self._bitfield)
             .is_some()
     }
     pub fn clear_enum_optional(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
-            self::_puroro_root::full_coverage2::Enum,
-            self::_puroro::internal::tags::Enum2::<
-                self::_puroro_root::full_coverage2::Enum,
-            >,
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
+            self::_root::full_coverage2::Enum,
+            self::_pinternal::tags::Enum2::<self::_root::full_coverage2::Enum>,
             9usize,
         > as NonRepeatedFieldType>::clear(&mut self.enum_optional, &mut self._bitfield)
     }
-    pub fn enum_repeated(&self) -> &[self::_puroro_root::full_coverage2::Enum] {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
-            self::_puroro_root::full_coverage2::Enum,
-            self::_puroro::internal::tags::Enum2::<
-                self::_puroro_root::full_coverage2::Enum,
-            >,
+    pub fn enum_repeated(&self) -> &[self::_root::full_coverage2::Enum] {
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
+            self::_root::full_coverage2::Enum,
+            self::_pinternal::tags::Enum2::<self::_root::full_coverage2::Enum>,
         > as RepeatedFieldType>::get_field(&self.enum_repeated, &self._bitfield)
     }
     pub fn enum_repeated_mut(
         &mut self,
-    ) -> &mut ::std::vec::Vec::<self::_puroro_root::full_coverage2::Enum> {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
-            self::_puroro_root::full_coverage2::Enum,
-            self::_puroro::internal::tags::Enum2::<
-                self::_puroro_root::full_coverage2::Enum,
-            >,
+    ) -> &mut ::std::vec::Vec::<self::_root::full_coverage2::Enum> {
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
+            self::_root::full_coverage2::Enum,
+            self::_pinternal::tags::Enum2::<self::_root::full_coverage2::Enum>,
         > as RepeatedFieldType>::get_field_mut(
             &mut self.enum_repeated,
             &mut self._bitfield,
         )
     }
     pub fn clear_enum_repeated(&mut self) {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
-            self::_puroro_root::full_coverage2::Enum,
-            self::_puroro::internal::tags::Enum2::<
-                self::_puroro_root::full_coverage2::Enum,
-            >,
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
+            self::_root::full_coverage2::Enum,
+            self::_pinternal::tags::Enum2::<self::_root::full_coverage2::Enum>,
         > as RepeatedFieldType>::clear(&mut self.enum_repeated, &mut self._bitfield)
     }
     pub fn submsg_required(
         &self,
-    ) -> ::std::option::Option::<&self::_puroro_root::full_coverage2::msg::Submsg> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::full_coverage2::msg::Submsg,
+    ) -> ::std::option::Option::<&self::_root::full_coverage2::msg::Submsg> {
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::full_coverage2::msg::Submsg,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.submsg_required,
             &self._bitfield,
@@ -901,18 +875,18 @@ impl Msg {
     }
     pub fn submsg_required_opt(
         &self,
-    ) -> ::std::option::Option::<&self::_puroro_root::full_coverage2::msg::Submsg> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::full_coverage2::msg::Submsg,
+    ) -> ::std::option::Option::<&self::_root::full_coverage2::msg::Submsg> {
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::full_coverage2::msg::Submsg,
         > as NonRepeatedFieldType>::get_field_opt(&self.submsg_required, &self._bitfield)
     }
     pub fn submsg_required_mut(
         &mut self,
-    ) -> &mut self::_puroro_root::full_coverage2::msg::Submsg {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::full_coverage2::msg::Submsg,
+    ) -> &mut self::_root::full_coverage2::msg::Submsg {
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::full_coverage2::msg::Submsg,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.submsg_required,
             &mut self._bitfield,
@@ -920,24 +894,24 @@ impl Msg {
         )
     }
     pub fn has_submsg_required(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::full_coverage2::msg::Submsg,
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::full_coverage2::msg::Submsg,
         > as NonRepeatedFieldType>::get_field_opt(&self.submsg_required, &self._bitfield)
             .is_some()
     }
     pub fn clear_submsg_required(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::full_coverage2::msg::Submsg,
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::full_coverage2::msg::Submsg,
         > as NonRepeatedFieldType>::clear(&mut self.submsg_required, &mut self._bitfield)
     }
     pub fn submsg_optional(
         &self,
-    ) -> ::std::option::Option::<&self::_puroro_root::full_coverage2::msg::Submsg> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::full_coverage2::msg::Submsg,
+    ) -> ::std::option::Option::<&self::_root::full_coverage2::msg::Submsg> {
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::full_coverage2::msg::Submsg,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.submsg_optional,
             &self._bitfield,
@@ -946,18 +920,18 @@ impl Msg {
     }
     pub fn submsg_optional_opt(
         &self,
-    ) -> ::std::option::Option::<&self::_puroro_root::full_coverage2::msg::Submsg> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::full_coverage2::msg::Submsg,
+    ) -> ::std::option::Option::<&self::_root::full_coverage2::msg::Submsg> {
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::full_coverage2::msg::Submsg,
         > as NonRepeatedFieldType>::get_field_opt(&self.submsg_optional, &self._bitfield)
     }
     pub fn submsg_optional_mut(
         &mut self,
-    ) -> &mut self::_puroro_root::full_coverage2::msg::Submsg {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::full_coverage2::msg::Submsg,
+    ) -> &mut self::_root::full_coverage2::msg::Submsg {
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::full_coverage2::msg::Submsg,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.submsg_optional,
             &mut self._bitfield,
@@ -965,46 +939,46 @@ impl Msg {
         )
     }
     pub fn has_submsg_optional(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::full_coverage2::msg::Submsg,
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::full_coverage2::msg::Submsg,
         > as NonRepeatedFieldType>::get_field_opt(&self.submsg_optional, &self._bitfield)
             .is_some()
     }
     pub fn clear_submsg_optional(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::full_coverage2::msg::Submsg,
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::full_coverage2::msg::Submsg,
         > as NonRepeatedFieldType>::clear(&mut self.submsg_optional, &mut self._bitfield)
     }
-    pub fn submsg_repeated(&self) -> &[self::_puroro_root::full_coverage2::msg::Submsg] {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::full_coverage2::msg::Submsg,
+    pub fn submsg_repeated(&self) -> &[self::_root::full_coverage2::msg::Submsg] {
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::full_coverage2::msg::Submsg,
         > as RepeatedFieldType>::get_field(&self.submsg_repeated, &self._bitfield)
     }
     pub fn submsg_repeated_mut(
         &mut self,
-    ) -> &mut ::std::vec::Vec::<self::_puroro_root::full_coverage2::msg::Submsg> {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::full_coverage2::msg::Submsg,
+    ) -> &mut ::std::vec::Vec::<self::_root::full_coverage2::msg::Submsg> {
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::full_coverage2::msg::Submsg,
         > as RepeatedFieldType>::get_field_mut(
             &mut self.submsg_repeated,
             &mut self._bitfield,
         )
     }
     pub fn clear_submsg_repeated(&mut self) {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::full_coverage2::msg::Submsg,
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::full_coverage2::msg::Submsg,
         > as RepeatedFieldType>::clear(&mut self.submsg_repeated, &mut self._bitfield)
     }
     pub fn i64_required(&self) -> i64 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i64,
-            self::_puroro::internal::tags::Int64,
+            self::_pinternal::tags::Int64,
             10usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.i64_required,
@@ -1013,18 +987,18 @@ impl Msg {
         )
     }
     pub fn i64_required_opt(&self) -> ::std::option::Option::<i64> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i64,
-            self::_puroro::internal::tags::Int64,
+            self::_pinternal::tags::Int64,
             10usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.i64_required, &self._bitfield)
     }
     pub fn i64_required_mut(&mut self) -> &mut i64 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i64,
-            self::_puroro::internal::tags::Int64,
+            self::_pinternal::tags::Int64,
             10usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.i64_required,
@@ -1033,27 +1007,27 @@ impl Msg {
         )
     }
     pub fn has_i64_required(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i64,
-            self::_puroro::internal::tags::Int64,
+            self::_pinternal::tags::Int64,
             10usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.i64_required, &self._bitfield)
             .is_some()
     }
     pub fn clear_i64_required(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i64,
-            self::_puroro::internal::tags::Int64,
+            self::_pinternal::tags::Int64,
             10usize,
         > as NonRepeatedFieldType>::clear(&mut self.i64_required, &mut self._bitfield)
     }
     pub fn i64_optional(&self) -> i64 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i64,
-            self::_puroro::internal::tags::Int64,
+            self::_pinternal::tags::Int64,
             11usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.i64_optional,
@@ -1062,18 +1036,18 @@ impl Msg {
         )
     }
     pub fn i64_optional_opt(&self) -> ::std::option::Option::<i64> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i64,
-            self::_puroro::internal::tags::Int64,
+            self::_pinternal::tags::Int64,
             11usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.i64_optional, &self._bitfield)
     }
     pub fn i64_optional_mut(&mut self) -> &mut i64 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i64,
-            self::_puroro::internal::tags::Int64,
+            self::_pinternal::tags::Int64,
             11usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.i64_optional,
@@ -1082,51 +1056,51 @@ impl Msg {
         )
     }
     pub fn has_i64_optional(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i64,
-            self::_puroro::internal::tags::Int64,
+            self::_pinternal::tags::Int64,
             11usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.i64_optional, &self._bitfield)
             .is_some()
     }
     pub fn clear_i64_optional(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i64,
-            self::_puroro::internal::tags::Int64,
+            self::_pinternal::tags::Int64,
             11usize,
         > as NonRepeatedFieldType>::clear(&mut self.i64_optional, &mut self._bitfield)
     }
     pub fn i64_repeated(&self) -> &[i64] {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             i64,
-            self::_puroro::internal::tags::Int64,
+            self::_pinternal::tags::Int64,
         > as RepeatedFieldType>::get_field(&self.i64_repeated, &self._bitfield)
     }
     pub fn i64_repeated_mut(&mut self) -> &mut ::std::vec::Vec::<i64> {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             i64,
-            self::_puroro::internal::tags::Int64,
+            self::_pinternal::tags::Int64,
         > as RepeatedFieldType>::get_field_mut(
             &mut self.i64_repeated,
             &mut self._bitfield,
         )
     }
     pub fn clear_i64_repeated(&mut self) {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             i64,
-            self::_puroro::internal::tags::Int64,
+            self::_pinternal::tags::Int64,
         > as RepeatedFieldType>::clear(&mut self.i64_repeated, &mut self._bitfield)
     }
     pub fn u32_required(&self) -> u32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u32,
-            self::_puroro::internal::tags::UInt32,
+            self::_pinternal::tags::UInt32,
             12usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.u32_required,
@@ -1135,18 +1109,18 @@ impl Msg {
         )
     }
     pub fn u32_required_opt(&self) -> ::std::option::Option::<u32> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u32,
-            self::_puroro::internal::tags::UInt32,
+            self::_pinternal::tags::UInt32,
             12usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.u32_required, &self._bitfield)
     }
     pub fn u32_required_mut(&mut self) -> &mut u32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u32,
-            self::_puroro::internal::tags::UInt32,
+            self::_pinternal::tags::UInt32,
             12usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.u32_required,
@@ -1155,27 +1129,27 @@ impl Msg {
         )
     }
     pub fn has_u32_required(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u32,
-            self::_puroro::internal::tags::UInt32,
+            self::_pinternal::tags::UInt32,
             12usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.u32_required, &self._bitfield)
             .is_some()
     }
     pub fn clear_u32_required(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u32,
-            self::_puroro::internal::tags::UInt32,
+            self::_pinternal::tags::UInt32,
             12usize,
         > as NonRepeatedFieldType>::clear(&mut self.u32_required, &mut self._bitfield)
     }
     pub fn u32_optional(&self) -> u32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u32,
-            self::_puroro::internal::tags::UInt32,
+            self::_pinternal::tags::UInt32,
             13usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.u32_optional,
@@ -1184,18 +1158,18 @@ impl Msg {
         )
     }
     pub fn u32_optional_opt(&self) -> ::std::option::Option::<u32> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u32,
-            self::_puroro::internal::tags::UInt32,
+            self::_pinternal::tags::UInt32,
             13usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.u32_optional, &self._bitfield)
     }
     pub fn u32_optional_mut(&mut self) -> &mut u32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u32,
-            self::_puroro::internal::tags::UInt32,
+            self::_pinternal::tags::UInt32,
             13usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.u32_optional,
@@ -1204,51 +1178,51 @@ impl Msg {
         )
     }
     pub fn has_u32_optional(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u32,
-            self::_puroro::internal::tags::UInt32,
+            self::_pinternal::tags::UInt32,
             13usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.u32_optional, &self._bitfield)
             .is_some()
     }
     pub fn clear_u32_optional(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u32,
-            self::_puroro::internal::tags::UInt32,
+            self::_pinternal::tags::UInt32,
             13usize,
         > as NonRepeatedFieldType>::clear(&mut self.u32_optional, &mut self._bitfield)
     }
     pub fn u32_repeated(&self) -> &[u32] {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             u32,
-            self::_puroro::internal::tags::UInt32,
+            self::_pinternal::tags::UInt32,
         > as RepeatedFieldType>::get_field(&self.u32_repeated, &self._bitfield)
     }
     pub fn u32_repeated_mut(&mut self) -> &mut ::std::vec::Vec::<u32> {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             u32,
-            self::_puroro::internal::tags::UInt32,
+            self::_pinternal::tags::UInt32,
         > as RepeatedFieldType>::get_field_mut(
             &mut self.u32_repeated,
             &mut self._bitfield,
         )
     }
     pub fn clear_u32_repeated(&mut self) {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             u32,
-            self::_puroro::internal::tags::UInt32,
+            self::_pinternal::tags::UInt32,
         > as RepeatedFieldType>::clear(&mut self.u32_repeated, &mut self._bitfield)
     }
     pub fn u64_required(&self) -> u64 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u64,
-            self::_puroro::internal::tags::UInt64,
+            self::_pinternal::tags::UInt64,
             14usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.u64_required,
@@ -1257,18 +1231,18 @@ impl Msg {
         )
     }
     pub fn u64_required_opt(&self) -> ::std::option::Option::<u64> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u64,
-            self::_puroro::internal::tags::UInt64,
+            self::_pinternal::tags::UInt64,
             14usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.u64_required, &self._bitfield)
     }
     pub fn u64_required_mut(&mut self) -> &mut u64 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u64,
-            self::_puroro::internal::tags::UInt64,
+            self::_pinternal::tags::UInt64,
             14usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.u64_required,
@@ -1277,27 +1251,27 @@ impl Msg {
         )
     }
     pub fn has_u64_required(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u64,
-            self::_puroro::internal::tags::UInt64,
+            self::_pinternal::tags::UInt64,
             14usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.u64_required, &self._bitfield)
             .is_some()
     }
     pub fn clear_u64_required(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u64,
-            self::_puroro::internal::tags::UInt64,
+            self::_pinternal::tags::UInt64,
             14usize,
         > as NonRepeatedFieldType>::clear(&mut self.u64_required, &mut self._bitfield)
     }
     pub fn u64_optional(&self) -> u64 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u64,
-            self::_puroro::internal::tags::UInt64,
+            self::_pinternal::tags::UInt64,
             15usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.u64_optional,
@@ -1306,18 +1280,18 @@ impl Msg {
         )
     }
     pub fn u64_optional_opt(&self) -> ::std::option::Option::<u64> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u64,
-            self::_puroro::internal::tags::UInt64,
+            self::_pinternal::tags::UInt64,
             15usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.u64_optional, &self._bitfield)
     }
     pub fn u64_optional_mut(&mut self) -> &mut u64 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u64,
-            self::_puroro::internal::tags::UInt64,
+            self::_pinternal::tags::UInt64,
             15usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.u64_optional,
@@ -1326,51 +1300,51 @@ impl Msg {
         )
     }
     pub fn has_u64_optional(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u64,
-            self::_puroro::internal::tags::UInt64,
+            self::_pinternal::tags::UInt64,
             15usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.u64_optional, &self._bitfield)
             .is_some()
     }
     pub fn clear_u64_optional(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u64,
-            self::_puroro::internal::tags::UInt64,
+            self::_pinternal::tags::UInt64,
             15usize,
         > as NonRepeatedFieldType>::clear(&mut self.u64_optional, &mut self._bitfield)
     }
     pub fn u64_repeated(&self) -> &[u64] {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             u64,
-            self::_puroro::internal::tags::UInt64,
+            self::_pinternal::tags::UInt64,
         > as RepeatedFieldType>::get_field(&self.u64_repeated, &self._bitfield)
     }
     pub fn u64_repeated_mut(&mut self) -> &mut ::std::vec::Vec::<u64> {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             u64,
-            self::_puroro::internal::tags::UInt64,
+            self::_pinternal::tags::UInt64,
         > as RepeatedFieldType>::get_field_mut(
             &mut self.u64_repeated,
             &mut self._bitfield,
         )
     }
     pub fn clear_u64_repeated(&mut self) {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             u64,
-            self::_puroro::internal::tags::UInt64,
+            self::_pinternal::tags::UInt64,
         > as RepeatedFieldType>::clear(&mut self.u64_repeated, &mut self._bitfield)
     }
     pub fn s32_required(&self) -> i32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::SInt32,
+            self::_pinternal::tags::SInt32,
             16usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.s32_required,
@@ -1379,18 +1353,18 @@ impl Msg {
         )
     }
     pub fn s32_required_opt(&self) -> ::std::option::Option::<i32> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::SInt32,
+            self::_pinternal::tags::SInt32,
             16usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.s32_required, &self._bitfield)
     }
     pub fn s32_required_mut(&mut self) -> &mut i32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::SInt32,
+            self::_pinternal::tags::SInt32,
             16usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.s32_required,
@@ -1399,27 +1373,27 @@ impl Msg {
         )
     }
     pub fn has_s32_required(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::SInt32,
+            self::_pinternal::tags::SInt32,
             16usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.s32_required, &self._bitfield)
             .is_some()
     }
     pub fn clear_s32_required(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::SInt32,
+            self::_pinternal::tags::SInt32,
             16usize,
         > as NonRepeatedFieldType>::clear(&mut self.s32_required, &mut self._bitfield)
     }
     pub fn s32_optional(&self) -> i32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::SInt32,
+            self::_pinternal::tags::SInt32,
             17usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.s32_optional,
@@ -1428,18 +1402,18 @@ impl Msg {
         )
     }
     pub fn s32_optional_opt(&self) -> ::std::option::Option::<i32> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::SInt32,
+            self::_pinternal::tags::SInt32,
             17usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.s32_optional, &self._bitfield)
     }
     pub fn s32_optional_mut(&mut self) -> &mut i32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::SInt32,
+            self::_pinternal::tags::SInt32,
             17usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.s32_optional,
@@ -1448,51 +1422,51 @@ impl Msg {
         )
     }
     pub fn has_s32_optional(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::SInt32,
+            self::_pinternal::tags::SInt32,
             17usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.s32_optional, &self._bitfield)
             .is_some()
     }
     pub fn clear_s32_optional(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::SInt32,
+            self::_pinternal::tags::SInt32,
             17usize,
         > as NonRepeatedFieldType>::clear(&mut self.s32_optional, &mut self._bitfield)
     }
     pub fn s32_repeated(&self) -> &[i32] {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             i32,
-            self::_puroro::internal::tags::SInt32,
+            self::_pinternal::tags::SInt32,
         > as RepeatedFieldType>::get_field(&self.s32_repeated, &self._bitfield)
     }
     pub fn s32_repeated_mut(&mut self) -> &mut ::std::vec::Vec::<i32> {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             i32,
-            self::_puroro::internal::tags::SInt32,
+            self::_pinternal::tags::SInt32,
         > as RepeatedFieldType>::get_field_mut(
             &mut self.s32_repeated,
             &mut self._bitfield,
         )
     }
     pub fn clear_s32_repeated(&mut self) {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             i32,
-            self::_puroro::internal::tags::SInt32,
+            self::_pinternal::tags::SInt32,
         > as RepeatedFieldType>::clear(&mut self.s32_repeated, &mut self._bitfield)
     }
     pub fn s64_required(&self) -> i64 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i64,
-            self::_puroro::internal::tags::SInt64,
+            self::_pinternal::tags::SInt64,
             18usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.s64_required,
@@ -1501,18 +1475,18 @@ impl Msg {
         )
     }
     pub fn s64_required_opt(&self) -> ::std::option::Option::<i64> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i64,
-            self::_puroro::internal::tags::SInt64,
+            self::_pinternal::tags::SInt64,
             18usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.s64_required, &self._bitfield)
     }
     pub fn s64_required_mut(&mut self) -> &mut i64 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i64,
-            self::_puroro::internal::tags::SInt64,
+            self::_pinternal::tags::SInt64,
             18usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.s64_required,
@@ -1521,27 +1495,27 @@ impl Msg {
         )
     }
     pub fn has_s64_required(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i64,
-            self::_puroro::internal::tags::SInt64,
+            self::_pinternal::tags::SInt64,
             18usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.s64_required, &self._bitfield)
             .is_some()
     }
     pub fn clear_s64_required(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i64,
-            self::_puroro::internal::tags::SInt64,
+            self::_pinternal::tags::SInt64,
             18usize,
         > as NonRepeatedFieldType>::clear(&mut self.s64_required, &mut self._bitfield)
     }
     pub fn s64_optional(&self) -> i64 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i64,
-            self::_puroro::internal::tags::SInt64,
+            self::_pinternal::tags::SInt64,
             19usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.s64_optional,
@@ -1550,18 +1524,18 @@ impl Msg {
         )
     }
     pub fn s64_optional_opt(&self) -> ::std::option::Option::<i64> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i64,
-            self::_puroro::internal::tags::SInt64,
+            self::_pinternal::tags::SInt64,
             19usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.s64_optional, &self._bitfield)
     }
     pub fn s64_optional_mut(&mut self) -> &mut i64 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i64,
-            self::_puroro::internal::tags::SInt64,
+            self::_pinternal::tags::SInt64,
             19usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.s64_optional,
@@ -1570,51 +1544,51 @@ impl Msg {
         )
     }
     pub fn has_s64_optional(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i64,
-            self::_puroro::internal::tags::SInt64,
+            self::_pinternal::tags::SInt64,
             19usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.s64_optional, &self._bitfield)
             .is_some()
     }
     pub fn clear_s64_optional(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i64,
-            self::_puroro::internal::tags::SInt64,
+            self::_pinternal::tags::SInt64,
             19usize,
         > as NonRepeatedFieldType>::clear(&mut self.s64_optional, &mut self._bitfield)
     }
     pub fn s64_repeated(&self) -> &[i64] {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             i64,
-            self::_puroro::internal::tags::SInt64,
+            self::_pinternal::tags::SInt64,
         > as RepeatedFieldType>::get_field(&self.s64_repeated, &self._bitfield)
     }
     pub fn s64_repeated_mut(&mut self) -> &mut ::std::vec::Vec::<i64> {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             i64,
-            self::_puroro::internal::tags::SInt64,
+            self::_pinternal::tags::SInt64,
         > as RepeatedFieldType>::get_field_mut(
             &mut self.s64_repeated,
             &mut self._bitfield,
         )
     }
     pub fn clear_s64_repeated(&mut self) {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             i64,
-            self::_puroro::internal::tags::SInt64,
+            self::_pinternal::tags::SInt64,
         > as RepeatedFieldType>::clear(&mut self.s64_repeated, &mut self._bitfield)
     }
     pub fn fixed32_required(&self) -> u32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u32,
-            self::_puroro::internal::tags::Fixed32,
+            self::_pinternal::tags::Fixed32,
             20usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.fixed32_required,
@@ -1623,10 +1597,10 @@ impl Msg {
         )
     }
     pub fn fixed32_required_opt(&self) -> ::std::option::Option::<u32> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u32,
-            self::_puroro::internal::tags::Fixed32,
+            self::_pinternal::tags::Fixed32,
             20usize,
         > as NonRepeatedFieldType>::get_field_opt(
             &self.fixed32_required,
@@ -1634,10 +1608,10 @@ impl Msg {
         )
     }
     pub fn fixed32_required_mut(&mut self) -> &mut u32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u32,
-            self::_puroro::internal::tags::Fixed32,
+            self::_pinternal::tags::Fixed32,
             20usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.fixed32_required,
@@ -1646,10 +1620,10 @@ impl Msg {
         )
     }
     pub fn has_fixed32_required(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u32,
-            self::_puroro::internal::tags::Fixed32,
+            self::_pinternal::tags::Fixed32,
             20usize,
         > as NonRepeatedFieldType>::get_field_opt(
                 &self.fixed32_required,
@@ -1658,10 +1632,10 @@ impl Msg {
             .is_some()
     }
     pub fn clear_fixed32_required(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u32,
-            self::_puroro::internal::tags::Fixed32,
+            self::_pinternal::tags::Fixed32,
             20usize,
         > as NonRepeatedFieldType>::clear(
             &mut self.fixed32_required,
@@ -1669,10 +1643,10 @@ impl Msg {
         )
     }
     pub fn fixed32_optional(&self) -> u32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u32,
-            self::_puroro::internal::tags::Fixed32,
+            self::_pinternal::tags::Fixed32,
             21usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.fixed32_optional,
@@ -1681,10 +1655,10 @@ impl Msg {
         )
     }
     pub fn fixed32_optional_opt(&self) -> ::std::option::Option::<u32> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u32,
-            self::_puroro::internal::tags::Fixed32,
+            self::_pinternal::tags::Fixed32,
             21usize,
         > as NonRepeatedFieldType>::get_field_opt(
             &self.fixed32_optional,
@@ -1692,10 +1666,10 @@ impl Msg {
         )
     }
     pub fn fixed32_optional_mut(&mut self) -> &mut u32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u32,
-            self::_puroro::internal::tags::Fixed32,
+            self::_pinternal::tags::Fixed32,
             21usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.fixed32_optional,
@@ -1704,10 +1678,10 @@ impl Msg {
         )
     }
     pub fn has_fixed32_optional(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u32,
-            self::_puroro::internal::tags::Fixed32,
+            self::_pinternal::tags::Fixed32,
             21usize,
         > as NonRepeatedFieldType>::get_field_opt(
                 &self.fixed32_optional,
@@ -1716,10 +1690,10 @@ impl Msg {
             .is_some()
     }
     pub fn clear_fixed32_optional(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u32,
-            self::_puroro::internal::tags::Fixed32,
+            self::_pinternal::tags::Fixed32,
             21usize,
         > as NonRepeatedFieldType>::clear(
             &mut self.fixed32_optional,
@@ -1727,34 +1701,34 @@ impl Msg {
         )
     }
     pub fn fixed32_repeated(&self) -> &[u32] {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             u32,
-            self::_puroro::internal::tags::Fixed32,
+            self::_pinternal::tags::Fixed32,
         > as RepeatedFieldType>::get_field(&self.fixed32_repeated, &self._bitfield)
     }
     pub fn fixed32_repeated_mut(&mut self) -> &mut ::std::vec::Vec::<u32> {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             u32,
-            self::_puroro::internal::tags::Fixed32,
+            self::_pinternal::tags::Fixed32,
         > as RepeatedFieldType>::get_field_mut(
             &mut self.fixed32_repeated,
             &mut self._bitfield,
         )
     }
     pub fn clear_fixed32_repeated(&mut self) {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             u32,
-            self::_puroro::internal::tags::Fixed32,
+            self::_pinternal::tags::Fixed32,
         > as RepeatedFieldType>::clear(&mut self.fixed32_repeated, &mut self._bitfield)
     }
     pub fn fixed64_required(&self) -> u64 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u64,
-            self::_puroro::internal::tags::Fixed64,
+            self::_pinternal::tags::Fixed64,
             22usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.fixed64_required,
@@ -1763,10 +1737,10 @@ impl Msg {
         )
     }
     pub fn fixed64_required_opt(&self) -> ::std::option::Option::<u64> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u64,
-            self::_puroro::internal::tags::Fixed64,
+            self::_pinternal::tags::Fixed64,
             22usize,
         > as NonRepeatedFieldType>::get_field_opt(
             &self.fixed64_required,
@@ -1774,10 +1748,10 @@ impl Msg {
         )
     }
     pub fn fixed64_required_mut(&mut self) -> &mut u64 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u64,
-            self::_puroro::internal::tags::Fixed64,
+            self::_pinternal::tags::Fixed64,
             22usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.fixed64_required,
@@ -1786,10 +1760,10 @@ impl Msg {
         )
     }
     pub fn has_fixed64_required(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u64,
-            self::_puroro::internal::tags::Fixed64,
+            self::_pinternal::tags::Fixed64,
             22usize,
         > as NonRepeatedFieldType>::get_field_opt(
                 &self.fixed64_required,
@@ -1798,10 +1772,10 @@ impl Msg {
             .is_some()
     }
     pub fn clear_fixed64_required(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u64,
-            self::_puroro::internal::tags::Fixed64,
+            self::_pinternal::tags::Fixed64,
             22usize,
         > as NonRepeatedFieldType>::clear(
             &mut self.fixed64_required,
@@ -1809,10 +1783,10 @@ impl Msg {
         )
     }
     pub fn fixed64_optional(&self) -> u64 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u64,
-            self::_puroro::internal::tags::Fixed64,
+            self::_pinternal::tags::Fixed64,
             23usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.fixed64_optional,
@@ -1821,10 +1795,10 @@ impl Msg {
         )
     }
     pub fn fixed64_optional_opt(&self) -> ::std::option::Option::<u64> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u64,
-            self::_puroro::internal::tags::Fixed64,
+            self::_pinternal::tags::Fixed64,
             23usize,
         > as NonRepeatedFieldType>::get_field_opt(
             &self.fixed64_optional,
@@ -1832,10 +1806,10 @@ impl Msg {
         )
     }
     pub fn fixed64_optional_mut(&mut self) -> &mut u64 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u64,
-            self::_puroro::internal::tags::Fixed64,
+            self::_pinternal::tags::Fixed64,
             23usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.fixed64_optional,
@@ -1844,10 +1818,10 @@ impl Msg {
         )
     }
     pub fn has_fixed64_optional(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u64,
-            self::_puroro::internal::tags::Fixed64,
+            self::_pinternal::tags::Fixed64,
             23usize,
         > as NonRepeatedFieldType>::get_field_opt(
                 &self.fixed64_optional,
@@ -1856,10 +1830,10 @@ impl Msg {
             .is_some()
     }
     pub fn clear_fixed64_optional(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u64,
-            self::_puroro::internal::tags::Fixed64,
+            self::_pinternal::tags::Fixed64,
             23usize,
         > as NonRepeatedFieldType>::clear(
             &mut self.fixed64_optional,
@@ -1867,34 +1841,34 @@ impl Msg {
         )
     }
     pub fn fixed64_repeated(&self) -> &[u64] {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             u64,
-            self::_puroro::internal::tags::Fixed64,
+            self::_pinternal::tags::Fixed64,
         > as RepeatedFieldType>::get_field(&self.fixed64_repeated, &self._bitfield)
     }
     pub fn fixed64_repeated_mut(&mut self) -> &mut ::std::vec::Vec::<u64> {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             u64,
-            self::_puroro::internal::tags::Fixed64,
+            self::_pinternal::tags::Fixed64,
         > as RepeatedFieldType>::get_field_mut(
             &mut self.fixed64_repeated,
             &mut self._bitfield,
         )
     }
     pub fn clear_fixed64_repeated(&mut self) {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             u64,
-            self::_puroro::internal::tags::Fixed64,
+            self::_pinternal::tags::Fixed64,
         > as RepeatedFieldType>::clear(&mut self.fixed64_repeated, &mut self._bitfield)
     }
     pub fn sfixed32_required(&self) -> i32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::SFixed32,
+            self::_pinternal::tags::SFixed32,
             24usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.sfixed32_required,
@@ -1903,10 +1877,10 @@ impl Msg {
         )
     }
     pub fn sfixed32_required_opt(&self) -> ::std::option::Option::<i32> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::SFixed32,
+            self::_pinternal::tags::SFixed32,
             24usize,
         > as NonRepeatedFieldType>::get_field_opt(
             &self.sfixed32_required,
@@ -1914,10 +1888,10 @@ impl Msg {
         )
     }
     pub fn sfixed32_required_mut(&mut self) -> &mut i32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::SFixed32,
+            self::_pinternal::tags::SFixed32,
             24usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.sfixed32_required,
@@ -1926,10 +1900,10 @@ impl Msg {
         )
     }
     pub fn has_sfixed32_required(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::SFixed32,
+            self::_pinternal::tags::SFixed32,
             24usize,
         > as NonRepeatedFieldType>::get_field_opt(
                 &self.sfixed32_required,
@@ -1938,10 +1912,10 @@ impl Msg {
             .is_some()
     }
     pub fn clear_sfixed32_required(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::SFixed32,
+            self::_pinternal::tags::SFixed32,
             24usize,
         > as NonRepeatedFieldType>::clear(
             &mut self.sfixed32_required,
@@ -1949,10 +1923,10 @@ impl Msg {
         )
     }
     pub fn sfixed32_optional(&self) -> i32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::SFixed32,
+            self::_pinternal::tags::SFixed32,
             25usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.sfixed32_optional,
@@ -1961,10 +1935,10 @@ impl Msg {
         )
     }
     pub fn sfixed32_optional_opt(&self) -> ::std::option::Option::<i32> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::SFixed32,
+            self::_pinternal::tags::SFixed32,
             25usize,
         > as NonRepeatedFieldType>::get_field_opt(
             &self.sfixed32_optional,
@@ -1972,10 +1946,10 @@ impl Msg {
         )
     }
     pub fn sfixed32_optional_mut(&mut self) -> &mut i32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::SFixed32,
+            self::_pinternal::tags::SFixed32,
             25usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.sfixed32_optional,
@@ -1984,10 +1958,10 @@ impl Msg {
         )
     }
     pub fn has_sfixed32_optional(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::SFixed32,
+            self::_pinternal::tags::SFixed32,
             25usize,
         > as NonRepeatedFieldType>::get_field_opt(
                 &self.sfixed32_optional,
@@ -1996,10 +1970,10 @@ impl Msg {
             .is_some()
     }
     pub fn clear_sfixed32_optional(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::SFixed32,
+            self::_pinternal::tags::SFixed32,
             25usize,
         > as NonRepeatedFieldType>::clear(
             &mut self.sfixed32_optional,
@@ -2007,34 +1981,34 @@ impl Msg {
         )
     }
     pub fn sfixed32_repeated(&self) -> &[i32] {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             i32,
-            self::_puroro::internal::tags::SFixed32,
+            self::_pinternal::tags::SFixed32,
         > as RepeatedFieldType>::get_field(&self.sfixed32_repeated, &self._bitfield)
     }
     pub fn sfixed32_repeated_mut(&mut self) -> &mut ::std::vec::Vec::<i32> {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             i32,
-            self::_puroro::internal::tags::SFixed32,
+            self::_pinternal::tags::SFixed32,
         > as RepeatedFieldType>::get_field_mut(
             &mut self.sfixed32_repeated,
             &mut self._bitfield,
         )
     }
     pub fn clear_sfixed32_repeated(&mut self) {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             i32,
-            self::_puroro::internal::tags::SFixed32,
+            self::_pinternal::tags::SFixed32,
         > as RepeatedFieldType>::clear(&mut self.sfixed32_repeated, &mut self._bitfield)
     }
     pub fn sfixed64_required(&self) -> i64 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i64,
-            self::_puroro::internal::tags::SFixed64,
+            self::_pinternal::tags::SFixed64,
             26usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.sfixed64_required,
@@ -2043,10 +2017,10 @@ impl Msg {
         )
     }
     pub fn sfixed64_required_opt(&self) -> ::std::option::Option::<i64> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i64,
-            self::_puroro::internal::tags::SFixed64,
+            self::_pinternal::tags::SFixed64,
             26usize,
         > as NonRepeatedFieldType>::get_field_opt(
             &self.sfixed64_required,
@@ -2054,10 +2028,10 @@ impl Msg {
         )
     }
     pub fn sfixed64_required_mut(&mut self) -> &mut i64 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i64,
-            self::_puroro::internal::tags::SFixed64,
+            self::_pinternal::tags::SFixed64,
             26usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.sfixed64_required,
@@ -2066,10 +2040,10 @@ impl Msg {
         )
     }
     pub fn has_sfixed64_required(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i64,
-            self::_puroro::internal::tags::SFixed64,
+            self::_pinternal::tags::SFixed64,
             26usize,
         > as NonRepeatedFieldType>::get_field_opt(
                 &self.sfixed64_required,
@@ -2078,10 +2052,10 @@ impl Msg {
             .is_some()
     }
     pub fn clear_sfixed64_required(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i64,
-            self::_puroro::internal::tags::SFixed64,
+            self::_pinternal::tags::SFixed64,
             26usize,
         > as NonRepeatedFieldType>::clear(
             &mut self.sfixed64_required,
@@ -2089,10 +2063,10 @@ impl Msg {
         )
     }
     pub fn sfixed64_optional(&self) -> i64 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i64,
-            self::_puroro::internal::tags::SFixed64,
+            self::_pinternal::tags::SFixed64,
             27usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.sfixed64_optional,
@@ -2101,10 +2075,10 @@ impl Msg {
         )
     }
     pub fn sfixed64_optional_opt(&self) -> ::std::option::Option::<i64> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i64,
-            self::_puroro::internal::tags::SFixed64,
+            self::_pinternal::tags::SFixed64,
             27usize,
         > as NonRepeatedFieldType>::get_field_opt(
             &self.sfixed64_optional,
@@ -2112,10 +2086,10 @@ impl Msg {
         )
     }
     pub fn sfixed64_optional_mut(&mut self) -> &mut i64 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i64,
-            self::_puroro::internal::tags::SFixed64,
+            self::_pinternal::tags::SFixed64,
             27usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.sfixed64_optional,
@@ -2124,10 +2098,10 @@ impl Msg {
         )
     }
     pub fn has_sfixed64_optional(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i64,
-            self::_puroro::internal::tags::SFixed64,
+            self::_pinternal::tags::SFixed64,
             27usize,
         > as NonRepeatedFieldType>::get_field_opt(
                 &self.sfixed64_optional,
@@ -2136,10 +2110,10 @@ impl Msg {
             .is_some()
     }
     pub fn clear_sfixed64_optional(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i64,
-            self::_puroro::internal::tags::SFixed64,
+            self::_pinternal::tags::SFixed64,
             27usize,
         > as NonRepeatedFieldType>::clear(
             &mut self.sfixed64_optional,
@@ -2147,34 +2121,34 @@ impl Msg {
         )
     }
     pub fn sfixed64_repeated(&self) -> &[i64] {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             i64,
-            self::_puroro::internal::tags::SFixed64,
+            self::_pinternal::tags::SFixed64,
         > as RepeatedFieldType>::get_field(&self.sfixed64_repeated, &self._bitfield)
     }
     pub fn sfixed64_repeated_mut(&mut self) -> &mut ::std::vec::Vec::<i64> {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             i64,
-            self::_puroro::internal::tags::SFixed64,
+            self::_pinternal::tags::SFixed64,
         > as RepeatedFieldType>::get_field_mut(
             &mut self.sfixed64_repeated,
             &mut self._bitfield,
         )
     }
     pub fn clear_sfixed64_repeated(&mut self) {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             i64,
-            self::_puroro::internal::tags::SFixed64,
+            self::_pinternal::tags::SFixed64,
         > as RepeatedFieldType>::clear(&mut self.sfixed64_repeated, &mut self._bitfield)
     }
     pub fn f64_required(&self) -> f64 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             f64,
-            self::_puroro::internal::tags::Double,
+            self::_pinternal::tags::Double,
             28usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.f64_required,
@@ -2183,18 +2157,18 @@ impl Msg {
         )
     }
     pub fn f64_required_opt(&self) -> ::std::option::Option::<f64> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             f64,
-            self::_puroro::internal::tags::Double,
+            self::_pinternal::tags::Double,
             28usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.f64_required, &self._bitfield)
     }
     pub fn f64_required_mut(&mut self) -> &mut f64 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             f64,
-            self::_puroro::internal::tags::Double,
+            self::_pinternal::tags::Double,
             28usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.f64_required,
@@ -2203,27 +2177,27 @@ impl Msg {
         )
     }
     pub fn has_f64_required(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             f64,
-            self::_puroro::internal::tags::Double,
+            self::_pinternal::tags::Double,
             28usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.f64_required, &self._bitfield)
             .is_some()
     }
     pub fn clear_f64_required(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             f64,
-            self::_puroro::internal::tags::Double,
+            self::_pinternal::tags::Double,
             28usize,
         > as NonRepeatedFieldType>::clear(&mut self.f64_required, &mut self._bitfield)
     }
     pub fn f64_optional(&self) -> f64 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             f64,
-            self::_puroro::internal::tags::Double,
+            self::_pinternal::tags::Double,
             29usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.f64_optional,
@@ -2232,18 +2206,18 @@ impl Msg {
         )
     }
     pub fn f64_optional_opt(&self) -> ::std::option::Option::<f64> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             f64,
-            self::_puroro::internal::tags::Double,
+            self::_pinternal::tags::Double,
             29usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.f64_optional, &self._bitfield)
     }
     pub fn f64_optional_mut(&mut self) -> &mut f64 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             f64,
-            self::_puroro::internal::tags::Double,
+            self::_pinternal::tags::Double,
             29usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.f64_optional,
@@ -2252,44 +2226,44 @@ impl Msg {
         )
     }
     pub fn has_f64_optional(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             f64,
-            self::_puroro::internal::tags::Double,
+            self::_pinternal::tags::Double,
             29usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.f64_optional, &self._bitfield)
             .is_some()
     }
     pub fn clear_f64_optional(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             f64,
-            self::_puroro::internal::tags::Double,
+            self::_pinternal::tags::Double,
             29usize,
         > as NonRepeatedFieldType>::clear(&mut self.f64_optional, &mut self._bitfield)
     }
     pub fn f64_repeated(&self) -> &[f64] {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             f64,
-            self::_puroro::internal::tags::Double,
+            self::_pinternal::tags::Double,
         > as RepeatedFieldType>::get_field(&self.f64_repeated, &self._bitfield)
     }
     pub fn f64_repeated_mut(&mut self) -> &mut ::std::vec::Vec::<f64> {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             f64,
-            self::_puroro::internal::tags::Double,
+            self::_pinternal::tags::Double,
         > as RepeatedFieldType>::get_field_mut(
             &mut self.f64_repeated,
             &mut self._bitfield,
         )
     }
     pub fn clear_f64_repeated(&mut self) {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             f64,
-            self::_puroro::internal::tags::Double,
+            self::_pinternal::tags::Double,
         > as RepeatedFieldType>::clear(&mut self.f64_repeated, &mut self._bitfield)
     }
 }
@@ -2305,520 +2279,520 @@ impl self::_puroro::Message for Msg {
         &mut self,
         mut iter: I,
     ) -> self::_puroro::Result<()> {
-        use self::_puroro::internal::ser::FieldData;
+        use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 1i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         i32,
-                        self::_puroro::internal::tags::Int32,
+                        self::_pinternal::tags::Int32,
                         0usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.i32_required,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 2i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         i32,
-                        self::_puroro::internal::tags::Int32,
+                        self::_pinternal::tags::Int32,
                         1usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.i32_optional,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 3i32 => {
-                    <self::_puroro::internal::field_type::RepeatedNumericalField::<
+                    <self::_pinternal::field_type::RepeatedNumericalField::<
                         i32,
-                        self::_puroro::internal::tags::Int32,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                        self::_pinternal::tags::Int32,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.i32_repeated,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 11i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         f32,
-                        self::_puroro::internal::tags::Float,
+                        self::_pinternal::tags::Float,
                         2usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.float_required,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 12i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         f32,
-                        self::_puroro::internal::tags::Float,
+                        self::_pinternal::tags::Float,
                         3usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.float_optional,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 13i32 => {
-                    <self::_puroro::internal::field_type::RepeatedNumericalField::<
+                    <self::_pinternal::field_type::RepeatedNumericalField::<
                         f32,
-                        self::_puroro::internal::tags::Float,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                        self::_pinternal::tags::Float,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.float_repeated,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 21i32 => {
-                    <self::_puroro::internal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::field_type::OptionalUnsizedField::<
                         ::std::vec::Vec<u8>,
-                        self::_puroro::internal::tags::Bytes,
+                        self::_pinternal::tags::Bytes,
                         4usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.bytes_required,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 22i32 => {
-                    <self::_puroro::internal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::field_type::OptionalUnsizedField::<
                         ::std::vec::Vec<u8>,
-                        self::_puroro::internal::tags::Bytes,
+                        self::_pinternal::tags::Bytes,
                         5usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.bytes_optional,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 23i32 => {
-                    <self::_puroro::internal::field_type::RepeatedUnsizedField::<
+                    <self::_pinternal::field_type::RepeatedUnsizedField::<
                         ::std::vec::Vec<u8>,
-                        self::_puroro::internal::tags::Bytes,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                        self::_pinternal::tags::Bytes,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.bytes_repeated,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 31i32 => {
-                    <self::_puroro::internal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::field_type::OptionalUnsizedField::<
                         ::std::string::String,
-                        self::_puroro::internal::tags::String,
+                        self::_pinternal::tags::String,
                         6usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.string_required,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 32i32 => {
-                    <self::_puroro::internal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::field_type::OptionalUnsizedField::<
                         ::std::string::String,
-                        self::_puroro::internal::tags::String,
+                        self::_pinternal::tags::String,
                         7usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.string_optional,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 33i32 => {
-                    <self::_puroro::internal::field_type::RepeatedUnsizedField::<
+                    <self::_pinternal::field_type::RepeatedUnsizedField::<
                         ::std::string::String,
-                        self::_puroro::internal::tags::String,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                        self::_pinternal::tags::String,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.string_repeated,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 41i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
-                        self::_puroro_root::full_coverage2::Enum,
-                        self::_puroro::internal::tags::Enum2::<
-                            self::_puroro_root::full_coverage2::Enum,
+                    <self::_pinternal::field_type::OptionalNumericalField::<
+                        self::_root::full_coverage2::Enum,
+                        self::_pinternal::tags::Enum2::<
+                            self::_root::full_coverage2::Enum,
                         >,
                         8usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.enum_required,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 42i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
-                        self::_puroro_root::full_coverage2::Enum,
-                        self::_puroro::internal::tags::Enum2::<
-                            self::_puroro_root::full_coverage2::Enum,
+                    <self::_pinternal::field_type::OptionalNumericalField::<
+                        self::_root::full_coverage2::Enum,
+                        self::_pinternal::tags::Enum2::<
+                            self::_root::full_coverage2::Enum,
                         >,
                         9usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.enum_optional,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 43i32 => {
-                    <self::_puroro::internal::field_type::RepeatedNumericalField::<
-                        self::_puroro_root::full_coverage2::Enum,
-                        self::_puroro::internal::tags::Enum2::<
-                            self::_puroro_root::full_coverage2::Enum,
+                    <self::_pinternal::field_type::RepeatedNumericalField::<
+                        self::_root::full_coverage2::Enum,
+                        self::_pinternal::tags::Enum2::<
+                            self::_root::full_coverage2::Enum,
                         >,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.enum_repeated,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 51i32 => {
-                    <self::_puroro::internal::field_type::SingularHeapMessageField::<
-                        self::_puroro_root::full_coverage2::msg::Submsg,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    <self::_pinternal::field_type::SingularHeapMessageField::<
+                        self::_root::full_coverage2::msg::Submsg,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.submsg_required,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 52i32 => {
-                    <self::_puroro::internal::field_type::SingularHeapMessageField::<
-                        self::_puroro_root::full_coverage2::msg::Submsg,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    <self::_pinternal::field_type::SingularHeapMessageField::<
+                        self::_root::full_coverage2::msg::Submsg,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.submsg_optional,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 53i32 => {
-                    <self::_puroro::internal::field_type::RepeatedMessageField::<
-                        self::_puroro_root::full_coverage2::msg::Submsg,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    <self::_pinternal::field_type::RepeatedMessageField::<
+                        self::_root::full_coverage2::msg::Submsg,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.submsg_repeated,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 101i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         i64,
-                        self::_puroro::internal::tags::Int64,
+                        self::_pinternal::tags::Int64,
                         10usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.i64_required,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 102i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         i64,
-                        self::_puroro::internal::tags::Int64,
+                        self::_pinternal::tags::Int64,
                         11usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.i64_optional,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 103i32 => {
-                    <self::_puroro::internal::field_type::RepeatedNumericalField::<
+                    <self::_pinternal::field_type::RepeatedNumericalField::<
                         i64,
-                        self::_puroro::internal::tags::Int64,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                        self::_pinternal::tags::Int64,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.i64_repeated,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 111i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         u32,
-                        self::_puroro::internal::tags::UInt32,
+                        self::_pinternal::tags::UInt32,
                         12usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.u32_required,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 112i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         u32,
-                        self::_puroro::internal::tags::UInt32,
+                        self::_pinternal::tags::UInt32,
                         13usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.u32_optional,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 113i32 => {
-                    <self::_puroro::internal::field_type::RepeatedNumericalField::<
+                    <self::_pinternal::field_type::RepeatedNumericalField::<
                         u32,
-                        self::_puroro::internal::tags::UInt32,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                        self::_pinternal::tags::UInt32,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.u32_repeated,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 121i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         u64,
-                        self::_puroro::internal::tags::UInt64,
+                        self::_pinternal::tags::UInt64,
                         14usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.u64_required,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 122i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         u64,
-                        self::_puroro::internal::tags::UInt64,
+                        self::_pinternal::tags::UInt64,
                         15usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.u64_optional,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 123i32 => {
-                    <self::_puroro::internal::field_type::RepeatedNumericalField::<
+                    <self::_pinternal::field_type::RepeatedNumericalField::<
                         u64,
-                        self::_puroro::internal::tags::UInt64,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                        self::_pinternal::tags::UInt64,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.u64_repeated,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 131i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         i32,
-                        self::_puroro::internal::tags::SInt32,
+                        self::_pinternal::tags::SInt32,
                         16usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.s32_required,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 132i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         i32,
-                        self::_puroro::internal::tags::SInt32,
+                        self::_pinternal::tags::SInt32,
                         17usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.s32_optional,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 133i32 => {
-                    <self::_puroro::internal::field_type::RepeatedNumericalField::<
+                    <self::_pinternal::field_type::RepeatedNumericalField::<
                         i32,
-                        self::_puroro::internal::tags::SInt32,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                        self::_pinternal::tags::SInt32,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.s32_repeated,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 141i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         i64,
-                        self::_puroro::internal::tags::SInt64,
+                        self::_pinternal::tags::SInt64,
                         18usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.s64_required,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 142i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         i64,
-                        self::_puroro::internal::tags::SInt64,
+                        self::_pinternal::tags::SInt64,
                         19usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.s64_optional,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 143i32 => {
-                    <self::_puroro::internal::field_type::RepeatedNumericalField::<
+                    <self::_pinternal::field_type::RepeatedNumericalField::<
                         i64,
-                        self::_puroro::internal::tags::SInt64,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                        self::_pinternal::tags::SInt64,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.s64_repeated,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 151i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         u32,
-                        self::_puroro::internal::tags::Fixed32,
+                        self::_pinternal::tags::Fixed32,
                         20usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.fixed32_required,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 152i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         u32,
-                        self::_puroro::internal::tags::Fixed32,
+                        self::_pinternal::tags::Fixed32,
                         21usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.fixed32_optional,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 153i32 => {
-                    <self::_puroro::internal::field_type::RepeatedNumericalField::<
+                    <self::_pinternal::field_type::RepeatedNumericalField::<
                         u32,
-                        self::_puroro::internal::tags::Fixed32,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                        self::_pinternal::tags::Fixed32,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.fixed32_repeated,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 161i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         u64,
-                        self::_puroro::internal::tags::Fixed64,
+                        self::_pinternal::tags::Fixed64,
                         22usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.fixed64_required,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 162i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         u64,
-                        self::_puroro::internal::tags::Fixed64,
+                        self::_pinternal::tags::Fixed64,
                         23usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.fixed64_optional,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 163i32 => {
-                    <self::_puroro::internal::field_type::RepeatedNumericalField::<
+                    <self::_pinternal::field_type::RepeatedNumericalField::<
                         u64,
-                        self::_puroro::internal::tags::Fixed64,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                        self::_pinternal::tags::Fixed64,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.fixed64_repeated,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 171i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         i32,
-                        self::_puroro::internal::tags::SFixed32,
+                        self::_pinternal::tags::SFixed32,
                         24usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.sfixed32_required,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 172i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         i32,
-                        self::_puroro::internal::tags::SFixed32,
+                        self::_pinternal::tags::SFixed32,
                         25usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.sfixed32_optional,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 173i32 => {
-                    <self::_puroro::internal::field_type::RepeatedNumericalField::<
+                    <self::_pinternal::field_type::RepeatedNumericalField::<
                         i32,
-                        self::_puroro::internal::tags::SFixed32,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                        self::_pinternal::tags::SFixed32,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.sfixed32_repeated,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 181i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         i64,
-                        self::_puroro::internal::tags::SFixed64,
+                        self::_pinternal::tags::SFixed64,
                         26usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.sfixed64_required,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 182i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         i64,
-                        self::_puroro::internal::tags::SFixed64,
+                        self::_pinternal::tags::SFixed64,
                         27usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.sfixed64_optional,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 183i32 => {
-                    <self::_puroro::internal::field_type::RepeatedNumericalField::<
+                    <self::_pinternal::field_type::RepeatedNumericalField::<
                         i64,
-                        self::_puroro::internal::tags::SFixed64,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                        self::_pinternal::tags::SFixed64,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.sfixed64_repeated,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 191i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         f64,
-                        self::_puroro::internal::tags::Double,
+                        self::_pinternal::tags::Double,
                         28usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.f64_required,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 192i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         f64,
-                        self::_puroro::internal::tags::Double,
+                        self::_pinternal::tags::Double,
                         29usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.f64_optional,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 193i32 => {
-                    <self::_puroro::internal::field_type::RepeatedNumericalField::<
+                    <self::_pinternal::field_type::RepeatedNumericalField::<
                         f64,
-                        self::_puroro::internal::tags::Double,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                        self::_pinternal::tags::Double,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.f64_repeated,
                         &mut self._bitfield,
                         field_data,
@@ -2835,467 +2809,461 @@ impl self::_puroro::Message for Msg {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::oneof_type::OneofUnion as _;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             0usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.i32_required,
             &self._bitfield,
             1i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             1usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.i32_optional,
             &self._bitfield,
             2i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+            self::_pinternal::tags::Int32,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.i32_repeated,
             &self._bitfield,
             3i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        <self::_pinternal::field_type::OptionalNumericalField::<
             f32,
-            self::_puroro::internal::tags::Float,
+            self::_pinternal::tags::Float,
             2usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.float_required,
             &self._bitfield,
             11i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        <self::_pinternal::field_type::OptionalNumericalField::<
             f32,
-            self::_puroro::internal::tags::Float,
+            self::_pinternal::tags::Float,
             3usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.float_optional,
             &self._bitfield,
             12i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             f32,
-            self::_puroro::internal::tags::Float,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+            self::_pinternal::tags::Float,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.float_repeated,
             &self._bitfield,
             13i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::vec::Vec<u8>,
-            self::_puroro::internal::tags::Bytes,
+            self::_pinternal::tags::Bytes,
             4usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.bytes_required,
             &self._bitfield,
             21i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::vec::Vec<u8>,
-            self::_puroro::internal::tags::Bytes,
+            self::_pinternal::tags::Bytes,
             5usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.bytes_optional,
             &self._bitfield,
             22i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::RepeatedUnsizedField::<
+        <self::_pinternal::field_type::RepeatedUnsizedField::<
             ::std::vec::Vec<u8>,
-            self::_puroro::internal::tags::Bytes,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+            self::_pinternal::tags::Bytes,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.bytes_repeated,
             &self._bitfield,
             23i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             6usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.string_required,
             &self._bitfield,
             31i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             7usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.string_optional,
             &self._bitfield,
             32i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::RepeatedUnsizedField::<
+        <self::_pinternal::field_type::RepeatedUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+            self::_pinternal::tags::String,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.string_repeated,
             &self._bitfield,
             33i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
-            self::_puroro_root::full_coverage2::Enum,
-            self::_puroro::internal::tags::Enum2::<
-                self::_puroro_root::full_coverage2::Enum,
-            >,
+        <self::_pinternal::field_type::OptionalNumericalField::<
+            self::_root::full_coverage2::Enum,
+            self::_pinternal::tags::Enum2::<self::_root::full_coverage2::Enum>,
             8usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.enum_required,
             &self._bitfield,
             41i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
-            self::_puroro_root::full_coverage2::Enum,
-            self::_puroro::internal::tags::Enum2::<
-                self::_puroro_root::full_coverage2::Enum,
-            >,
+        <self::_pinternal::field_type::OptionalNumericalField::<
+            self::_root::full_coverage2::Enum,
+            self::_pinternal::tags::Enum2::<self::_root::full_coverage2::Enum>,
             9usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.enum_optional,
             &self._bitfield,
             42i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
-            self::_puroro_root::full_coverage2::Enum,
-            self::_puroro::internal::tags::Enum2::<
-                self::_puroro_root::full_coverage2::Enum,
-            >,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        <self::_pinternal::field_type::RepeatedNumericalField::<
+            self::_root::full_coverage2::Enum,
+            self::_pinternal::tags::Enum2::<self::_root::full_coverage2::Enum>,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.enum_repeated,
             &self._bitfield,
             43i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::full_coverage2::msg::Submsg,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::full_coverage2::msg::Submsg,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.submsg_required,
             &self._bitfield,
             51i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::full_coverage2::msg::Submsg,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::full_coverage2::msg::Submsg,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.submsg_optional,
             &self._bitfield,
             52i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::full_coverage2::msg::Submsg,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::full_coverage2::msg::Submsg,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.submsg_repeated,
             &self._bitfield,
             53i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i64,
-            self::_puroro::internal::tags::Int64,
+            self::_pinternal::tags::Int64,
             10usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.i64_required,
             &self._bitfield,
             101i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i64,
-            self::_puroro::internal::tags::Int64,
+            self::_pinternal::tags::Int64,
             11usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.i64_optional,
             &self._bitfield,
             102i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             i64,
-            self::_puroro::internal::tags::Int64,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+            self::_pinternal::tags::Int64,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.i64_repeated,
             &self._bitfield,
             103i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u32,
-            self::_puroro::internal::tags::UInt32,
+            self::_pinternal::tags::UInt32,
             12usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.u32_required,
             &self._bitfield,
             111i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u32,
-            self::_puroro::internal::tags::UInt32,
+            self::_pinternal::tags::UInt32,
             13usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.u32_optional,
             &self._bitfield,
             112i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             u32,
-            self::_puroro::internal::tags::UInt32,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+            self::_pinternal::tags::UInt32,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.u32_repeated,
             &self._bitfield,
             113i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u64,
-            self::_puroro::internal::tags::UInt64,
+            self::_pinternal::tags::UInt64,
             14usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.u64_required,
             &self._bitfield,
             121i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u64,
-            self::_puroro::internal::tags::UInt64,
+            self::_pinternal::tags::UInt64,
             15usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.u64_optional,
             &self._bitfield,
             122i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             u64,
-            self::_puroro::internal::tags::UInt64,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+            self::_pinternal::tags::UInt64,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.u64_repeated,
             &self._bitfield,
             123i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::SInt32,
+            self::_pinternal::tags::SInt32,
             16usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.s32_required,
             &self._bitfield,
             131i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::SInt32,
+            self::_pinternal::tags::SInt32,
             17usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.s32_optional,
             &self._bitfield,
             132i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             i32,
-            self::_puroro::internal::tags::SInt32,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+            self::_pinternal::tags::SInt32,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.s32_repeated,
             &self._bitfield,
             133i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i64,
-            self::_puroro::internal::tags::SInt64,
+            self::_pinternal::tags::SInt64,
             18usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.s64_required,
             &self._bitfield,
             141i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i64,
-            self::_puroro::internal::tags::SInt64,
+            self::_pinternal::tags::SInt64,
             19usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.s64_optional,
             &self._bitfield,
             142i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             i64,
-            self::_puroro::internal::tags::SInt64,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+            self::_pinternal::tags::SInt64,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.s64_repeated,
             &self._bitfield,
             143i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u32,
-            self::_puroro::internal::tags::Fixed32,
+            self::_pinternal::tags::Fixed32,
             20usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.fixed32_required,
             &self._bitfield,
             151i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u32,
-            self::_puroro::internal::tags::Fixed32,
+            self::_pinternal::tags::Fixed32,
             21usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.fixed32_optional,
             &self._bitfield,
             152i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             u32,
-            self::_puroro::internal::tags::Fixed32,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+            self::_pinternal::tags::Fixed32,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.fixed32_repeated,
             &self._bitfield,
             153i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u64,
-            self::_puroro::internal::tags::Fixed64,
+            self::_pinternal::tags::Fixed64,
             22usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.fixed64_required,
             &self._bitfield,
             161i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u64,
-            self::_puroro::internal::tags::Fixed64,
+            self::_pinternal::tags::Fixed64,
             23usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.fixed64_optional,
             &self._bitfield,
             162i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             u64,
-            self::_puroro::internal::tags::Fixed64,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+            self::_pinternal::tags::Fixed64,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.fixed64_repeated,
             &self._bitfield,
             163i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::SFixed32,
+            self::_pinternal::tags::SFixed32,
             24usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.sfixed32_required,
             &self._bitfield,
             171i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::SFixed32,
+            self::_pinternal::tags::SFixed32,
             25usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.sfixed32_optional,
             &self._bitfield,
             172i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             i32,
-            self::_puroro::internal::tags::SFixed32,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+            self::_pinternal::tags::SFixed32,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.sfixed32_repeated,
             &self._bitfield,
             173i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i64,
-            self::_puroro::internal::tags::SFixed64,
+            self::_pinternal::tags::SFixed64,
             26usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.sfixed64_required,
             &self._bitfield,
             181i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i64,
-            self::_puroro::internal::tags::SFixed64,
+            self::_pinternal::tags::SFixed64,
             27usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.sfixed64_optional,
             &self._bitfield,
             182i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             i64,
-            self::_puroro::internal::tags::SFixed64,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+            self::_pinternal::tags::SFixed64,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.sfixed64_repeated,
             &self._bitfield,
             183i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        <self::_pinternal::field_type::OptionalNumericalField::<
             f64,
-            self::_puroro::internal::tags::Double,
+            self::_pinternal::tags::Double,
             28usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.f64_required,
             &self._bitfield,
             191i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        <self::_pinternal::field_type::OptionalNumericalField::<
             f64,
-            self::_puroro::internal::tags::Double,
+            self::_pinternal::tags::Double,
             29usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.f64_optional,
             &self._bitfield,
             192i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             f64,
-            self::_puroro::internal::tags::Double,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+            self::_pinternal::tags::Double,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.f64_repeated,
             &self._bitfield,
             193i32,
@@ -3307,230 +3275,224 @@ impl self::_puroro::Message for Msg {
 impl ::std::clone::Clone for Msg {
     fn clone(&self) -> Self {
         Self {
-            i32_required: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            i32_required: <self::_pinternal::field_type::OptionalNumericalField::<
                 i32,
-                self::_puroro::internal::tags::Int32,
+                self::_pinternal::tags::Int32,
                 0usize,
             > as ::std::clone::Clone>::clone(&self.i32_required),
-            i32_optional: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            i32_optional: <self::_pinternal::field_type::OptionalNumericalField::<
                 i32,
-                self::_puroro::internal::tags::Int32,
+                self::_pinternal::tags::Int32,
                 1usize,
             > as ::std::clone::Clone>::clone(&self.i32_optional),
-            i32_repeated: <self::_puroro::internal::field_type::RepeatedNumericalField::<
+            i32_repeated: <self::_pinternal::field_type::RepeatedNumericalField::<
                 i32,
-                self::_puroro::internal::tags::Int32,
+                self::_pinternal::tags::Int32,
             > as ::std::clone::Clone>::clone(&self.i32_repeated),
-            float_required: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            float_required: <self::_pinternal::field_type::OptionalNumericalField::<
                 f32,
-                self::_puroro::internal::tags::Float,
+                self::_pinternal::tags::Float,
                 2usize,
             > as ::std::clone::Clone>::clone(&self.float_required),
-            float_optional: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            float_optional: <self::_pinternal::field_type::OptionalNumericalField::<
                 f32,
-                self::_puroro::internal::tags::Float,
+                self::_pinternal::tags::Float,
                 3usize,
             > as ::std::clone::Clone>::clone(&self.float_optional),
-            float_repeated: <self::_puroro::internal::field_type::RepeatedNumericalField::<
+            float_repeated: <self::_pinternal::field_type::RepeatedNumericalField::<
                 f32,
-                self::_puroro::internal::tags::Float,
+                self::_pinternal::tags::Float,
             > as ::std::clone::Clone>::clone(&self.float_repeated),
-            bytes_required: <self::_puroro::internal::field_type::OptionalUnsizedField::<
+            bytes_required: <self::_pinternal::field_type::OptionalUnsizedField::<
                 ::std::vec::Vec<u8>,
-                self::_puroro::internal::tags::Bytes,
+                self::_pinternal::tags::Bytes,
                 4usize,
             > as ::std::clone::Clone>::clone(&self.bytes_required),
-            bytes_optional: <self::_puroro::internal::field_type::OptionalUnsizedField::<
+            bytes_optional: <self::_pinternal::field_type::OptionalUnsizedField::<
                 ::std::vec::Vec<u8>,
-                self::_puroro::internal::tags::Bytes,
+                self::_pinternal::tags::Bytes,
                 5usize,
             > as ::std::clone::Clone>::clone(&self.bytes_optional),
-            bytes_repeated: <self::_puroro::internal::field_type::RepeatedUnsizedField::<
+            bytes_repeated: <self::_pinternal::field_type::RepeatedUnsizedField::<
                 ::std::vec::Vec<u8>,
-                self::_puroro::internal::tags::Bytes,
+                self::_pinternal::tags::Bytes,
             > as ::std::clone::Clone>::clone(&self.bytes_repeated),
-            string_required: <self::_puroro::internal::field_type::OptionalUnsizedField::<
+            string_required: <self::_pinternal::field_type::OptionalUnsizedField::<
                 ::std::string::String,
-                self::_puroro::internal::tags::String,
+                self::_pinternal::tags::String,
                 6usize,
             > as ::std::clone::Clone>::clone(&self.string_required),
-            string_optional: <self::_puroro::internal::field_type::OptionalUnsizedField::<
+            string_optional: <self::_pinternal::field_type::OptionalUnsizedField::<
                 ::std::string::String,
-                self::_puroro::internal::tags::String,
+                self::_pinternal::tags::String,
                 7usize,
             > as ::std::clone::Clone>::clone(&self.string_optional),
-            string_repeated: <self::_puroro::internal::field_type::RepeatedUnsizedField::<
+            string_repeated: <self::_pinternal::field_type::RepeatedUnsizedField::<
                 ::std::string::String,
-                self::_puroro::internal::tags::String,
+                self::_pinternal::tags::String,
             > as ::std::clone::Clone>::clone(&self.string_repeated),
-            enum_required: <self::_puroro::internal::field_type::OptionalNumericalField::<
-                self::_puroro_root::full_coverage2::Enum,
-                self::_puroro::internal::tags::Enum2::<
-                    self::_puroro_root::full_coverage2::Enum,
-                >,
+            enum_required: <self::_pinternal::field_type::OptionalNumericalField::<
+                self::_root::full_coverage2::Enum,
+                self::_pinternal::tags::Enum2::<self::_root::full_coverage2::Enum>,
                 8usize,
             > as ::std::clone::Clone>::clone(&self.enum_required),
-            enum_optional: <self::_puroro::internal::field_type::OptionalNumericalField::<
-                self::_puroro_root::full_coverage2::Enum,
-                self::_puroro::internal::tags::Enum2::<
-                    self::_puroro_root::full_coverage2::Enum,
-                >,
+            enum_optional: <self::_pinternal::field_type::OptionalNumericalField::<
+                self::_root::full_coverage2::Enum,
+                self::_pinternal::tags::Enum2::<self::_root::full_coverage2::Enum>,
                 9usize,
             > as ::std::clone::Clone>::clone(&self.enum_optional),
-            enum_repeated: <self::_puroro::internal::field_type::RepeatedNumericalField::<
-                self::_puroro_root::full_coverage2::Enum,
-                self::_puroro::internal::tags::Enum2::<
-                    self::_puroro_root::full_coverage2::Enum,
-                >,
+            enum_repeated: <self::_pinternal::field_type::RepeatedNumericalField::<
+                self::_root::full_coverage2::Enum,
+                self::_pinternal::tags::Enum2::<self::_root::full_coverage2::Enum>,
             > as ::std::clone::Clone>::clone(&self.enum_repeated),
-            submsg_required: <self::_puroro::internal::field_type::SingularHeapMessageField::<
-                self::_puroro_root::full_coverage2::msg::Submsg,
+            submsg_required: <self::_pinternal::field_type::SingularHeapMessageField::<
+                self::_root::full_coverage2::msg::Submsg,
             > as ::std::clone::Clone>::clone(&self.submsg_required),
-            submsg_optional: <self::_puroro::internal::field_type::SingularHeapMessageField::<
-                self::_puroro_root::full_coverage2::msg::Submsg,
+            submsg_optional: <self::_pinternal::field_type::SingularHeapMessageField::<
+                self::_root::full_coverage2::msg::Submsg,
             > as ::std::clone::Clone>::clone(&self.submsg_optional),
-            submsg_repeated: <self::_puroro::internal::field_type::RepeatedMessageField::<
-                self::_puroro_root::full_coverage2::msg::Submsg,
+            submsg_repeated: <self::_pinternal::field_type::RepeatedMessageField::<
+                self::_root::full_coverage2::msg::Submsg,
             > as ::std::clone::Clone>::clone(&self.submsg_repeated),
-            i64_required: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            i64_required: <self::_pinternal::field_type::OptionalNumericalField::<
                 i64,
-                self::_puroro::internal::tags::Int64,
+                self::_pinternal::tags::Int64,
                 10usize,
             > as ::std::clone::Clone>::clone(&self.i64_required),
-            i64_optional: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            i64_optional: <self::_pinternal::field_type::OptionalNumericalField::<
                 i64,
-                self::_puroro::internal::tags::Int64,
+                self::_pinternal::tags::Int64,
                 11usize,
             > as ::std::clone::Clone>::clone(&self.i64_optional),
-            i64_repeated: <self::_puroro::internal::field_type::RepeatedNumericalField::<
+            i64_repeated: <self::_pinternal::field_type::RepeatedNumericalField::<
                 i64,
-                self::_puroro::internal::tags::Int64,
+                self::_pinternal::tags::Int64,
             > as ::std::clone::Clone>::clone(&self.i64_repeated),
-            u32_required: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            u32_required: <self::_pinternal::field_type::OptionalNumericalField::<
                 u32,
-                self::_puroro::internal::tags::UInt32,
+                self::_pinternal::tags::UInt32,
                 12usize,
             > as ::std::clone::Clone>::clone(&self.u32_required),
-            u32_optional: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            u32_optional: <self::_pinternal::field_type::OptionalNumericalField::<
                 u32,
-                self::_puroro::internal::tags::UInt32,
+                self::_pinternal::tags::UInt32,
                 13usize,
             > as ::std::clone::Clone>::clone(&self.u32_optional),
-            u32_repeated: <self::_puroro::internal::field_type::RepeatedNumericalField::<
+            u32_repeated: <self::_pinternal::field_type::RepeatedNumericalField::<
                 u32,
-                self::_puroro::internal::tags::UInt32,
+                self::_pinternal::tags::UInt32,
             > as ::std::clone::Clone>::clone(&self.u32_repeated),
-            u64_required: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            u64_required: <self::_pinternal::field_type::OptionalNumericalField::<
                 u64,
-                self::_puroro::internal::tags::UInt64,
+                self::_pinternal::tags::UInt64,
                 14usize,
             > as ::std::clone::Clone>::clone(&self.u64_required),
-            u64_optional: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            u64_optional: <self::_pinternal::field_type::OptionalNumericalField::<
                 u64,
-                self::_puroro::internal::tags::UInt64,
+                self::_pinternal::tags::UInt64,
                 15usize,
             > as ::std::clone::Clone>::clone(&self.u64_optional),
-            u64_repeated: <self::_puroro::internal::field_type::RepeatedNumericalField::<
+            u64_repeated: <self::_pinternal::field_type::RepeatedNumericalField::<
                 u64,
-                self::_puroro::internal::tags::UInt64,
+                self::_pinternal::tags::UInt64,
             > as ::std::clone::Clone>::clone(&self.u64_repeated),
-            s32_required: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            s32_required: <self::_pinternal::field_type::OptionalNumericalField::<
                 i32,
-                self::_puroro::internal::tags::SInt32,
+                self::_pinternal::tags::SInt32,
                 16usize,
             > as ::std::clone::Clone>::clone(&self.s32_required),
-            s32_optional: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            s32_optional: <self::_pinternal::field_type::OptionalNumericalField::<
                 i32,
-                self::_puroro::internal::tags::SInt32,
+                self::_pinternal::tags::SInt32,
                 17usize,
             > as ::std::clone::Clone>::clone(&self.s32_optional),
-            s32_repeated: <self::_puroro::internal::field_type::RepeatedNumericalField::<
+            s32_repeated: <self::_pinternal::field_type::RepeatedNumericalField::<
                 i32,
-                self::_puroro::internal::tags::SInt32,
+                self::_pinternal::tags::SInt32,
             > as ::std::clone::Clone>::clone(&self.s32_repeated),
-            s64_required: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            s64_required: <self::_pinternal::field_type::OptionalNumericalField::<
                 i64,
-                self::_puroro::internal::tags::SInt64,
+                self::_pinternal::tags::SInt64,
                 18usize,
             > as ::std::clone::Clone>::clone(&self.s64_required),
-            s64_optional: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            s64_optional: <self::_pinternal::field_type::OptionalNumericalField::<
                 i64,
-                self::_puroro::internal::tags::SInt64,
+                self::_pinternal::tags::SInt64,
                 19usize,
             > as ::std::clone::Clone>::clone(&self.s64_optional),
-            s64_repeated: <self::_puroro::internal::field_type::RepeatedNumericalField::<
+            s64_repeated: <self::_pinternal::field_type::RepeatedNumericalField::<
                 i64,
-                self::_puroro::internal::tags::SInt64,
+                self::_pinternal::tags::SInt64,
             > as ::std::clone::Clone>::clone(&self.s64_repeated),
-            fixed32_required: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            fixed32_required: <self::_pinternal::field_type::OptionalNumericalField::<
                 u32,
-                self::_puroro::internal::tags::Fixed32,
+                self::_pinternal::tags::Fixed32,
                 20usize,
             > as ::std::clone::Clone>::clone(&self.fixed32_required),
-            fixed32_optional: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            fixed32_optional: <self::_pinternal::field_type::OptionalNumericalField::<
                 u32,
-                self::_puroro::internal::tags::Fixed32,
+                self::_pinternal::tags::Fixed32,
                 21usize,
             > as ::std::clone::Clone>::clone(&self.fixed32_optional),
-            fixed32_repeated: <self::_puroro::internal::field_type::RepeatedNumericalField::<
+            fixed32_repeated: <self::_pinternal::field_type::RepeatedNumericalField::<
                 u32,
-                self::_puroro::internal::tags::Fixed32,
+                self::_pinternal::tags::Fixed32,
             > as ::std::clone::Clone>::clone(&self.fixed32_repeated),
-            fixed64_required: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            fixed64_required: <self::_pinternal::field_type::OptionalNumericalField::<
                 u64,
-                self::_puroro::internal::tags::Fixed64,
+                self::_pinternal::tags::Fixed64,
                 22usize,
             > as ::std::clone::Clone>::clone(&self.fixed64_required),
-            fixed64_optional: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            fixed64_optional: <self::_pinternal::field_type::OptionalNumericalField::<
                 u64,
-                self::_puroro::internal::tags::Fixed64,
+                self::_pinternal::tags::Fixed64,
                 23usize,
             > as ::std::clone::Clone>::clone(&self.fixed64_optional),
-            fixed64_repeated: <self::_puroro::internal::field_type::RepeatedNumericalField::<
+            fixed64_repeated: <self::_pinternal::field_type::RepeatedNumericalField::<
                 u64,
-                self::_puroro::internal::tags::Fixed64,
+                self::_pinternal::tags::Fixed64,
             > as ::std::clone::Clone>::clone(&self.fixed64_repeated),
-            sfixed32_required: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            sfixed32_required: <self::_pinternal::field_type::OptionalNumericalField::<
                 i32,
-                self::_puroro::internal::tags::SFixed32,
+                self::_pinternal::tags::SFixed32,
                 24usize,
             > as ::std::clone::Clone>::clone(&self.sfixed32_required),
-            sfixed32_optional: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            sfixed32_optional: <self::_pinternal::field_type::OptionalNumericalField::<
                 i32,
-                self::_puroro::internal::tags::SFixed32,
+                self::_pinternal::tags::SFixed32,
                 25usize,
             > as ::std::clone::Clone>::clone(&self.sfixed32_optional),
-            sfixed32_repeated: <self::_puroro::internal::field_type::RepeatedNumericalField::<
+            sfixed32_repeated: <self::_pinternal::field_type::RepeatedNumericalField::<
                 i32,
-                self::_puroro::internal::tags::SFixed32,
+                self::_pinternal::tags::SFixed32,
             > as ::std::clone::Clone>::clone(&self.sfixed32_repeated),
-            sfixed64_required: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            sfixed64_required: <self::_pinternal::field_type::OptionalNumericalField::<
                 i64,
-                self::_puroro::internal::tags::SFixed64,
+                self::_pinternal::tags::SFixed64,
                 26usize,
             > as ::std::clone::Clone>::clone(&self.sfixed64_required),
-            sfixed64_optional: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            sfixed64_optional: <self::_pinternal::field_type::OptionalNumericalField::<
                 i64,
-                self::_puroro::internal::tags::SFixed64,
+                self::_pinternal::tags::SFixed64,
                 27usize,
             > as ::std::clone::Clone>::clone(&self.sfixed64_optional),
-            sfixed64_repeated: <self::_puroro::internal::field_type::RepeatedNumericalField::<
+            sfixed64_repeated: <self::_pinternal::field_type::RepeatedNumericalField::<
                 i64,
-                self::_puroro::internal::tags::SFixed64,
+                self::_pinternal::tags::SFixed64,
             > as ::std::clone::Clone>::clone(&self.sfixed64_repeated),
-            f64_required: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            f64_required: <self::_pinternal::field_type::OptionalNumericalField::<
                 f64,
-                self::_puroro::internal::tags::Double,
+                self::_pinternal::tags::Double,
                 28usize,
             > as ::std::clone::Clone>::clone(&self.f64_required),
-            f64_optional: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            f64_optional: <self::_pinternal::field_type::OptionalNumericalField::<
                 f64,
-                self::_puroro::internal::tags::Double,
+                self::_pinternal::tags::Double,
                 29usize,
             > as ::std::clone::Clone>::clone(&self.f64_optional),
-            f64_repeated: <self::_puroro::internal::field_type::RepeatedNumericalField::<
+            f64_repeated: <self::_pinternal::field_type::RepeatedNumericalField::<
                 f64,
-                self::_puroro::internal::tags::Double,
+                self::_pinternal::tags::Double,
             > as ::std::clone::Clone>::clone(&self.f64_repeated),
             _bitfield: ::std::clone::Clone::clone(&self._bitfield),
         }
@@ -3539,7 +3501,7 @@ impl ::std::clone::Clone for Msg {
 impl ::std::ops::Drop for Msg {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for Msg {
@@ -3602,7 +3564,7 @@ impl ::std::fmt::Debug for Msg {
 impl ::std::cmp::PartialEq for Msg {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         true && self.i32_required_opt() == rhs.i32_required_opt()
             && self.i32_optional_opt() == rhs.i32_optional_opt()
             && self.i32_repeated() == rhs.i32_repeated()

--- a/tests-pb/src/full_coverage2/msg.rs
+++ b/tests-pb/src/full_coverage2/msg.rs
@@ -1,31 +1,35 @@
-mod _puroro_root {
+mod _root {
     #[allow(unused)]
-    pub(crate) use super::super::_puroro_root::*;
+    pub(crate) use super::super::_root::*;
 }
 mod _puroro {
     #[allow(unused)]
     pub(crate) use ::puroro::*;
 }
+mod _pinternal {
+    #[allow(unused)]
+    pub(crate) use ::puroro::internal::*;
+}
 #[derive(::std::default::Default)]
 pub struct Submsg {
-    i32_required: self::_puroro::internal::field_type::OptionalNumericalField::<
+    i32_required: self::_pinternal::field_type::OptionalNumericalField::<
         i32,
-        self::_puroro::internal::tags::Int32,
+        self::_pinternal::tags::Int32,
         0usize,
     >,
-    i64_required: self::_puroro::internal::field_type::OptionalNumericalField::<
+    i64_required: self::_pinternal::field_type::OptionalNumericalField::<
         i64,
-        self::_puroro::internal::tags::Int64,
+        self::_pinternal::tags::Int64,
         1usize,
     >,
-    _bitfield: self::_puroro::internal::bitvec::BitArray<1usize>,
+    _bitfield: self::_pinternal::bitvec::BitArray<1usize>,
 }
 impl Submsg {
     pub fn i32_required(&self) -> i32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             0usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.i32_required,
@@ -34,18 +38,18 @@ impl Submsg {
         )
     }
     pub fn i32_required_opt(&self) -> ::std::option::Option::<i32> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.i32_required, &self._bitfield)
     }
     pub fn i32_required_mut(&mut self) -> &mut i32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             0usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.i32_required,
@@ -54,27 +58,27 @@ impl Submsg {
         )
     }
     pub fn has_i32_required(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.i32_required, &self._bitfield)
             .is_some()
     }
     pub fn clear_i32_required(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             0usize,
         > as NonRepeatedFieldType>::clear(&mut self.i32_required, &mut self._bitfield)
     }
     pub fn i64_required(&self) -> i64 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i64,
-            self::_puroro::internal::tags::Int64,
+            self::_pinternal::tags::Int64,
             1usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.i64_required,
@@ -83,18 +87,18 @@ impl Submsg {
         )
     }
     pub fn i64_required_opt(&self) -> ::std::option::Option::<i64> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i64,
-            self::_puroro::internal::tags::Int64,
+            self::_pinternal::tags::Int64,
             1usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.i64_required, &self._bitfield)
     }
     pub fn i64_required_mut(&mut self) -> &mut i64 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i64,
-            self::_puroro::internal::tags::Int64,
+            self::_pinternal::tags::Int64,
             1usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.i64_required,
@@ -103,19 +107,19 @@ impl Submsg {
         )
     }
     pub fn has_i64_required(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i64,
-            self::_puroro::internal::tags::Int64,
+            self::_pinternal::tags::Int64,
             1usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.i64_required, &self._bitfield)
             .is_some()
     }
     pub fn clear_i64_required(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i64,
-            self::_puroro::internal::tags::Int64,
+            self::_pinternal::tags::Int64,
             1usize,
         > as NonRepeatedFieldType>::clear(&mut self.i64_required, &mut self._bitfield)
     }
@@ -132,29 +136,29 @@ impl self::_puroro::Message for Submsg {
         &mut self,
         mut iter: I,
     ) -> self::_puroro::Result<()> {
-        use self::_puroro::internal::ser::FieldData;
+        use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 1i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         i32,
-                        self::_puroro::internal::tags::Int32,
+                        self::_pinternal::tags::Int32,
                         0usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.i32_required,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 101i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         i64,
-                        self::_puroro::internal::tags::Int64,
+                        self::_pinternal::tags::Int64,
                         1usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.i64_required,
                         &mut self._bitfield,
                         field_data,
@@ -171,22 +175,22 @@ impl self::_puroro::Message for Submsg {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::oneof_type::OneofUnion as _;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             0usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.i32_required,
             &self._bitfield,
             1i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i64,
-            self::_puroro::internal::tags::Int64,
+            self::_pinternal::tags::Int64,
             1usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.i64_required,
             &self._bitfield,
             101i32,
@@ -198,14 +202,14 @@ impl self::_puroro::Message for Submsg {
 impl ::std::clone::Clone for Submsg {
     fn clone(&self) -> Self {
         Self {
-            i32_required: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            i32_required: <self::_pinternal::field_type::OptionalNumericalField::<
                 i32,
-                self::_puroro::internal::tags::Int32,
+                self::_pinternal::tags::Int32,
                 0usize,
             > as ::std::clone::Clone>::clone(&self.i32_required),
-            i64_required: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            i64_required: <self::_pinternal::field_type::OptionalNumericalField::<
                 i64,
-                self::_puroro::internal::tags::Int64,
+                self::_pinternal::tags::Int64,
                 1usize,
             > as ::std::clone::Clone>::clone(&self.i64_required),
             _bitfield: ::std::clone::Clone::clone(&self._bitfield),
@@ -215,7 +219,7 @@ impl ::std::clone::Clone for Submsg {
 impl ::std::ops::Drop for Submsg {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for Submsg {
@@ -232,7 +236,7 @@ impl ::std::fmt::Debug for Submsg {
 impl ::std::cmp::PartialEq for Submsg {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         true && self.i32_required_opt() == rhs.i32_required_opt()
             && self.i64_required_opt() == rhs.i64_required_opt()
     }

--- a/tests-pb/src/full_coverage2/msg.rs
+++ b/tests-pb/src/full_coverage2/msg.rs
@@ -12,22 +12,22 @@ mod _pinternal {
 }
 #[derive(::std::default::Default)]
 pub struct Submsg {
-    i32_required: self::_pinternal::field_type::OptionalNumericalField::<
+    i32_required: self::_pinternal::OptionalNumericalField::<
         i32,
         self::_pinternal::tags::Int32,
         0usize,
     >,
-    i64_required: self::_pinternal::field_type::OptionalNumericalField::<
+    i64_required: self::_pinternal::OptionalNumericalField::<
         i64,
         self::_pinternal::tags::Int64,
         1usize,
     >,
-    _bitfield: self::_pinternal::bitvec::BitArray<1usize>,
+    _bitfield: self::_pinternal::BitArray<1usize>,
 }
 impl Submsg {
     pub fn i32_required(&self) -> i32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             0usize,
@@ -38,16 +38,16 @@ impl Submsg {
         )
     }
     pub fn i32_required_opt(&self) -> ::std::option::Option::<i32> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.i32_required, &self._bitfield)
     }
     pub fn i32_required_mut(&mut self) -> &mut i32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             0usize,
@@ -58,8 +58,8 @@ impl Submsg {
         )
     }
     pub fn has_i32_required(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             0usize,
@@ -67,16 +67,16 @@ impl Submsg {
             .is_some()
     }
     pub fn clear_i32_required(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             0usize,
         > as NonRepeatedFieldType>::clear(&mut self.i32_required, &mut self._bitfield)
     }
     pub fn i64_required(&self) -> i64 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i64,
             self::_pinternal::tags::Int64,
             1usize,
@@ -87,16 +87,16 @@ impl Submsg {
         )
     }
     pub fn i64_required_opt(&self) -> ::std::option::Option::<i64> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i64,
             self::_pinternal::tags::Int64,
             1usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.i64_required, &self._bitfield)
     }
     pub fn i64_required_mut(&mut self) -> &mut i64 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i64,
             self::_pinternal::tags::Int64,
             1usize,
@@ -107,8 +107,8 @@ impl Submsg {
         )
     }
     pub fn has_i64_required(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i64,
             self::_pinternal::tags::Int64,
             1usize,
@@ -116,8 +116,8 @@ impl Submsg {
             .is_some()
     }
     pub fn clear_i64_required(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i64,
             self::_pinternal::tags::Int64,
             1usize,
@@ -138,27 +138,27 @@ impl self::_puroro::Message for Submsg {
     ) -> self::_puroro::Result<()> {
         use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 1i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         i32,
                         self::_pinternal::tags::Int32,
                         0usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.i32_required,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 101i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         i64,
                         self::_pinternal::tags::Int64,
                         1usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.i64_required,
                         &mut self._bitfield,
                         field_data,
@@ -175,22 +175,22 @@ impl self::_puroro::Message for Submsg {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::OneofUnion as _;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             0usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.i32_required,
             &self._bitfield,
             1i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        <self::_pinternal::OptionalNumericalField::<
             i64,
             self::_pinternal::tags::Int64,
             1usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.i64_required,
             &self._bitfield,
             101i32,
@@ -202,12 +202,12 @@ impl self::_puroro::Message for Submsg {
 impl ::std::clone::Clone for Submsg {
     fn clone(&self) -> Self {
         Self {
-            i32_required: <self::_pinternal::field_type::OptionalNumericalField::<
+            i32_required: <self::_pinternal::OptionalNumericalField::<
                 i32,
                 self::_pinternal::tags::Int32,
                 0usize,
             > as ::std::clone::Clone>::clone(&self.i32_required),
-            i64_required: <self::_pinternal::field_type::OptionalNumericalField::<
+            i64_required: <self::_pinternal::OptionalNumericalField::<
                 i64,
                 self::_pinternal::tags::Int64,
                 1usize,
@@ -219,7 +219,7 @@ impl ::std::clone::Clone for Submsg {
 impl ::std::ops::Drop for Submsg {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for Submsg {
@@ -236,7 +236,7 @@ impl ::std::fmt::Debug for Submsg {
 impl ::std::cmp::PartialEq for Submsg {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         true && self.i32_required_opt() == rhs.i32_required_opt()
             && self.i64_required_opt() == rhs.i64_required_opt()
     }

--- a/tests-pb/src/full_coverage3.rs
+++ b/tests-pb/src/full_coverage3.rs
@@ -1,226 +1,230 @@
-mod _puroro_root {
+mod _root {
     #[allow(unused)]
-    pub(crate) use super::super::_puroro_root::*;
+    pub(crate) use super::super::_root::*;
 }
 mod _puroro {
     #[allow(unused)]
     pub(crate) use ::puroro::*;
 }
+mod _pinternal {
+    #[allow(unused)]
+    pub(crate) use ::puroro::internal::*;
+}
 pub mod msg;
 #[derive(::std::default::Default)]
 pub struct Msg {
-    i32_unlabeled: self::_puroro::internal::field_type::SingularNumericalField::<
+    i32_unlabeled: self::_pinternal::field_type::SingularNumericalField::<
         i32,
-        self::_puroro::internal::tags::Int32,
+        self::_pinternal::tags::Int32,
     >,
-    i32_optional: self::_puroro::internal::field_type::OptionalNumericalField::<
+    i32_optional: self::_pinternal::field_type::OptionalNumericalField::<
         i32,
-        self::_puroro::internal::tags::Int32,
+        self::_pinternal::tags::Int32,
         0usize,
     >,
-    i32_repeated: self::_puroro::internal::field_type::RepeatedNumericalField::<
+    i32_repeated: self::_pinternal::field_type::RepeatedNumericalField::<
         i32,
-        self::_puroro::internal::tags::Int32,
+        self::_pinternal::tags::Int32,
     >,
-    float_unlabeled: self::_puroro::internal::field_type::SingularNumericalField::<
+    float_unlabeled: self::_pinternal::field_type::SingularNumericalField::<
         f32,
-        self::_puroro::internal::tags::Float,
+        self::_pinternal::tags::Float,
     >,
-    float_optional: self::_puroro::internal::field_type::OptionalNumericalField::<
+    float_optional: self::_pinternal::field_type::OptionalNumericalField::<
         f32,
-        self::_puroro::internal::tags::Float,
+        self::_pinternal::tags::Float,
         1usize,
     >,
-    float_repeated: self::_puroro::internal::field_type::RepeatedNumericalField::<
+    float_repeated: self::_pinternal::field_type::RepeatedNumericalField::<
         f32,
-        self::_puroro::internal::tags::Float,
+        self::_pinternal::tags::Float,
     >,
-    bytes_unlabeled: self::_puroro::internal::field_type::SingularUnsizedField::<
+    bytes_unlabeled: self::_pinternal::field_type::SingularUnsizedField::<
         ::std::vec::Vec<u8>,
-        self::_puroro::internal::tags::Bytes,
+        self::_pinternal::tags::Bytes,
     >,
-    bytes_optional: self::_puroro::internal::field_type::OptionalUnsizedField::<
+    bytes_optional: self::_pinternal::field_type::OptionalUnsizedField::<
         ::std::vec::Vec<u8>,
-        self::_puroro::internal::tags::Bytes,
+        self::_pinternal::tags::Bytes,
         2usize,
     >,
-    bytes_repeated: self::_puroro::internal::field_type::RepeatedUnsizedField::<
+    bytes_repeated: self::_pinternal::field_type::RepeatedUnsizedField::<
         ::std::vec::Vec<u8>,
-        self::_puroro::internal::tags::Bytes,
+        self::_pinternal::tags::Bytes,
     >,
-    string_unlabeled: self::_puroro::internal::field_type::SingularUnsizedField::<
+    string_unlabeled: self::_pinternal::field_type::SingularUnsizedField::<
         ::std::string::String,
-        self::_puroro::internal::tags::String,
+        self::_pinternal::tags::String,
     >,
-    string_optional: self::_puroro::internal::field_type::OptionalUnsizedField::<
+    string_optional: self::_pinternal::field_type::OptionalUnsizedField::<
         ::std::string::String,
-        self::_puroro::internal::tags::String,
+        self::_pinternal::tags::String,
         3usize,
     >,
-    string_repeated: self::_puroro::internal::field_type::RepeatedUnsizedField::<
+    string_repeated: self::_pinternal::field_type::RepeatedUnsizedField::<
         ::std::string::String,
-        self::_puroro::internal::tags::String,
+        self::_pinternal::tags::String,
     >,
-    enum_unlabeled: self::_puroro::internal::field_type::SingularNumericalField::<
-        self::_puroro_root::full_coverage3::Enum,
-        self::_puroro::internal::tags::Enum3::<self::_puroro_root::full_coverage3::Enum>,
+    enum_unlabeled: self::_pinternal::field_type::SingularNumericalField::<
+        self::_root::full_coverage3::Enum,
+        self::_pinternal::tags::Enum3::<self::_root::full_coverage3::Enum>,
     >,
-    enum_optional: self::_puroro::internal::field_type::OptionalNumericalField::<
-        self::_puroro_root::full_coverage3::Enum,
-        self::_puroro::internal::tags::Enum3::<self::_puroro_root::full_coverage3::Enum>,
+    enum_optional: self::_pinternal::field_type::OptionalNumericalField::<
+        self::_root::full_coverage3::Enum,
+        self::_pinternal::tags::Enum3::<self::_root::full_coverage3::Enum>,
         4usize,
     >,
-    enum_repeated: self::_puroro::internal::field_type::RepeatedNumericalField::<
-        self::_puroro_root::full_coverage3::Enum,
-        self::_puroro::internal::tags::Enum3::<self::_puroro_root::full_coverage3::Enum>,
+    enum_repeated: self::_pinternal::field_type::RepeatedNumericalField::<
+        self::_root::full_coverage3::Enum,
+        self::_pinternal::tags::Enum3::<self::_root::full_coverage3::Enum>,
     >,
-    submsg_unlabeled: self::_puroro::internal::field_type::SingularHeapMessageField::<
-        self::_puroro_root::full_coverage3::msg::Submsg,
+    submsg_unlabeled: self::_pinternal::field_type::SingularHeapMessageField::<
+        self::_root::full_coverage3::msg::Submsg,
     >,
-    submsg_optional: self::_puroro::internal::field_type::SingularHeapMessageField::<
-        self::_puroro_root::full_coverage3::msg::Submsg,
+    submsg_optional: self::_pinternal::field_type::SingularHeapMessageField::<
+        self::_root::full_coverage3::msg::Submsg,
     >,
-    submsg_repeated: self::_puroro::internal::field_type::RepeatedMessageField::<
-        self::_puroro_root::full_coverage3::msg::Submsg,
+    submsg_repeated: self::_pinternal::field_type::RepeatedMessageField::<
+        self::_root::full_coverage3::msg::Submsg,
     >,
-    i64_unlabeled: self::_puroro::internal::field_type::SingularNumericalField::<
+    i64_unlabeled: self::_pinternal::field_type::SingularNumericalField::<
         i64,
-        self::_puroro::internal::tags::Int64,
+        self::_pinternal::tags::Int64,
     >,
-    i64_optional: self::_puroro::internal::field_type::OptionalNumericalField::<
+    i64_optional: self::_pinternal::field_type::OptionalNumericalField::<
         i64,
-        self::_puroro::internal::tags::Int64,
+        self::_pinternal::tags::Int64,
         5usize,
     >,
-    i64_repeated: self::_puroro::internal::field_type::RepeatedNumericalField::<
+    i64_repeated: self::_pinternal::field_type::RepeatedNumericalField::<
         i64,
-        self::_puroro::internal::tags::Int64,
+        self::_pinternal::tags::Int64,
     >,
-    u32_unlabeled: self::_puroro::internal::field_type::SingularNumericalField::<
+    u32_unlabeled: self::_pinternal::field_type::SingularNumericalField::<
         u32,
-        self::_puroro::internal::tags::UInt32,
+        self::_pinternal::tags::UInt32,
     >,
-    u32_optional: self::_puroro::internal::field_type::OptionalNumericalField::<
+    u32_optional: self::_pinternal::field_type::OptionalNumericalField::<
         u32,
-        self::_puroro::internal::tags::UInt32,
+        self::_pinternal::tags::UInt32,
         6usize,
     >,
-    u32_repeated: self::_puroro::internal::field_type::RepeatedNumericalField::<
+    u32_repeated: self::_pinternal::field_type::RepeatedNumericalField::<
         u32,
-        self::_puroro::internal::tags::UInt32,
+        self::_pinternal::tags::UInt32,
     >,
-    u64_unlabeled: self::_puroro::internal::field_type::SingularNumericalField::<
+    u64_unlabeled: self::_pinternal::field_type::SingularNumericalField::<
         u64,
-        self::_puroro::internal::tags::UInt64,
+        self::_pinternal::tags::UInt64,
     >,
-    u64_optional: self::_puroro::internal::field_type::OptionalNumericalField::<
+    u64_optional: self::_pinternal::field_type::OptionalNumericalField::<
         u64,
-        self::_puroro::internal::tags::UInt64,
+        self::_pinternal::tags::UInt64,
         7usize,
     >,
-    u64_repeated: self::_puroro::internal::field_type::RepeatedNumericalField::<
+    u64_repeated: self::_pinternal::field_type::RepeatedNumericalField::<
         u64,
-        self::_puroro::internal::tags::UInt64,
+        self::_pinternal::tags::UInt64,
     >,
-    s32_unlabeled: self::_puroro::internal::field_type::SingularNumericalField::<
+    s32_unlabeled: self::_pinternal::field_type::SingularNumericalField::<
         i32,
-        self::_puroro::internal::tags::SInt32,
+        self::_pinternal::tags::SInt32,
     >,
-    s32_optional: self::_puroro::internal::field_type::OptionalNumericalField::<
+    s32_optional: self::_pinternal::field_type::OptionalNumericalField::<
         i32,
-        self::_puroro::internal::tags::SInt32,
+        self::_pinternal::tags::SInt32,
         8usize,
     >,
-    s32_repeated: self::_puroro::internal::field_type::RepeatedNumericalField::<
+    s32_repeated: self::_pinternal::field_type::RepeatedNumericalField::<
         i32,
-        self::_puroro::internal::tags::SInt32,
+        self::_pinternal::tags::SInt32,
     >,
-    s64_unlabeled: self::_puroro::internal::field_type::SingularNumericalField::<
+    s64_unlabeled: self::_pinternal::field_type::SingularNumericalField::<
         i64,
-        self::_puroro::internal::tags::SInt64,
+        self::_pinternal::tags::SInt64,
     >,
-    s64_optional: self::_puroro::internal::field_type::OptionalNumericalField::<
+    s64_optional: self::_pinternal::field_type::OptionalNumericalField::<
         i64,
-        self::_puroro::internal::tags::SInt64,
+        self::_pinternal::tags::SInt64,
         9usize,
     >,
-    s64_repeated: self::_puroro::internal::field_type::RepeatedNumericalField::<
+    s64_repeated: self::_pinternal::field_type::RepeatedNumericalField::<
         i64,
-        self::_puroro::internal::tags::SInt64,
+        self::_pinternal::tags::SInt64,
     >,
-    fixed32_unlabeled: self::_puroro::internal::field_type::SingularNumericalField::<
+    fixed32_unlabeled: self::_pinternal::field_type::SingularNumericalField::<
         u32,
-        self::_puroro::internal::tags::Fixed32,
+        self::_pinternal::tags::Fixed32,
     >,
-    fixed32_optional: self::_puroro::internal::field_type::OptionalNumericalField::<
+    fixed32_optional: self::_pinternal::field_type::OptionalNumericalField::<
         u32,
-        self::_puroro::internal::tags::Fixed32,
+        self::_pinternal::tags::Fixed32,
         10usize,
     >,
-    fixed32_repeated: self::_puroro::internal::field_type::RepeatedNumericalField::<
+    fixed32_repeated: self::_pinternal::field_type::RepeatedNumericalField::<
         u32,
-        self::_puroro::internal::tags::Fixed32,
+        self::_pinternal::tags::Fixed32,
     >,
-    fixed64_unlabeled: self::_puroro::internal::field_type::SingularNumericalField::<
+    fixed64_unlabeled: self::_pinternal::field_type::SingularNumericalField::<
         u64,
-        self::_puroro::internal::tags::Fixed64,
+        self::_pinternal::tags::Fixed64,
     >,
-    fixed64_optional: self::_puroro::internal::field_type::OptionalNumericalField::<
+    fixed64_optional: self::_pinternal::field_type::OptionalNumericalField::<
         u64,
-        self::_puroro::internal::tags::Fixed64,
+        self::_pinternal::tags::Fixed64,
         11usize,
     >,
-    fixed64_repeated: self::_puroro::internal::field_type::RepeatedNumericalField::<
+    fixed64_repeated: self::_pinternal::field_type::RepeatedNumericalField::<
         u64,
-        self::_puroro::internal::tags::Fixed64,
+        self::_pinternal::tags::Fixed64,
     >,
-    sfixed32_unlabeled: self::_puroro::internal::field_type::SingularNumericalField::<
+    sfixed32_unlabeled: self::_pinternal::field_type::SingularNumericalField::<
         i32,
-        self::_puroro::internal::tags::SFixed32,
+        self::_pinternal::tags::SFixed32,
     >,
-    sfixed32_optional: self::_puroro::internal::field_type::OptionalNumericalField::<
+    sfixed32_optional: self::_pinternal::field_type::OptionalNumericalField::<
         i32,
-        self::_puroro::internal::tags::SFixed32,
+        self::_pinternal::tags::SFixed32,
         12usize,
     >,
-    sfixed32_repeated: self::_puroro::internal::field_type::RepeatedNumericalField::<
+    sfixed32_repeated: self::_pinternal::field_type::RepeatedNumericalField::<
         i32,
-        self::_puroro::internal::tags::SFixed32,
+        self::_pinternal::tags::SFixed32,
     >,
-    sfixed64_unlabeled: self::_puroro::internal::field_type::SingularNumericalField::<
+    sfixed64_unlabeled: self::_pinternal::field_type::SingularNumericalField::<
         i64,
-        self::_puroro::internal::tags::SFixed64,
+        self::_pinternal::tags::SFixed64,
     >,
-    sfixed64_optional: self::_puroro::internal::field_type::OptionalNumericalField::<
+    sfixed64_optional: self::_pinternal::field_type::OptionalNumericalField::<
         i64,
-        self::_puroro::internal::tags::SFixed64,
+        self::_pinternal::tags::SFixed64,
         13usize,
     >,
-    sfixed64_repeated: self::_puroro::internal::field_type::RepeatedNumericalField::<
+    sfixed64_repeated: self::_pinternal::field_type::RepeatedNumericalField::<
         i64,
-        self::_puroro::internal::tags::SFixed64,
+        self::_pinternal::tags::SFixed64,
     >,
-    f64_unlabeled: self::_puroro::internal::field_type::SingularNumericalField::<
+    f64_unlabeled: self::_pinternal::field_type::SingularNumericalField::<
         f64,
-        self::_puroro::internal::tags::Double,
+        self::_pinternal::tags::Double,
     >,
-    f64_optional: self::_puroro::internal::field_type::OptionalNumericalField::<
+    f64_optional: self::_pinternal::field_type::OptionalNumericalField::<
         f64,
-        self::_puroro::internal::tags::Double,
+        self::_pinternal::tags::Double,
         14usize,
     >,
-    f64_repeated: self::_puroro::internal::field_type::RepeatedNumericalField::<
+    f64_repeated: self::_pinternal::field_type::RepeatedNumericalField::<
         f64,
-        self::_puroro::internal::tags::Double,
+        self::_pinternal::tags::Double,
     >,
-    _bitfield: self::_puroro::internal::bitvec::BitArray<1usize>,
+    _bitfield: self::_pinternal::bitvec::BitArray<1usize>,
 }
 impl Msg {
     pub fn i32_unlabeled(&self) -> i32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.i32_unlabeled,
             &self._bitfield,
@@ -228,17 +232,17 @@ impl Msg {
         )
     }
     pub fn i32_unlabeled_opt(&self) -> ::std::option::Option::<i32> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
         > as NonRepeatedFieldType>::get_field_opt(&self.i32_unlabeled, &self._bitfield)
     }
     pub fn i32_unlabeled_mut(&mut self) -> &mut i32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.i32_unlabeled,
             &mut self._bitfield,
@@ -246,25 +250,25 @@ impl Msg {
         )
     }
     pub fn has_i32_unlabeled(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
         > as NonRepeatedFieldType>::get_field_opt(&self.i32_unlabeled, &self._bitfield)
             .is_some()
     }
     pub fn clear_i32_unlabeled(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
         > as NonRepeatedFieldType>::clear(&mut self.i32_unlabeled, &mut self._bitfield)
     }
     pub fn i32_optional(&self) -> i32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             0usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.i32_optional,
@@ -273,18 +277,18 @@ impl Msg {
         )
     }
     pub fn i32_optional_opt(&self) -> ::std::option::Option::<i32> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.i32_optional, &self._bitfield)
     }
     pub fn i32_optional_mut(&mut self) -> &mut i32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             0usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.i32_optional,
@@ -293,51 +297,51 @@ impl Msg {
         )
     }
     pub fn has_i32_optional(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.i32_optional, &self._bitfield)
             .is_some()
     }
     pub fn clear_i32_optional(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             0usize,
         > as NonRepeatedFieldType>::clear(&mut self.i32_optional, &mut self._bitfield)
     }
     pub fn i32_repeated(&self) -> &[i32] {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
         > as RepeatedFieldType>::get_field(&self.i32_repeated, &self._bitfield)
     }
     pub fn i32_repeated_mut(&mut self) -> &mut ::std::vec::Vec::<i32> {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
         > as RepeatedFieldType>::get_field_mut(
             &mut self.i32_repeated,
             &mut self._bitfield,
         )
     }
     pub fn clear_i32_repeated(&mut self) {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
         > as RepeatedFieldType>::clear(&mut self.i32_repeated, &mut self._bitfield)
     }
     pub fn float_unlabeled(&self) -> f32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             f32,
-            self::_puroro::internal::tags::Float,
+            self::_pinternal::tags::Float,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.float_unlabeled,
             &self._bitfield,
@@ -345,17 +349,17 @@ impl Msg {
         )
     }
     pub fn float_unlabeled_opt(&self) -> ::std::option::Option::<f32> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             f32,
-            self::_puroro::internal::tags::Float,
+            self::_pinternal::tags::Float,
         > as NonRepeatedFieldType>::get_field_opt(&self.float_unlabeled, &self._bitfield)
     }
     pub fn float_unlabeled_mut(&mut self) -> &mut f32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             f32,
-            self::_puroro::internal::tags::Float,
+            self::_pinternal::tags::Float,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.float_unlabeled,
             &mut self._bitfield,
@@ -363,25 +367,25 @@ impl Msg {
         )
     }
     pub fn has_float_unlabeled(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             f32,
-            self::_puroro::internal::tags::Float,
+            self::_pinternal::tags::Float,
         > as NonRepeatedFieldType>::get_field_opt(&self.float_unlabeled, &self._bitfield)
             .is_some()
     }
     pub fn clear_float_unlabeled(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             f32,
-            self::_puroro::internal::tags::Float,
+            self::_pinternal::tags::Float,
         > as NonRepeatedFieldType>::clear(&mut self.float_unlabeled, &mut self._bitfield)
     }
     pub fn float_optional(&self) -> f32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             f32,
-            self::_puroro::internal::tags::Float,
+            self::_pinternal::tags::Float,
             1usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.float_optional,
@@ -390,18 +394,18 @@ impl Msg {
         )
     }
     pub fn float_optional_opt(&self) -> ::std::option::Option::<f32> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             f32,
-            self::_puroro::internal::tags::Float,
+            self::_pinternal::tags::Float,
             1usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.float_optional, &self._bitfield)
     }
     pub fn float_optional_mut(&mut self) -> &mut f32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             f32,
-            self::_puroro::internal::tags::Float,
+            self::_pinternal::tags::Float,
             1usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.float_optional,
@@ -410,51 +414,51 @@ impl Msg {
         )
     }
     pub fn has_float_optional(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             f32,
-            self::_puroro::internal::tags::Float,
+            self::_pinternal::tags::Float,
             1usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.float_optional, &self._bitfield)
             .is_some()
     }
     pub fn clear_float_optional(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             f32,
-            self::_puroro::internal::tags::Float,
+            self::_pinternal::tags::Float,
             1usize,
         > as NonRepeatedFieldType>::clear(&mut self.float_optional, &mut self._bitfield)
     }
     pub fn float_repeated(&self) -> &[f32] {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             f32,
-            self::_puroro::internal::tags::Float,
+            self::_pinternal::tags::Float,
         > as RepeatedFieldType>::get_field(&self.float_repeated, &self._bitfield)
     }
     pub fn float_repeated_mut(&mut self) -> &mut ::std::vec::Vec::<f32> {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             f32,
-            self::_puroro::internal::tags::Float,
+            self::_pinternal::tags::Float,
         > as RepeatedFieldType>::get_field_mut(
             &mut self.float_repeated,
             &mut self._bitfield,
         )
     }
     pub fn clear_float_repeated(&mut self) {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             f32,
-            self::_puroro::internal::tags::Float,
+            self::_pinternal::tags::Float,
         > as RepeatedFieldType>::clear(&mut self.float_repeated, &mut self._bitfield)
     }
     pub fn bytes_unlabeled(&self) -> &[u8] {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularUnsizedField::<
             ::std::vec::Vec<u8>,
-            self::_puroro::internal::tags::Bytes,
+            self::_pinternal::tags::Bytes,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.bytes_unlabeled,
             &self._bitfield,
@@ -462,17 +466,17 @@ impl Msg {
         )
     }
     pub fn bytes_unlabeled_opt(&self) -> ::std::option::Option::<&[u8]> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularUnsizedField::<
             ::std::vec::Vec<u8>,
-            self::_puroro::internal::tags::Bytes,
+            self::_pinternal::tags::Bytes,
         > as NonRepeatedFieldType>::get_field_opt(&self.bytes_unlabeled, &self._bitfield)
     }
     pub fn bytes_unlabeled_mut(&mut self) -> &mut ::std::vec::Vec::<u8> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularUnsizedField::<
             ::std::vec::Vec<u8>,
-            self::_puroro::internal::tags::Bytes,
+            self::_pinternal::tags::Bytes,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.bytes_unlabeled,
             &mut self._bitfield,
@@ -480,25 +484,25 @@ impl Msg {
         )
     }
     pub fn has_bytes_unlabeled(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularUnsizedField::<
             ::std::vec::Vec<u8>,
-            self::_puroro::internal::tags::Bytes,
+            self::_pinternal::tags::Bytes,
         > as NonRepeatedFieldType>::get_field_opt(&self.bytes_unlabeled, &self._bitfield)
             .is_some()
     }
     pub fn clear_bytes_unlabeled(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularUnsizedField::<
             ::std::vec::Vec<u8>,
-            self::_puroro::internal::tags::Bytes,
+            self::_pinternal::tags::Bytes,
         > as NonRepeatedFieldType>::clear(&mut self.bytes_unlabeled, &mut self._bitfield)
     }
     pub fn bytes_optional(&self) -> &[u8] {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::vec::Vec<u8>,
-            self::_puroro::internal::tags::Bytes,
+            self::_pinternal::tags::Bytes,
             2usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.bytes_optional,
@@ -507,18 +511,18 @@ impl Msg {
         )
     }
     pub fn bytes_optional_opt(&self) -> ::std::option::Option::<&[u8]> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::vec::Vec<u8>,
-            self::_puroro::internal::tags::Bytes,
+            self::_pinternal::tags::Bytes,
             2usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.bytes_optional, &self._bitfield)
     }
     pub fn bytes_optional_mut(&mut self) -> &mut ::std::vec::Vec::<u8> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::vec::Vec<u8>,
-            self::_puroro::internal::tags::Bytes,
+            self::_pinternal::tags::Bytes,
             2usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.bytes_optional,
@@ -527,19 +531,19 @@ impl Msg {
         )
     }
     pub fn has_bytes_optional(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::vec::Vec<u8>,
-            self::_puroro::internal::tags::Bytes,
+            self::_pinternal::tags::Bytes,
             2usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.bytes_optional, &self._bitfield)
             .is_some()
     }
     pub fn clear_bytes_optional(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::vec::Vec<u8>,
-            self::_puroro::internal::tags::Bytes,
+            self::_pinternal::tags::Bytes,
             2usize,
         > as NonRepeatedFieldType>::clear(&mut self.bytes_optional, &mut self._bitfield)
     }
@@ -548,34 +552,34 @@ impl Msg {
     ) -> &[impl ::std::ops::Deref::<
         Target = [u8],
     > + ::std::fmt::Debug + ::std::cmp::PartialEq] {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedUnsizedField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedUnsizedField::<
             ::std::vec::Vec<u8>,
-            self::_puroro::internal::tags::Bytes,
+            self::_pinternal::tags::Bytes,
         > as RepeatedFieldType>::get_field(&self.bytes_repeated, &self._bitfield)
     }
     pub fn bytes_repeated_mut(&mut self) -> &mut ::std::vec::Vec::<::std::vec::Vec<u8>> {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedUnsizedField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedUnsizedField::<
             ::std::vec::Vec<u8>,
-            self::_puroro::internal::tags::Bytes,
+            self::_pinternal::tags::Bytes,
         > as RepeatedFieldType>::get_field_mut(
             &mut self.bytes_repeated,
             &mut self._bitfield,
         )
     }
     pub fn clear_bytes_repeated(&mut self) {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedUnsizedField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedUnsizedField::<
             ::std::vec::Vec<u8>,
-            self::_puroro::internal::tags::Bytes,
+            self::_pinternal::tags::Bytes,
         > as RepeatedFieldType>::clear(&mut self.bytes_repeated, &mut self._bitfield)
     }
     pub fn string_unlabeled(&self) -> &str {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.string_unlabeled,
             &self._bitfield,
@@ -583,20 +587,20 @@ impl Msg {
         )
     }
     pub fn string_unlabeled_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
         > as NonRepeatedFieldType>::get_field_opt(
             &self.string_unlabeled,
             &self._bitfield,
         )
     }
     pub fn string_unlabeled_mut(&mut self) -> &mut ::std::string::String {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.string_unlabeled,
             &mut self._bitfield,
@@ -604,10 +608,10 @@ impl Msg {
         )
     }
     pub fn has_string_unlabeled(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
         > as NonRepeatedFieldType>::get_field_opt(
                 &self.string_unlabeled,
                 &self._bitfield,
@@ -615,20 +619,20 @@ impl Msg {
             .is_some()
     }
     pub fn clear_string_unlabeled(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
         > as NonRepeatedFieldType>::clear(
             &mut self.string_unlabeled,
             &mut self._bitfield,
         )
     }
     pub fn string_optional(&self) -> &str {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             3usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.string_optional,
@@ -637,18 +641,18 @@ impl Msg {
         )
     }
     pub fn string_optional_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             3usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.string_optional, &self._bitfield)
     }
     pub fn string_optional_mut(&mut self) -> &mut ::std::string::String {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             3usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.string_optional,
@@ -657,19 +661,19 @@ impl Msg {
         )
     }
     pub fn has_string_optional(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             3usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.string_optional, &self._bitfield)
             .is_some()
     }
     pub fn clear_string_optional(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             3usize,
         > as NonRepeatedFieldType>::clear(&mut self.string_optional, &mut self._bitfield)
     }
@@ -678,38 +682,36 @@ impl Msg {
     ) -> &[impl ::std::ops::Deref::<
         Target = str,
     > + ::std::fmt::Debug + ::std::cmp::PartialEq] {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedUnsizedField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
         > as RepeatedFieldType>::get_field(&self.string_repeated, &self._bitfield)
     }
     pub fn string_repeated_mut(
         &mut self,
     ) -> &mut ::std::vec::Vec::<::std::string::String> {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedUnsizedField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
         > as RepeatedFieldType>::get_field_mut(
             &mut self.string_repeated,
             &mut self._bitfield,
         )
     }
     pub fn clear_string_repeated(&mut self) {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedUnsizedField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
         > as RepeatedFieldType>::clear(&mut self.string_repeated, &mut self._bitfield)
     }
-    pub fn enum_unlabeled(&self) -> self::_puroro_root::full_coverage3::Enum {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
-            self::_puroro_root::full_coverage3::Enum,
-            self::_puroro::internal::tags::Enum3::<
-                self::_puroro_root::full_coverage3::Enum,
-            >,
+    pub fn enum_unlabeled(&self) -> self::_root::full_coverage3::Enum {
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
+            self::_root::full_coverage3::Enum,
+            self::_pinternal::tags::Enum3::<self::_root::full_coverage3::Enum>,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.enum_unlabeled,
             &self._bitfield,
@@ -718,24 +720,18 @@ impl Msg {
     }
     pub fn enum_unlabeled_opt(
         &self,
-    ) -> ::std::option::Option::<self::_puroro_root::full_coverage3::Enum> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
-            self::_puroro_root::full_coverage3::Enum,
-            self::_puroro::internal::tags::Enum3::<
-                self::_puroro_root::full_coverage3::Enum,
-            >,
+    ) -> ::std::option::Option::<self::_root::full_coverage3::Enum> {
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
+            self::_root::full_coverage3::Enum,
+            self::_pinternal::tags::Enum3::<self::_root::full_coverage3::Enum>,
         > as NonRepeatedFieldType>::get_field_opt(&self.enum_unlabeled, &self._bitfield)
     }
-    pub fn enum_unlabeled_mut(
-        &mut self,
-    ) -> &mut self::_puroro_root::full_coverage3::Enum {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
-            self::_puroro_root::full_coverage3::Enum,
-            self::_puroro::internal::tags::Enum3::<
-                self::_puroro_root::full_coverage3::Enum,
-            >,
+    pub fn enum_unlabeled_mut(&mut self) -> &mut self::_root::full_coverage3::Enum {
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
+            self::_root::full_coverage3::Enum,
+            self::_pinternal::tags::Enum3::<self::_root::full_coverage3::Enum>,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.enum_unlabeled,
             &mut self._bitfield,
@@ -743,31 +739,25 @@ impl Msg {
         )
     }
     pub fn has_enum_unlabeled(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
-            self::_puroro_root::full_coverage3::Enum,
-            self::_puroro::internal::tags::Enum3::<
-                self::_puroro_root::full_coverage3::Enum,
-            >,
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
+            self::_root::full_coverage3::Enum,
+            self::_pinternal::tags::Enum3::<self::_root::full_coverage3::Enum>,
         > as NonRepeatedFieldType>::get_field_opt(&self.enum_unlabeled, &self._bitfield)
             .is_some()
     }
     pub fn clear_enum_unlabeled(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
-            self::_puroro_root::full_coverage3::Enum,
-            self::_puroro::internal::tags::Enum3::<
-                self::_puroro_root::full_coverage3::Enum,
-            >,
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
+            self::_root::full_coverage3::Enum,
+            self::_pinternal::tags::Enum3::<self::_root::full_coverage3::Enum>,
         > as NonRepeatedFieldType>::clear(&mut self.enum_unlabeled, &mut self._bitfield)
     }
-    pub fn enum_optional(&self) -> self::_puroro_root::full_coverage3::Enum {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
-            self::_puroro_root::full_coverage3::Enum,
-            self::_puroro::internal::tags::Enum3::<
-                self::_puroro_root::full_coverage3::Enum,
-            >,
+    pub fn enum_optional(&self) -> self::_root::full_coverage3::Enum {
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
+            self::_root::full_coverage3::Enum,
+            self::_pinternal::tags::Enum3::<self::_root::full_coverage3::Enum>,
             4usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.enum_optional,
@@ -777,25 +767,19 @@ impl Msg {
     }
     pub fn enum_optional_opt(
         &self,
-    ) -> ::std::option::Option::<self::_puroro_root::full_coverage3::Enum> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
-            self::_puroro_root::full_coverage3::Enum,
-            self::_puroro::internal::tags::Enum3::<
-                self::_puroro_root::full_coverage3::Enum,
-            >,
+    ) -> ::std::option::Option::<self::_root::full_coverage3::Enum> {
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
+            self::_root::full_coverage3::Enum,
+            self::_pinternal::tags::Enum3::<self::_root::full_coverage3::Enum>,
             4usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.enum_optional, &self._bitfield)
     }
-    pub fn enum_optional_mut(
-        &mut self,
-    ) -> &mut self::_puroro_root::full_coverage3::Enum {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
-            self::_puroro_root::full_coverage3::Enum,
-            self::_puroro::internal::tags::Enum3::<
-                self::_puroro_root::full_coverage3::Enum,
-            >,
+    pub fn enum_optional_mut(&mut self) -> &mut self::_root::full_coverage3::Enum {
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
+            self::_root::full_coverage3::Enum,
+            self::_pinternal::tags::Enum3::<self::_root::full_coverage3::Enum>,
             4usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.enum_optional,
@@ -804,64 +788,54 @@ impl Msg {
         )
     }
     pub fn has_enum_optional(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
-            self::_puroro_root::full_coverage3::Enum,
-            self::_puroro::internal::tags::Enum3::<
-                self::_puroro_root::full_coverage3::Enum,
-            >,
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
+            self::_root::full_coverage3::Enum,
+            self::_pinternal::tags::Enum3::<self::_root::full_coverage3::Enum>,
             4usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.enum_optional, &self._bitfield)
             .is_some()
     }
     pub fn clear_enum_optional(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
-            self::_puroro_root::full_coverage3::Enum,
-            self::_puroro::internal::tags::Enum3::<
-                self::_puroro_root::full_coverage3::Enum,
-            >,
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
+            self::_root::full_coverage3::Enum,
+            self::_pinternal::tags::Enum3::<self::_root::full_coverage3::Enum>,
             4usize,
         > as NonRepeatedFieldType>::clear(&mut self.enum_optional, &mut self._bitfield)
     }
-    pub fn enum_repeated(&self) -> &[self::_puroro_root::full_coverage3::Enum] {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
-            self::_puroro_root::full_coverage3::Enum,
-            self::_puroro::internal::tags::Enum3::<
-                self::_puroro_root::full_coverage3::Enum,
-            >,
+    pub fn enum_repeated(&self) -> &[self::_root::full_coverage3::Enum] {
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
+            self::_root::full_coverage3::Enum,
+            self::_pinternal::tags::Enum3::<self::_root::full_coverage3::Enum>,
         > as RepeatedFieldType>::get_field(&self.enum_repeated, &self._bitfield)
     }
     pub fn enum_repeated_mut(
         &mut self,
-    ) -> &mut ::std::vec::Vec::<self::_puroro_root::full_coverage3::Enum> {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
-            self::_puroro_root::full_coverage3::Enum,
-            self::_puroro::internal::tags::Enum3::<
-                self::_puroro_root::full_coverage3::Enum,
-            >,
+    ) -> &mut ::std::vec::Vec::<self::_root::full_coverage3::Enum> {
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
+            self::_root::full_coverage3::Enum,
+            self::_pinternal::tags::Enum3::<self::_root::full_coverage3::Enum>,
         > as RepeatedFieldType>::get_field_mut(
             &mut self.enum_repeated,
             &mut self._bitfield,
         )
     }
     pub fn clear_enum_repeated(&mut self) {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
-            self::_puroro_root::full_coverage3::Enum,
-            self::_puroro::internal::tags::Enum3::<
-                self::_puroro_root::full_coverage3::Enum,
-            >,
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
+            self::_root::full_coverage3::Enum,
+            self::_pinternal::tags::Enum3::<self::_root::full_coverage3::Enum>,
         > as RepeatedFieldType>::clear(&mut self.enum_repeated, &mut self._bitfield)
     }
     pub fn submsg_unlabeled(
         &self,
-    ) -> ::std::option::Option::<&self::_puroro_root::full_coverage3::msg::Submsg> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::full_coverage3::msg::Submsg,
+    ) -> ::std::option::Option::<&self::_root::full_coverage3::msg::Submsg> {
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::full_coverage3::msg::Submsg,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.submsg_unlabeled,
             &self._bitfield,
@@ -870,10 +844,10 @@ impl Msg {
     }
     pub fn submsg_unlabeled_opt(
         &self,
-    ) -> ::std::option::Option::<&self::_puroro_root::full_coverage3::msg::Submsg> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::full_coverage3::msg::Submsg,
+    ) -> ::std::option::Option::<&self::_root::full_coverage3::msg::Submsg> {
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::full_coverage3::msg::Submsg,
         > as NonRepeatedFieldType>::get_field_opt(
             &self.submsg_unlabeled,
             &self._bitfield,
@@ -881,10 +855,10 @@ impl Msg {
     }
     pub fn submsg_unlabeled_mut(
         &mut self,
-    ) -> &mut self::_puroro_root::full_coverage3::msg::Submsg {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::full_coverage3::msg::Submsg,
+    ) -> &mut self::_root::full_coverage3::msg::Submsg {
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::full_coverage3::msg::Submsg,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.submsg_unlabeled,
             &mut self._bitfield,
@@ -892,9 +866,9 @@ impl Msg {
         )
     }
     pub fn has_submsg_unlabeled(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::full_coverage3::msg::Submsg,
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::full_coverage3::msg::Submsg,
         > as NonRepeatedFieldType>::get_field_opt(
                 &self.submsg_unlabeled,
                 &self._bitfield,
@@ -902,9 +876,9 @@ impl Msg {
             .is_some()
     }
     pub fn clear_submsg_unlabeled(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::full_coverage3::msg::Submsg,
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::full_coverage3::msg::Submsg,
         > as NonRepeatedFieldType>::clear(
             &mut self.submsg_unlabeled,
             &mut self._bitfield,
@@ -912,10 +886,10 @@ impl Msg {
     }
     pub fn submsg_optional(
         &self,
-    ) -> ::std::option::Option::<&self::_puroro_root::full_coverage3::msg::Submsg> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::full_coverage3::msg::Submsg,
+    ) -> ::std::option::Option::<&self::_root::full_coverage3::msg::Submsg> {
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::full_coverage3::msg::Submsg,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.submsg_optional,
             &self._bitfield,
@@ -924,18 +898,18 @@ impl Msg {
     }
     pub fn submsg_optional_opt(
         &self,
-    ) -> ::std::option::Option::<&self::_puroro_root::full_coverage3::msg::Submsg> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::full_coverage3::msg::Submsg,
+    ) -> ::std::option::Option::<&self::_root::full_coverage3::msg::Submsg> {
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::full_coverage3::msg::Submsg,
         > as NonRepeatedFieldType>::get_field_opt(&self.submsg_optional, &self._bitfield)
     }
     pub fn submsg_optional_mut(
         &mut self,
-    ) -> &mut self::_puroro_root::full_coverage3::msg::Submsg {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::full_coverage3::msg::Submsg,
+    ) -> &mut self::_root::full_coverage3::msg::Submsg {
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::full_coverage3::msg::Submsg,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.submsg_optional,
             &mut self._bitfield,
@@ -943,46 +917,46 @@ impl Msg {
         )
     }
     pub fn has_submsg_optional(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::full_coverage3::msg::Submsg,
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::full_coverage3::msg::Submsg,
         > as NonRepeatedFieldType>::get_field_opt(&self.submsg_optional, &self._bitfield)
             .is_some()
     }
     pub fn clear_submsg_optional(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::full_coverage3::msg::Submsg,
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::full_coverage3::msg::Submsg,
         > as NonRepeatedFieldType>::clear(&mut self.submsg_optional, &mut self._bitfield)
     }
-    pub fn submsg_repeated(&self) -> &[self::_puroro_root::full_coverage3::msg::Submsg] {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::full_coverage3::msg::Submsg,
+    pub fn submsg_repeated(&self) -> &[self::_root::full_coverage3::msg::Submsg] {
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::full_coverage3::msg::Submsg,
         > as RepeatedFieldType>::get_field(&self.submsg_repeated, &self._bitfield)
     }
     pub fn submsg_repeated_mut(
         &mut self,
-    ) -> &mut ::std::vec::Vec::<self::_puroro_root::full_coverage3::msg::Submsg> {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::full_coverage3::msg::Submsg,
+    ) -> &mut ::std::vec::Vec::<self::_root::full_coverage3::msg::Submsg> {
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::full_coverage3::msg::Submsg,
         > as RepeatedFieldType>::get_field_mut(
             &mut self.submsg_repeated,
             &mut self._bitfield,
         )
     }
     pub fn clear_submsg_repeated(&mut self) {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::full_coverage3::msg::Submsg,
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::full_coverage3::msg::Submsg,
         > as RepeatedFieldType>::clear(&mut self.submsg_repeated, &mut self._bitfield)
     }
     pub fn i64_unlabeled(&self) -> i64 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             i64,
-            self::_puroro::internal::tags::Int64,
+            self::_pinternal::tags::Int64,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.i64_unlabeled,
             &self._bitfield,
@@ -990,17 +964,17 @@ impl Msg {
         )
     }
     pub fn i64_unlabeled_opt(&self) -> ::std::option::Option::<i64> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             i64,
-            self::_puroro::internal::tags::Int64,
+            self::_pinternal::tags::Int64,
         > as NonRepeatedFieldType>::get_field_opt(&self.i64_unlabeled, &self._bitfield)
     }
     pub fn i64_unlabeled_mut(&mut self) -> &mut i64 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             i64,
-            self::_puroro::internal::tags::Int64,
+            self::_pinternal::tags::Int64,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.i64_unlabeled,
             &mut self._bitfield,
@@ -1008,25 +982,25 @@ impl Msg {
         )
     }
     pub fn has_i64_unlabeled(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             i64,
-            self::_puroro::internal::tags::Int64,
+            self::_pinternal::tags::Int64,
         > as NonRepeatedFieldType>::get_field_opt(&self.i64_unlabeled, &self._bitfield)
             .is_some()
     }
     pub fn clear_i64_unlabeled(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             i64,
-            self::_puroro::internal::tags::Int64,
+            self::_pinternal::tags::Int64,
         > as NonRepeatedFieldType>::clear(&mut self.i64_unlabeled, &mut self._bitfield)
     }
     pub fn i64_optional(&self) -> i64 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i64,
-            self::_puroro::internal::tags::Int64,
+            self::_pinternal::tags::Int64,
             5usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.i64_optional,
@@ -1035,18 +1009,18 @@ impl Msg {
         )
     }
     pub fn i64_optional_opt(&self) -> ::std::option::Option::<i64> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i64,
-            self::_puroro::internal::tags::Int64,
+            self::_pinternal::tags::Int64,
             5usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.i64_optional, &self._bitfield)
     }
     pub fn i64_optional_mut(&mut self) -> &mut i64 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i64,
-            self::_puroro::internal::tags::Int64,
+            self::_pinternal::tags::Int64,
             5usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.i64_optional,
@@ -1055,51 +1029,51 @@ impl Msg {
         )
     }
     pub fn has_i64_optional(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i64,
-            self::_puroro::internal::tags::Int64,
+            self::_pinternal::tags::Int64,
             5usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.i64_optional, &self._bitfield)
             .is_some()
     }
     pub fn clear_i64_optional(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i64,
-            self::_puroro::internal::tags::Int64,
+            self::_pinternal::tags::Int64,
             5usize,
         > as NonRepeatedFieldType>::clear(&mut self.i64_optional, &mut self._bitfield)
     }
     pub fn i64_repeated(&self) -> &[i64] {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             i64,
-            self::_puroro::internal::tags::Int64,
+            self::_pinternal::tags::Int64,
         > as RepeatedFieldType>::get_field(&self.i64_repeated, &self._bitfield)
     }
     pub fn i64_repeated_mut(&mut self) -> &mut ::std::vec::Vec::<i64> {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             i64,
-            self::_puroro::internal::tags::Int64,
+            self::_pinternal::tags::Int64,
         > as RepeatedFieldType>::get_field_mut(
             &mut self.i64_repeated,
             &mut self._bitfield,
         )
     }
     pub fn clear_i64_repeated(&mut self) {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             i64,
-            self::_puroro::internal::tags::Int64,
+            self::_pinternal::tags::Int64,
         > as RepeatedFieldType>::clear(&mut self.i64_repeated, &mut self._bitfield)
     }
     pub fn u32_unlabeled(&self) -> u32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             u32,
-            self::_puroro::internal::tags::UInt32,
+            self::_pinternal::tags::UInt32,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.u32_unlabeled,
             &self._bitfield,
@@ -1107,17 +1081,17 @@ impl Msg {
         )
     }
     pub fn u32_unlabeled_opt(&self) -> ::std::option::Option::<u32> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             u32,
-            self::_puroro::internal::tags::UInt32,
+            self::_pinternal::tags::UInt32,
         > as NonRepeatedFieldType>::get_field_opt(&self.u32_unlabeled, &self._bitfield)
     }
     pub fn u32_unlabeled_mut(&mut self) -> &mut u32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             u32,
-            self::_puroro::internal::tags::UInt32,
+            self::_pinternal::tags::UInt32,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.u32_unlabeled,
             &mut self._bitfield,
@@ -1125,25 +1099,25 @@ impl Msg {
         )
     }
     pub fn has_u32_unlabeled(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             u32,
-            self::_puroro::internal::tags::UInt32,
+            self::_pinternal::tags::UInt32,
         > as NonRepeatedFieldType>::get_field_opt(&self.u32_unlabeled, &self._bitfield)
             .is_some()
     }
     pub fn clear_u32_unlabeled(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             u32,
-            self::_puroro::internal::tags::UInt32,
+            self::_pinternal::tags::UInt32,
         > as NonRepeatedFieldType>::clear(&mut self.u32_unlabeled, &mut self._bitfield)
     }
     pub fn u32_optional(&self) -> u32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u32,
-            self::_puroro::internal::tags::UInt32,
+            self::_pinternal::tags::UInt32,
             6usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.u32_optional,
@@ -1152,18 +1126,18 @@ impl Msg {
         )
     }
     pub fn u32_optional_opt(&self) -> ::std::option::Option::<u32> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u32,
-            self::_puroro::internal::tags::UInt32,
+            self::_pinternal::tags::UInt32,
             6usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.u32_optional, &self._bitfield)
     }
     pub fn u32_optional_mut(&mut self) -> &mut u32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u32,
-            self::_puroro::internal::tags::UInt32,
+            self::_pinternal::tags::UInt32,
             6usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.u32_optional,
@@ -1172,51 +1146,51 @@ impl Msg {
         )
     }
     pub fn has_u32_optional(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u32,
-            self::_puroro::internal::tags::UInt32,
+            self::_pinternal::tags::UInt32,
             6usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.u32_optional, &self._bitfield)
             .is_some()
     }
     pub fn clear_u32_optional(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u32,
-            self::_puroro::internal::tags::UInt32,
+            self::_pinternal::tags::UInt32,
             6usize,
         > as NonRepeatedFieldType>::clear(&mut self.u32_optional, &mut self._bitfield)
     }
     pub fn u32_repeated(&self) -> &[u32] {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             u32,
-            self::_puroro::internal::tags::UInt32,
+            self::_pinternal::tags::UInt32,
         > as RepeatedFieldType>::get_field(&self.u32_repeated, &self._bitfield)
     }
     pub fn u32_repeated_mut(&mut self) -> &mut ::std::vec::Vec::<u32> {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             u32,
-            self::_puroro::internal::tags::UInt32,
+            self::_pinternal::tags::UInt32,
         > as RepeatedFieldType>::get_field_mut(
             &mut self.u32_repeated,
             &mut self._bitfield,
         )
     }
     pub fn clear_u32_repeated(&mut self) {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             u32,
-            self::_puroro::internal::tags::UInt32,
+            self::_pinternal::tags::UInt32,
         > as RepeatedFieldType>::clear(&mut self.u32_repeated, &mut self._bitfield)
     }
     pub fn u64_unlabeled(&self) -> u64 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             u64,
-            self::_puroro::internal::tags::UInt64,
+            self::_pinternal::tags::UInt64,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.u64_unlabeled,
             &self._bitfield,
@@ -1224,17 +1198,17 @@ impl Msg {
         )
     }
     pub fn u64_unlabeled_opt(&self) -> ::std::option::Option::<u64> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             u64,
-            self::_puroro::internal::tags::UInt64,
+            self::_pinternal::tags::UInt64,
         > as NonRepeatedFieldType>::get_field_opt(&self.u64_unlabeled, &self._bitfield)
     }
     pub fn u64_unlabeled_mut(&mut self) -> &mut u64 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             u64,
-            self::_puroro::internal::tags::UInt64,
+            self::_pinternal::tags::UInt64,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.u64_unlabeled,
             &mut self._bitfield,
@@ -1242,25 +1216,25 @@ impl Msg {
         )
     }
     pub fn has_u64_unlabeled(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             u64,
-            self::_puroro::internal::tags::UInt64,
+            self::_pinternal::tags::UInt64,
         > as NonRepeatedFieldType>::get_field_opt(&self.u64_unlabeled, &self._bitfield)
             .is_some()
     }
     pub fn clear_u64_unlabeled(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             u64,
-            self::_puroro::internal::tags::UInt64,
+            self::_pinternal::tags::UInt64,
         > as NonRepeatedFieldType>::clear(&mut self.u64_unlabeled, &mut self._bitfield)
     }
     pub fn u64_optional(&self) -> u64 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u64,
-            self::_puroro::internal::tags::UInt64,
+            self::_pinternal::tags::UInt64,
             7usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.u64_optional,
@@ -1269,18 +1243,18 @@ impl Msg {
         )
     }
     pub fn u64_optional_opt(&self) -> ::std::option::Option::<u64> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u64,
-            self::_puroro::internal::tags::UInt64,
+            self::_pinternal::tags::UInt64,
             7usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.u64_optional, &self._bitfield)
     }
     pub fn u64_optional_mut(&mut self) -> &mut u64 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u64,
-            self::_puroro::internal::tags::UInt64,
+            self::_pinternal::tags::UInt64,
             7usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.u64_optional,
@@ -1289,51 +1263,51 @@ impl Msg {
         )
     }
     pub fn has_u64_optional(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u64,
-            self::_puroro::internal::tags::UInt64,
+            self::_pinternal::tags::UInt64,
             7usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.u64_optional, &self._bitfield)
             .is_some()
     }
     pub fn clear_u64_optional(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u64,
-            self::_puroro::internal::tags::UInt64,
+            self::_pinternal::tags::UInt64,
             7usize,
         > as NonRepeatedFieldType>::clear(&mut self.u64_optional, &mut self._bitfield)
     }
     pub fn u64_repeated(&self) -> &[u64] {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             u64,
-            self::_puroro::internal::tags::UInt64,
+            self::_pinternal::tags::UInt64,
         > as RepeatedFieldType>::get_field(&self.u64_repeated, &self._bitfield)
     }
     pub fn u64_repeated_mut(&mut self) -> &mut ::std::vec::Vec::<u64> {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             u64,
-            self::_puroro::internal::tags::UInt64,
+            self::_pinternal::tags::UInt64,
         > as RepeatedFieldType>::get_field_mut(
             &mut self.u64_repeated,
             &mut self._bitfield,
         )
     }
     pub fn clear_u64_repeated(&mut self) {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             u64,
-            self::_puroro::internal::tags::UInt64,
+            self::_pinternal::tags::UInt64,
         > as RepeatedFieldType>::clear(&mut self.u64_repeated, &mut self._bitfield)
     }
     pub fn s32_unlabeled(&self) -> i32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             i32,
-            self::_puroro::internal::tags::SInt32,
+            self::_pinternal::tags::SInt32,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.s32_unlabeled,
             &self._bitfield,
@@ -1341,17 +1315,17 @@ impl Msg {
         )
     }
     pub fn s32_unlabeled_opt(&self) -> ::std::option::Option::<i32> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             i32,
-            self::_puroro::internal::tags::SInt32,
+            self::_pinternal::tags::SInt32,
         > as NonRepeatedFieldType>::get_field_opt(&self.s32_unlabeled, &self._bitfield)
     }
     pub fn s32_unlabeled_mut(&mut self) -> &mut i32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             i32,
-            self::_puroro::internal::tags::SInt32,
+            self::_pinternal::tags::SInt32,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.s32_unlabeled,
             &mut self._bitfield,
@@ -1359,25 +1333,25 @@ impl Msg {
         )
     }
     pub fn has_s32_unlabeled(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             i32,
-            self::_puroro::internal::tags::SInt32,
+            self::_pinternal::tags::SInt32,
         > as NonRepeatedFieldType>::get_field_opt(&self.s32_unlabeled, &self._bitfield)
             .is_some()
     }
     pub fn clear_s32_unlabeled(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             i32,
-            self::_puroro::internal::tags::SInt32,
+            self::_pinternal::tags::SInt32,
         > as NonRepeatedFieldType>::clear(&mut self.s32_unlabeled, &mut self._bitfield)
     }
     pub fn s32_optional(&self) -> i32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::SInt32,
+            self::_pinternal::tags::SInt32,
             8usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.s32_optional,
@@ -1386,18 +1360,18 @@ impl Msg {
         )
     }
     pub fn s32_optional_opt(&self) -> ::std::option::Option::<i32> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::SInt32,
+            self::_pinternal::tags::SInt32,
             8usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.s32_optional, &self._bitfield)
     }
     pub fn s32_optional_mut(&mut self) -> &mut i32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::SInt32,
+            self::_pinternal::tags::SInt32,
             8usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.s32_optional,
@@ -1406,51 +1380,51 @@ impl Msg {
         )
     }
     pub fn has_s32_optional(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::SInt32,
+            self::_pinternal::tags::SInt32,
             8usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.s32_optional, &self._bitfield)
             .is_some()
     }
     pub fn clear_s32_optional(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::SInt32,
+            self::_pinternal::tags::SInt32,
             8usize,
         > as NonRepeatedFieldType>::clear(&mut self.s32_optional, &mut self._bitfield)
     }
     pub fn s32_repeated(&self) -> &[i32] {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             i32,
-            self::_puroro::internal::tags::SInt32,
+            self::_pinternal::tags::SInt32,
         > as RepeatedFieldType>::get_field(&self.s32_repeated, &self._bitfield)
     }
     pub fn s32_repeated_mut(&mut self) -> &mut ::std::vec::Vec::<i32> {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             i32,
-            self::_puroro::internal::tags::SInt32,
+            self::_pinternal::tags::SInt32,
         > as RepeatedFieldType>::get_field_mut(
             &mut self.s32_repeated,
             &mut self._bitfield,
         )
     }
     pub fn clear_s32_repeated(&mut self) {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             i32,
-            self::_puroro::internal::tags::SInt32,
+            self::_pinternal::tags::SInt32,
         > as RepeatedFieldType>::clear(&mut self.s32_repeated, &mut self._bitfield)
     }
     pub fn s64_unlabeled(&self) -> i64 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             i64,
-            self::_puroro::internal::tags::SInt64,
+            self::_pinternal::tags::SInt64,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.s64_unlabeled,
             &self._bitfield,
@@ -1458,17 +1432,17 @@ impl Msg {
         )
     }
     pub fn s64_unlabeled_opt(&self) -> ::std::option::Option::<i64> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             i64,
-            self::_puroro::internal::tags::SInt64,
+            self::_pinternal::tags::SInt64,
         > as NonRepeatedFieldType>::get_field_opt(&self.s64_unlabeled, &self._bitfield)
     }
     pub fn s64_unlabeled_mut(&mut self) -> &mut i64 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             i64,
-            self::_puroro::internal::tags::SInt64,
+            self::_pinternal::tags::SInt64,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.s64_unlabeled,
             &mut self._bitfield,
@@ -1476,25 +1450,25 @@ impl Msg {
         )
     }
     pub fn has_s64_unlabeled(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             i64,
-            self::_puroro::internal::tags::SInt64,
+            self::_pinternal::tags::SInt64,
         > as NonRepeatedFieldType>::get_field_opt(&self.s64_unlabeled, &self._bitfield)
             .is_some()
     }
     pub fn clear_s64_unlabeled(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             i64,
-            self::_puroro::internal::tags::SInt64,
+            self::_pinternal::tags::SInt64,
         > as NonRepeatedFieldType>::clear(&mut self.s64_unlabeled, &mut self._bitfield)
     }
     pub fn s64_optional(&self) -> i64 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i64,
-            self::_puroro::internal::tags::SInt64,
+            self::_pinternal::tags::SInt64,
             9usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.s64_optional,
@@ -1503,18 +1477,18 @@ impl Msg {
         )
     }
     pub fn s64_optional_opt(&self) -> ::std::option::Option::<i64> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i64,
-            self::_puroro::internal::tags::SInt64,
+            self::_pinternal::tags::SInt64,
             9usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.s64_optional, &self._bitfield)
     }
     pub fn s64_optional_mut(&mut self) -> &mut i64 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i64,
-            self::_puroro::internal::tags::SInt64,
+            self::_pinternal::tags::SInt64,
             9usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.s64_optional,
@@ -1523,51 +1497,51 @@ impl Msg {
         )
     }
     pub fn has_s64_optional(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i64,
-            self::_puroro::internal::tags::SInt64,
+            self::_pinternal::tags::SInt64,
             9usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.s64_optional, &self._bitfield)
             .is_some()
     }
     pub fn clear_s64_optional(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i64,
-            self::_puroro::internal::tags::SInt64,
+            self::_pinternal::tags::SInt64,
             9usize,
         > as NonRepeatedFieldType>::clear(&mut self.s64_optional, &mut self._bitfield)
     }
     pub fn s64_repeated(&self) -> &[i64] {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             i64,
-            self::_puroro::internal::tags::SInt64,
+            self::_pinternal::tags::SInt64,
         > as RepeatedFieldType>::get_field(&self.s64_repeated, &self._bitfield)
     }
     pub fn s64_repeated_mut(&mut self) -> &mut ::std::vec::Vec::<i64> {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             i64,
-            self::_puroro::internal::tags::SInt64,
+            self::_pinternal::tags::SInt64,
         > as RepeatedFieldType>::get_field_mut(
             &mut self.s64_repeated,
             &mut self._bitfield,
         )
     }
     pub fn clear_s64_repeated(&mut self) {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             i64,
-            self::_puroro::internal::tags::SInt64,
+            self::_pinternal::tags::SInt64,
         > as RepeatedFieldType>::clear(&mut self.s64_repeated, &mut self._bitfield)
     }
     pub fn fixed32_unlabeled(&self) -> u32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             u32,
-            self::_puroro::internal::tags::Fixed32,
+            self::_pinternal::tags::Fixed32,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.fixed32_unlabeled,
             &self._bitfield,
@@ -1575,20 +1549,20 @@ impl Msg {
         )
     }
     pub fn fixed32_unlabeled_opt(&self) -> ::std::option::Option::<u32> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             u32,
-            self::_puroro::internal::tags::Fixed32,
+            self::_pinternal::tags::Fixed32,
         > as NonRepeatedFieldType>::get_field_opt(
             &self.fixed32_unlabeled,
             &self._bitfield,
         )
     }
     pub fn fixed32_unlabeled_mut(&mut self) -> &mut u32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             u32,
-            self::_puroro::internal::tags::Fixed32,
+            self::_pinternal::tags::Fixed32,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.fixed32_unlabeled,
             &mut self._bitfield,
@@ -1596,10 +1570,10 @@ impl Msg {
         )
     }
     pub fn has_fixed32_unlabeled(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             u32,
-            self::_puroro::internal::tags::Fixed32,
+            self::_pinternal::tags::Fixed32,
         > as NonRepeatedFieldType>::get_field_opt(
                 &self.fixed32_unlabeled,
                 &self._bitfield,
@@ -1607,20 +1581,20 @@ impl Msg {
             .is_some()
     }
     pub fn clear_fixed32_unlabeled(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             u32,
-            self::_puroro::internal::tags::Fixed32,
+            self::_pinternal::tags::Fixed32,
         > as NonRepeatedFieldType>::clear(
             &mut self.fixed32_unlabeled,
             &mut self._bitfield,
         )
     }
     pub fn fixed32_optional(&self) -> u32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u32,
-            self::_puroro::internal::tags::Fixed32,
+            self::_pinternal::tags::Fixed32,
             10usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.fixed32_optional,
@@ -1629,10 +1603,10 @@ impl Msg {
         )
     }
     pub fn fixed32_optional_opt(&self) -> ::std::option::Option::<u32> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u32,
-            self::_puroro::internal::tags::Fixed32,
+            self::_pinternal::tags::Fixed32,
             10usize,
         > as NonRepeatedFieldType>::get_field_opt(
             &self.fixed32_optional,
@@ -1640,10 +1614,10 @@ impl Msg {
         )
     }
     pub fn fixed32_optional_mut(&mut self) -> &mut u32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u32,
-            self::_puroro::internal::tags::Fixed32,
+            self::_pinternal::tags::Fixed32,
             10usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.fixed32_optional,
@@ -1652,10 +1626,10 @@ impl Msg {
         )
     }
     pub fn has_fixed32_optional(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u32,
-            self::_puroro::internal::tags::Fixed32,
+            self::_pinternal::tags::Fixed32,
             10usize,
         > as NonRepeatedFieldType>::get_field_opt(
                 &self.fixed32_optional,
@@ -1664,10 +1638,10 @@ impl Msg {
             .is_some()
     }
     pub fn clear_fixed32_optional(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u32,
-            self::_puroro::internal::tags::Fixed32,
+            self::_pinternal::tags::Fixed32,
             10usize,
         > as NonRepeatedFieldType>::clear(
             &mut self.fixed32_optional,
@@ -1675,34 +1649,34 @@ impl Msg {
         )
     }
     pub fn fixed32_repeated(&self) -> &[u32] {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             u32,
-            self::_puroro::internal::tags::Fixed32,
+            self::_pinternal::tags::Fixed32,
         > as RepeatedFieldType>::get_field(&self.fixed32_repeated, &self._bitfield)
     }
     pub fn fixed32_repeated_mut(&mut self) -> &mut ::std::vec::Vec::<u32> {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             u32,
-            self::_puroro::internal::tags::Fixed32,
+            self::_pinternal::tags::Fixed32,
         > as RepeatedFieldType>::get_field_mut(
             &mut self.fixed32_repeated,
             &mut self._bitfield,
         )
     }
     pub fn clear_fixed32_repeated(&mut self) {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             u32,
-            self::_puroro::internal::tags::Fixed32,
+            self::_pinternal::tags::Fixed32,
         > as RepeatedFieldType>::clear(&mut self.fixed32_repeated, &mut self._bitfield)
     }
     pub fn fixed64_unlabeled(&self) -> u64 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             u64,
-            self::_puroro::internal::tags::Fixed64,
+            self::_pinternal::tags::Fixed64,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.fixed64_unlabeled,
             &self._bitfield,
@@ -1710,20 +1684,20 @@ impl Msg {
         )
     }
     pub fn fixed64_unlabeled_opt(&self) -> ::std::option::Option::<u64> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             u64,
-            self::_puroro::internal::tags::Fixed64,
+            self::_pinternal::tags::Fixed64,
         > as NonRepeatedFieldType>::get_field_opt(
             &self.fixed64_unlabeled,
             &self._bitfield,
         )
     }
     pub fn fixed64_unlabeled_mut(&mut self) -> &mut u64 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             u64,
-            self::_puroro::internal::tags::Fixed64,
+            self::_pinternal::tags::Fixed64,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.fixed64_unlabeled,
             &mut self._bitfield,
@@ -1731,10 +1705,10 @@ impl Msg {
         )
     }
     pub fn has_fixed64_unlabeled(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             u64,
-            self::_puroro::internal::tags::Fixed64,
+            self::_pinternal::tags::Fixed64,
         > as NonRepeatedFieldType>::get_field_opt(
                 &self.fixed64_unlabeled,
                 &self._bitfield,
@@ -1742,20 +1716,20 @@ impl Msg {
             .is_some()
     }
     pub fn clear_fixed64_unlabeled(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             u64,
-            self::_puroro::internal::tags::Fixed64,
+            self::_pinternal::tags::Fixed64,
         > as NonRepeatedFieldType>::clear(
             &mut self.fixed64_unlabeled,
             &mut self._bitfield,
         )
     }
     pub fn fixed64_optional(&self) -> u64 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u64,
-            self::_puroro::internal::tags::Fixed64,
+            self::_pinternal::tags::Fixed64,
             11usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.fixed64_optional,
@@ -1764,10 +1738,10 @@ impl Msg {
         )
     }
     pub fn fixed64_optional_opt(&self) -> ::std::option::Option::<u64> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u64,
-            self::_puroro::internal::tags::Fixed64,
+            self::_pinternal::tags::Fixed64,
             11usize,
         > as NonRepeatedFieldType>::get_field_opt(
             &self.fixed64_optional,
@@ -1775,10 +1749,10 @@ impl Msg {
         )
     }
     pub fn fixed64_optional_mut(&mut self) -> &mut u64 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u64,
-            self::_puroro::internal::tags::Fixed64,
+            self::_pinternal::tags::Fixed64,
             11usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.fixed64_optional,
@@ -1787,10 +1761,10 @@ impl Msg {
         )
     }
     pub fn has_fixed64_optional(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u64,
-            self::_puroro::internal::tags::Fixed64,
+            self::_pinternal::tags::Fixed64,
             11usize,
         > as NonRepeatedFieldType>::get_field_opt(
                 &self.fixed64_optional,
@@ -1799,10 +1773,10 @@ impl Msg {
             .is_some()
     }
     pub fn clear_fixed64_optional(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u64,
-            self::_puroro::internal::tags::Fixed64,
+            self::_pinternal::tags::Fixed64,
             11usize,
         > as NonRepeatedFieldType>::clear(
             &mut self.fixed64_optional,
@@ -1810,34 +1784,34 @@ impl Msg {
         )
     }
     pub fn fixed64_repeated(&self) -> &[u64] {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             u64,
-            self::_puroro::internal::tags::Fixed64,
+            self::_pinternal::tags::Fixed64,
         > as RepeatedFieldType>::get_field(&self.fixed64_repeated, &self._bitfield)
     }
     pub fn fixed64_repeated_mut(&mut self) -> &mut ::std::vec::Vec::<u64> {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             u64,
-            self::_puroro::internal::tags::Fixed64,
+            self::_pinternal::tags::Fixed64,
         > as RepeatedFieldType>::get_field_mut(
             &mut self.fixed64_repeated,
             &mut self._bitfield,
         )
     }
     pub fn clear_fixed64_repeated(&mut self) {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             u64,
-            self::_puroro::internal::tags::Fixed64,
+            self::_pinternal::tags::Fixed64,
         > as RepeatedFieldType>::clear(&mut self.fixed64_repeated, &mut self._bitfield)
     }
     pub fn sfixed32_unlabeled(&self) -> i32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             i32,
-            self::_puroro::internal::tags::SFixed32,
+            self::_pinternal::tags::SFixed32,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.sfixed32_unlabeled,
             &self._bitfield,
@@ -1845,20 +1819,20 @@ impl Msg {
         )
     }
     pub fn sfixed32_unlabeled_opt(&self) -> ::std::option::Option::<i32> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             i32,
-            self::_puroro::internal::tags::SFixed32,
+            self::_pinternal::tags::SFixed32,
         > as NonRepeatedFieldType>::get_field_opt(
             &self.sfixed32_unlabeled,
             &self._bitfield,
         )
     }
     pub fn sfixed32_unlabeled_mut(&mut self) -> &mut i32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             i32,
-            self::_puroro::internal::tags::SFixed32,
+            self::_pinternal::tags::SFixed32,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.sfixed32_unlabeled,
             &mut self._bitfield,
@@ -1866,10 +1840,10 @@ impl Msg {
         )
     }
     pub fn has_sfixed32_unlabeled(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             i32,
-            self::_puroro::internal::tags::SFixed32,
+            self::_pinternal::tags::SFixed32,
         > as NonRepeatedFieldType>::get_field_opt(
                 &self.sfixed32_unlabeled,
                 &self._bitfield,
@@ -1877,20 +1851,20 @@ impl Msg {
             .is_some()
     }
     pub fn clear_sfixed32_unlabeled(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             i32,
-            self::_puroro::internal::tags::SFixed32,
+            self::_pinternal::tags::SFixed32,
         > as NonRepeatedFieldType>::clear(
             &mut self.sfixed32_unlabeled,
             &mut self._bitfield,
         )
     }
     pub fn sfixed32_optional(&self) -> i32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::SFixed32,
+            self::_pinternal::tags::SFixed32,
             12usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.sfixed32_optional,
@@ -1899,10 +1873,10 @@ impl Msg {
         )
     }
     pub fn sfixed32_optional_opt(&self) -> ::std::option::Option::<i32> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::SFixed32,
+            self::_pinternal::tags::SFixed32,
             12usize,
         > as NonRepeatedFieldType>::get_field_opt(
             &self.sfixed32_optional,
@@ -1910,10 +1884,10 @@ impl Msg {
         )
     }
     pub fn sfixed32_optional_mut(&mut self) -> &mut i32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::SFixed32,
+            self::_pinternal::tags::SFixed32,
             12usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.sfixed32_optional,
@@ -1922,10 +1896,10 @@ impl Msg {
         )
     }
     pub fn has_sfixed32_optional(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::SFixed32,
+            self::_pinternal::tags::SFixed32,
             12usize,
         > as NonRepeatedFieldType>::get_field_opt(
                 &self.sfixed32_optional,
@@ -1934,10 +1908,10 @@ impl Msg {
             .is_some()
     }
     pub fn clear_sfixed32_optional(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::SFixed32,
+            self::_pinternal::tags::SFixed32,
             12usize,
         > as NonRepeatedFieldType>::clear(
             &mut self.sfixed32_optional,
@@ -1945,34 +1919,34 @@ impl Msg {
         )
     }
     pub fn sfixed32_repeated(&self) -> &[i32] {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             i32,
-            self::_puroro::internal::tags::SFixed32,
+            self::_pinternal::tags::SFixed32,
         > as RepeatedFieldType>::get_field(&self.sfixed32_repeated, &self._bitfield)
     }
     pub fn sfixed32_repeated_mut(&mut self) -> &mut ::std::vec::Vec::<i32> {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             i32,
-            self::_puroro::internal::tags::SFixed32,
+            self::_pinternal::tags::SFixed32,
         > as RepeatedFieldType>::get_field_mut(
             &mut self.sfixed32_repeated,
             &mut self._bitfield,
         )
     }
     pub fn clear_sfixed32_repeated(&mut self) {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             i32,
-            self::_puroro::internal::tags::SFixed32,
+            self::_pinternal::tags::SFixed32,
         > as RepeatedFieldType>::clear(&mut self.sfixed32_repeated, &mut self._bitfield)
     }
     pub fn sfixed64_unlabeled(&self) -> i64 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             i64,
-            self::_puroro::internal::tags::SFixed64,
+            self::_pinternal::tags::SFixed64,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.sfixed64_unlabeled,
             &self._bitfield,
@@ -1980,20 +1954,20 @@ impl Msg {
         )
     }
     pub fn sfixed64_unlabeled_opt(&self) -> ::std::option::Option::<i64> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             i64,
-            self::_puroro::internal::tags::SFixed64,
+            self::_pinternal::tags::SFixed64,
         > as NonRepeatedFieldType>::get_field_opt(
             &self.sfixed64_unlabeled,
             &self._bitfield,
         )
     }
     pub fn sfixed64_unlabeled_mut(&mut self) -> &mut i64 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             i64,
-            self::_puroro::internal::tags::SFixed64,
+            self::_pinternal::tags::SFixed64,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.sfixed64_unlabeled,
             &mut self._bitfield,
@@ -2001,10 +1975,10 @@ impl Msg {
         )
     }
     pub fn has_sfixed64_unlabeled(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             i64,
-            self::_puroro::internal::tags::SFixed64,
+            self::_pinternal::tags::SFixed64,
         > as NonRepeatedFieldType>::get_field_opt(
                 &self.sfixed64_unlabeled,
                 &self._bitfield,
@@ -2012,20 +1986,20 @@ impl Msg {
             .is_some()
     }
     pub fn clear_sfixed64_unlabeled(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             i64,
-            self::_puroro::internal::tags::SFixed64,
+            self::_pinternal::tags::SFixed64,
         > as NonRepeatedFieldType>::clear(
             &mut self.sfixed64_unlabeled,
             &mut self._bitfield,
         )
     }
     pub fn sfixed64_optional(&self) -> i64 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i64,
-            self::_puroro::internal::tags::SFixed64,
+            self::_pinternal::tags::SFixed64,
             13usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.sfixed64_optional,
@@ -2034,10 +2008,10 @@ impl Msg {
         )
     }
     pub fn sfixed64_optional_opt(&self) -> ::std::option::Option::<i64> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i64,
-            self::_puroro::internal::tags::SFixed64,
+            self::_pinternal::tags::SFixed64,
             13usize,
         > as NonRepeatedFieldType>::get_field_opt(
             &self.sfixed64_optional,
@@ -2045,10 +2019,10 @@ impl Msg {
         )
     }
     pub fn sfixed64_optional_mut(&mut self) -> &mut i64 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i64,
-            self::_puroro::internal::tags::SFixed64,
+            self::_pinternal::tags::SFixed64,
             13usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.sfixed64_optional,
@@ -2057,10 +2031,10 @@ impl Msg {
         )
     }
     pub fn has_sfixed64_optional(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i64,
-            self::_puroro::internal::tags::SFixed64,
+            self::_pinternal::tags::SFixed64,
             13usize,
         > as NonRepeatedFieldType>::get_field_opt(
                 &self.sfixed64_optional,
@@ -2069,10 +2043,10 @@ impl Msg {
             .is_some()
     }
     pub fn clear_sfixed64_optional(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i64,
-            self::_puroro::internal::tags::SFixed64,
+            self::_pinternal::tags::SFixed64,
             13usize,
         > as NonRepeatedFieldType>::clear(
             &mut self.sfixed64_optional,
@@ -2080,34 +2054,34 @@ impl Msg {
         )
     }
     pub fn sfixed64_repeated(&self) -> &[i64] {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             i64,
-            self::_puroro::internal::tags::SFixed64,
+            self::_pinternal::tags::SFixed64,
         > as RepeatedFieldType>::get_field(&self.sfixed64_repeated, &self._bitfield)
     }
     pub fn sfixed64_repeated_mut(&mut self) -> &mut ::std::vec::Vec::<i64> {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             i64,
-            self::_puroro::internal::tags::SFixed64,
+            self::_pinternal::tags::SFixed64,
         > as RepeatedFieldType>::get_field_mut(
             &mut self.sfixed64_repeated,
             &mut self._bitfield,
         )
     }
     pub fn clear_sfixed64_repeated(&mut self) {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             i64,
-            self::_puroro::internal::tags::SFixed64,
+            self::_pinternal::tags::SFixed64,
         > as RepeatedFieldType>::clear(&mut self.sfixed64_repeated, &mut self._bitfield)
     }
     pub fn f64_unlabeled(&self) -> f64 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             f64,
-            self::_puroro::internal::tags::Double,
+            self::_pinternal::tags::Double,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.f64_unlabeled,
             &self._bitfield,
@@ -2115,17 +2089,17 @@ impl Msg {
         )
     }
     pub fn f64_unlabeled_opt(&self) -> ::std::option::Option::<f64> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             f64,
-            self::_puroro::internal::tags::Double,
+            self::_pinternal::tags::Double,
         > as NonRepeatedFieldType>::get_field_opt(&self.f64_unlabeled, &self._bitfield)
     }
     pub fn f64_unlabeled_mut(&mut self) -> &mut f64 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             f64,
-            self::_puroro::internal::tags::Double,
+            self::_pinternal::tags::Double,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.f64_unlabeled,
             &mut self._bitfield,
@@ -2133,25 +2107,25 @@ impl Msg {
         )
     }
     pub fn has_f64_unlabeled(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             f64,
-            self::_puroro::internal::tags::Double,
+            self::_pinternal::tags::Double,
         > as NonRepeatedFieldType>::get_field_opt(&self.f64_unlabeled, &self._bitfield)
             .is_some()
     }
     pub fn clear_f64_unlabeled(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             f64,
-            self::_puroro::internal::tags::Double,
+            self::_pinternal::tags::Double,
         > as NonRepeatedFieldType>::clear(&mut self.f64_unlabeled, &mut self._bitfield)
     }
     pub fn f64_optional(&self) -> f64 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             f64,
-            self::_puroro::internal::tags::Double,
+            self::_pinternal::tags::Double,
             14usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.f64_optional,
@@ -2160,18 +2134,18 @@ impl Msg {
         )
     }
     pub fn f64_optional_opt(&self) -> ::std::option::Option::<f64> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             f64,
-            self::_puroro::internal::tags::Double,
+            self::_pinternal::tags::Double,
             14usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.f64_optional, &self._bitfield)
     }
     pub fn f64_optional_mut(&mut self) -> &mut f64 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             f64,
-            self::_puroro::internal::tags::Double,
+            self::_pinternal::tags::Double,
             14usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.f64_optional,
@@ -2180,44 +2154,44 @@ impl Msg {
         )
     }
     pub fn has_f64_optional(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             f64,
-            self::_puroro::internal::tags::Double,
+            self::_pinternal::tags::Double,
             14usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.f64_optional, &self._bitfield)
             .is_some()
     }
     pub fn clear_f64_optional(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             f64,
-            self::_puroro::internal::tags::Double,
+            self::_pinternal::tags::Double,
             14usize,
         > as NonRepeatedFieldType>::clear(&mut self.f64_optional, &mut self._bitfield)
     }
     pub fn f64_repeated(&self) -> &[f64] {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             f64,
-            self::_puroro::internal::tags::Double,
+            self::_pinternal::tags::Double,
         > as RepeatedFieldType>::get_field(&self.f64_repeated, &self._bitfield)
     }
     pub fn f64_repeated_mut(&mut self) -> &mut ::std::vec::Vec::<f64> {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             f64,
-            self::_puroro::internal::tags::Double,
+            self::_pinternal::tags::Double,
         > as RepeatedFieldType>::get_field_mut(
             &mut self.f64_repeated,
             &mut self._bitfield,
         )
     }
     pub fn clear_f64_repeated(&mut self) {
-        use self::_puroro::internal::field_type::RepeatedFieldType;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::field_type::RepeatedFieldType;
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             f64,
-            self::_puroro::internal::tags::Double,
+            self::_pinternal::tags::Double,
         > as RepeatedFieldType>::clear(&mut self.f64_repeated, &mut self._bitfield)
     }
 }
@@ -2233,505 +2207,505 @@ impl self::_puroro::Message for Msg {
         &mut self,
         mut iter: I,
     ) -> self::_puroro::Result<()> {
-        use self::_puroro::internal::ser::FieldData;
+        use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 1i32 => {
-                    <self::_puroro::internal::field_type::SingularNumericalField::<
+                    <self::_pinternal::field_type::SingularNumericalField::<
                         i32,
-                        self::_puroro::internal::tags::Int32,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                        self::_pinternal::tags::Int32,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.i32_unlabeled,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 2i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         i32,
-                        self::_puroro::internal::tags::Int32,
+                        self::_pinternal::tags::Int32,
                         0usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.i32_optional,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 3i32 => {
-                    <self::_puroro::internal::field_type::RepeatedNumericalField::<
+                    <self::_pinternal::field_type::RepeatedNumericalField::<
                         i32,
-                        self::_puroro::internal::tags::Int32,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                        self::_pinternal::tags::Int32,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.i32_repeated,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 11i32 => {
-                    <self::_puroro::internal::field_type::SingularNumericalField::<
+                    <self::_pinternal::field_type::SingularNumericalField::<
                         f32,
-                        self::_puroro::internal::tags::Float,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                        self::_pinternal::tags::Float,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.float_unlabeled,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 12i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         f32,
-                        self::_puroro::internal::tags::Float,
+                        self::_pinternal::tags::Float,
                         1usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.float_optional,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 13i32 => {
-                    <self::_puroro::internal::field_type::RepeatedNumericalField::<
+                    <self::_pinternal::field_type::RepeatedNumericalField::<
                         f32,
-                        self::_puroro::internal::tags::Float,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                        self::_pinternal::tags::Float,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.float_repeated,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 21i32 => {
-                    <self::_puroro::internal::field_type::SingularUnsizedField::<
+                    <self::_pinternal::field_type::SingularUnsizedField::<
                         ::std::vec::Vec<u8>,
-                        self::_puroro::internal::tags::Bytes,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                        self::_pinternal::tags::Bytes,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.bytes_unlabeled,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 22i32 => {
-                    <self::_puroro::internal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::field_type::OptionalUnsizedField::<
                         ::std::vec::Vec<u8>,
-                        self::_puroro::internal::tags::Bytes,
+                        self::_pinternal::tags::Bytes,
                         2usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.bytes_optional,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 23i32 => {
-                    <self::_puroro::internal::field_type::RepeatedUnsizedField::<
+                    <self::_pinternal::field_type::RepeatedUnsizedField::<
                         ::std::vec::Vec<u8>,
-                        self::_puroro::internal::tags::Bytes,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                        self::_pinternal::tags::Bytes,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.bytes_repeated,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 31i32 => {
-                    <self::_puroro::internal::field_type::SingularUnsizedField::<
+                    <self::_pinternal::field_type::SingularUnsizedField::<
                         ::std::string::String,
-                        self::_puroro::internal::tags::String,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                        self::_pinternal::tags::String,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.string_unlabeled,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 32i32 => {
-                    <self::_puroro::internal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::field_type::OptionalUnsizedField::<
                         ::std::string::String,
-                        self::_puroro::internal::tags::String,
+                        self::_pinternal::tags::String,
                         3usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.string_optional,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 33i32 => {
-                    <self::_puroro::internal::field_type::RepeatedUnsizedField::<
+                    <self::_pinternal::field_type::RepeatedUnsizedField::<
                         ::std::string::String,
-                        self::_puroro::internal::tags::String,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                        self::_pinternal::tags::String,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.string_repeated,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 41i32 => {
-                    <self::_puroro::internal::field_type::SingularNumericalField::<
-                        self::_puroro_root::full_coverage3::Enum,
-                        self::_puroro::internal::tags::Enum3::<
-                            self::_puroro_root::full_coverage3::Enum,
+                    <self::_pinternal::field_type::SingularNumericalField::<
+                        self::_root::full_coverage3::Enum,
+                        self::_pinternal::tags::Enum3::<
+                            self::_root::full_coverage3::Enum,
                         >,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.enum_unlabeled,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 42i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
-                        self::_puroro_root::full_coverage3::Enum,
-                        self::_puroro::internal::tags::Enum3::<
-                            self::_puroro_root::full_coverage3::Enum,
+                    <self::_pinternal::field_type::OptionalNumericalField::<
+                        self::_root::full_coverage3::Enum,
+                        self::_pinternal::tags::Enum3::<
+                            self::_root::full_coverage3::Enum,
                         >,
                         4usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.enum_optional,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 43i32 => {
-                    <self::_puroro::internal::field_type::RepeatedNumericalField::<
-                        self::_puroro_root::full_coverage3::Enum,
-                        self::_puroro::internal::tags::Enum3::<
-                            self::_puroro_root::full_coverage3::Enum,
+                    <self::_pinternal::field_type::RepeatedNumericalField::<
+                        self::_root::full_coverage3::Enum,
+                        self::_pinternal::tags::Enum3::<
+                            self::_root::full_coverage3::Enum,
                         >,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.enum_repeated,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 51i32 => {
-                    <self::_puroro::internal::field_type::SingularHeapMessageField::<
-                        self::_puroro_root::full_coverage3::msg::Submsg,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    <self::_pinternal::field_type::SingularHeapMessageField::<
+                        self::_root::full_coverage3::msg::Submsg,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.submsg_unlabeled,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 52i32 => {
-                    <self::_puroro::internal::field_type::SingularHeapMessageField::<
-                        self::_puroro_root::full_coverage3::msg::Submsg,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    <self::_pinternal::field_type::SingularHeapMessageField::<
+                        self::_root::full_coverage3::msg::Submsg,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.submsg_optional,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 53i32 => {
-                    <self::_puroro::internal::field_type::RepeatedMessageField::<
-                        self::_puroro_root::full_coverage3::msg::Submsg,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    <self::_pinternal::field_type::RepeatedMessageField::<
+                        self::_root::full_coverage3::msg::Submsg,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.submsg_repeated,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 101i32 => {
-                    <self::_puroro::internal::field_type::SingularNumericalField::<
+                    <self::_pinternal::field_type::SingularNumericalField::<
                         i64,
-                        self::_puroro::internal::tags::Int64,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                        self::_pinternal::tags::Int64,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.i64_unlabeled,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 102i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         i64,
-                        self::_puroro::internal::tags::Int64,
+                        self::_pinternal::tags::Int64,
                         5usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.i64_optional,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 103i32 => {
-                    <self::_puroro::internal::field_type::RepeatedNumericalField::<
+                    <self::_pinternal::field_type::RepeatedNumericalField::<
                         i64,
-                        self::_puroro::internal::tags::Int64,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                        self::_pinternal::tags::Int64,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.i64_repeated,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 111i32 => {
-                    <self::_puroro::internal::field_type::SingularNumericalField::<
+                    <self::_pinternal::field_type::SingularNumericalField::<
                         u32,
-                        self::_puroro::internal::tags::UInt32,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                        self::_pinternal::tags::UInt32,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.u32_unlabeled,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 112i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         u32,
-                        self::_puroro::internal::tags::UInt32,
+                        self::_pinternal::tags::UInt32,
                         6usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.u32_optional,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 113i32 => {
-                    <self::_puroro::internal::field_type::RepeatedNumericalField::<
+                    <self::_pinternal::field_type::RepeatedNumericalField::<
                         u32,
-                        self::_puroro::internal::tags::UInt32,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                        self::_pinternal::tags::UInt32,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.u32_repeated,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 121i32 => {
-                    <self::_puroro::internal::field_type::SingularNumericalField::<
+                    <self::_pinternal::field_type::SingularNumericalField::<
                         u64,
-                        self::_puroro::internal::tags::UInt64,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                        self::_pinternal::tags::UInt64,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.u64_unlabeled,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 122i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         u64,
-                        self::_puroro::internal::tags::UInt64,
+                        self::_pinternal::tags::UInt64,
                         7usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.u64_optional,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 123i32 => {
-                    <self::_puroro::internal::field_type::RepeatedNumericalField::<
+                    <self::_pinternal::field_type::RepeatedNumericalField::<
                         u64,
-                        self::_puroro::internal::tags::UInt64,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                        self::_pinternal::tags::UInt64,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.u64_repeated,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 131i32 => {
-                    <self::_puroro::internal::field_type::SingularNumericalField::<
+                    <self::_pinternal::field_type::SingularNumericalField::<
                         i32,
-                        self::_puroro::internal::tags::SInt32,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                        self::_pinternal::tags::SInt32,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.s32_unlabeled,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 132i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         i32,
-                        self::_puroro::internal::tags::SInt32,
+                        self::_pinternal::tags::SInt32,
                         8usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.s32_optional,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 133i32 => {
-                    <self::_puroro::internal::field_type::RepeatedNumericalField::<
+                    <self::_pinternal::field_type::RepeatedNumericalField::<
                         i32,
-                        self::_puroro::internal::tags::SInt32,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                        self::_pinternal::tags::SInt32,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.s32_repeated,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 141i32 => {
-                    <self::_puroro::internal::field_type::SingularNumericalField::<
+                    <self::_pinternal::field_type::SingularNumericalField::<
                         i64,
-                        self::_puroro::internal::tags::SInt64,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                        self::_pinternal::tags::SInt64,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.s64_unlabeled,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 142i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         i64,
-                        self::_puroro::internal::tags::SInt64,
+                        self::_pinternal::tags::SInt64,
                         9usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.s64_optional,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 143i32 => {
-                    <self::_puroro::internal::field_type::RepeatedNumericalField::<
+                    <self::_pinternal::field_type::RepeatedNumericalField::<
                         i64,
-                        self::_puroro::internal::tags::SInt64,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                        self::_pinternal::tags::SInt64,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.s64_repeated,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 151i32 => {
-                    <self::_puroro::internal::field_type::SingularNumericalField::<
+                    <self::_pinternal::field_type::SingularNumericalField::<
                         u32,
-                        self::_puroro::internal::tags::Fixed32,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                        self::_pinternal::tags::Fixed32,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.fixed32_unlabeled,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 152i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         u32,
-                        self::_puroro::internal::tags::Fixed32,
+                        self::_pinternal::tags::Fixed32,
                         10usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.fixed32_optional,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 153i32 => {
-                    <self::_puroro::internal::field_type::RepeatedNumericalField::<
+                    <self::_pinternal::field_type::RepeatedNumericalField::<
                         u32,
-                        self::_puroro::internal::tags::Fixed32,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                        self::_pinternal::tags::Fixed32,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.fixed32_repeated,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 161i32 => {
-                    <self::_puroro::internal::field_type::SingularNumericalField::<
+                    <self::_pinternal::field_type::SingularNumericalField::<
                         u64,
-                        self::_puroro::internal::tags::Fixed64,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                        self::_pinternal::tags::Fixed64,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.fixed64_unlabeled,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 162i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         u64,
-                        self::_puroro::internal::tags::Fixed64,
+                        self::_pinternal::tags::Fixed64,
                         11usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.fixed64_optional,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 163i32 => {
-                    <self::_puroro::internal::field_type::RepeatedNumericalField::<
+                    <self::_pinternal::field_type::RepeatedNumericalField::<
                         u64,
-                        self::_puroro::internal::tags::Fixed64,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                        self::_pinternal::tags::Fixed64,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.fixed64_repeated,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 171i32 => {
-                    <self::_puroro::internal::field_type::SingularNumericalField::<
+                    <self::_pinternal::field_type::SingularNumericalField::<
                         i32,
-                        self::_puroro::internal::tags::SFixed32,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                        self::_pinternal::tags::SFixed32,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.sfixed32_unlabeled,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 172i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         i32,
-                        self::_puroro::internal::tags::SFixed32,
+                        self::_pinternal::tags::SFixed32,
                         12usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.sfixed32_optional,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 173i32 => {
-                    <self::_puroro::internal::field_type::RepeatedNumericalField::<
+                    <self::_pinternal::field_type::RepeatedNumericalField::<
                         i32,
-                        self::_puroro::internal::tags::SFixed32,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                        self::_pinternal::tags::SFixed32,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.sfixed32_repeated,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 181i32 => {
-                    <self::_puroro::internal::field_type::SingularNumericalField::<
+                    <self::_pinternal::field_type::SingularNumericalField::<
                         i64,
-                        self::_puroro::internal::tags::SFixed64,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                        self::_pinternal::tags::SFixed64,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.sfixed64_unlabeled,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 182i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         i64,
-                        self::_puroro::internal::tags::SFixed64,
+                        self::_pinternal::tags::SFixed64,
                         13usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.sfixed64_optional,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 183i32 => {
-                    <self::_puroro::internal::field_type::RepeatedNumericalField::<
+                    <self::_pinternal::field_type::RepeatedNumericalField::<
                         i64,
-                        self::_puroro::internal::tags::SFixed64,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                        self::_pinternal::tags::SFixed64,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.sfixed64_repeated,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 191i32 => {
-                    <self::_puroro::internal::field_type::SingularNumericalField::<
+                    <self::_pinternal::field_type::SingularNumericalField::<
                         f64,
-                        self::_puroro::internal::tags::Double,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                        self::_pinternal::tags::Double,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.f64_unlabeled,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 192i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         f64,
-                        self::_puroro::internal::tags::Double,
+                        self::_pinternal::tags::Double,
                         14usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.f64_optional,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 193i32 => {
-                    <self::_puroro::internal::field_type::RepeatedNumericalField::<
+                    <self::_pinternal::field_type::RepeatedNumericalField::<
                         f64,
-                        self::_puroro::internal::tags::Double,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                        self::_pinternal::tags::Double,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.f64_repeated,
                         &mut self._bitfield,
                         field_data,
@@ -2748,452 +2722,446 @@ impl self::_puroro::Message for Msg {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::oneof_type::OneofUnion as _;
+        <self::_pinternal::field_type::SingularNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+            self::_pinternal::tags::Int32,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.i32_unlabeled,
             &self._bitfield,
             1i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             0usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.i32_optional,
             &self._bitfield,
             2i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+            self::_pinternal::tags::Int32,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.i32_repeated,
             &self._bitfield,
             3i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        <self::_pinternal::field_type::SingularNumericalField::<
             f32,
-            self::_puroro::internal::tags::Float,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+            self::_pinternal::tags::Float,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.float_unlabeled,
             &self._bitfield,
             11i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        <self::_pinternal::field_type::OptionalNumericalField::<
             f32,
-            self::_puroro::internal::tags::Float,
+            self::_pinternal::tags::Float,
             1usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.float_optional,
             &self._bitfield,
             12i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             f32,
-            self::_puroro::internal::tags::Float,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+            self::_pinternal::tags::Float,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.float_repeated,
             &self._bitfield,
             13i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::SingularUnsizedField::<
+        <self::_pinternal::field_type::SingularUnsizedField::<
             ::std::vec::Vec<u8>,
-            self::_puroro::internal::tags::Bytes,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+            self::_pinternal::tags::Bytes,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.bytes_unlabeled,
             &self._bitfield,
             21i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::vec::Vec<u8>,
-            self::_puroro::internal::tags::Bytes,
+            self::_pinternal::tags::Bytes,
             2usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.bytes_optional,
             &self._bitfield,
             22i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::RepeatedUnsizedField::<
+        <self::_pinternal::field_type::RepeatedUnsizedField::<
             ::std::vec::Vec<u8>,
-            self::_puroro::internal::tags::Bytes,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+            self::_pinternal::tags::Bytes,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.bytes_repeated,
             &self._bitfield,
             23i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::SingularUnsizedField::<
+        <self::_pinternal::field_type::SingularUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+            self::_pinternal::tags::String,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.string_unlabeled,
             &self._bitfield,
             31i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalUnsizedField::<
+        <self::_pinternal::field_type::OptionalUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
+            self::_pinternal::tags::String,
             3usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.string_optional,
             &self._bitfield,
             32i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::RepeatedUnsizedField::<
+        <self::_pinternal::field_type::RepeatedUnsizedField::<
             ::std::string::String,
-            self::_puroro::internal::tags::String,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+            self::_pinternal::tags::String,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.string_repeated,
             &self._bitfield,
             33i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
-            self::_puroro_root::full_coverage3::Enum,
-            self::_puroro::internal::tags::Enum3::<
-                self::_puroro_root::full_coverage3::Enum,
-            >,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        <self::_pinternal::field_type::SingularNumericalField::<
+            self::_root::full_coverage3::Enum,
+            self::_pinternal::tags::Enum3::<self::_root::full_coverage3::Enum>,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.enum_unlabeled,
             &self._bitfield,
             41i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
-            self::_puroro_root::full_coverage3::Enum,
-            self::_puroro::internal::tags::Enum3::<
-                self::_puroro_root::full_coverage3::Enum,
-            >,
+        <self::_pinternal::field_type::OptionalNumericalField::<
+            self::_root::full_coverage3::Enum,
+            self::_pinternal::tags::Enum3::<self::_root::full_coverage3::Enum>,
             4usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.enum_optional,
             &self._bitfield,
             42i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
-            self::_puroro_root::full_coverage3::Enum,
-            self::_puroro::internal::tags::Enum3::<
-                self::_puroro_root::full_coverage3::Enum,
-            >,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        <self::_pinternal::field_type::RepeatedNumericalField::<
+            self::_root::full_coverage3::Enum,
+            self::_pinternal::tags::Enum3::<self::_root::full_coverage3::Enum>,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.enum_repeated,
             &self._bitfield,
             43i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::full_coverage3::msg::Submsg,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::full_coverage3::msg::Submsg,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.submsg_unlabeled,
             &self._bitfield,
             51i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::full_coverage3::msg::Submsg,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::full_coverage3::msg::Submsg,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.submsg_optional,
             &self._bitfield,
             52i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::RepeatedMessageField::<
-            self::_puroro_root::full_coverage3::msg::Submsg,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        <self::_pinternal::field_type::RepeatedMessageField::<
+            self::_root::full_coverage3::msg::Submsg,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.submsg_repeated,
             &self._bitfield,
             53i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        <self::_pinternal::field_type::SingularNumericalField::<
             i64,
-            self::_puroro::internal::tags::Int64,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+            self::_pinternal::tags::Int64,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.i64_unlabeled,
             &self._bitfield,
             101i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i64,
-            self::_puroro::internal::tags::Int64,
+            self::_pinternal::tags::Int64,
             5usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.i64_optional,
             &self._bitfield,
             102i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             i64,
-            self::_puroro::internal::tags::Int64,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+            self::_pinternal::tags::Int64,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.i64_repeated,
             &self._bitfield,
             103i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        <self::_pinternal::field_type::SingularNumericalField::<
             u32,
-            self::_puroro::internal::tags::UInt32,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+            self::_pinternal::tags::UInt32,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.u32_unlabeled,
             &self._bitfield,
             111i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u32,
-            self::_puroro::internal::tags::UInt32,
+            self::_pinternal::tags::UInt32,
             6usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.u32_optional,
             &self._bitfield,
             112i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             u32,
-            self::_puroro::internal::tags::UInt32,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+            self::_pinternal::tags::UInt32,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.u32_repeated,
             &self._bitfield,
             113i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        <self::_pinternal::field_type::SingularNumericalField::<
             u64,
-            self::_puroro::internal::tags::UInt64,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+            self::_pinternal::tags::UInt64,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.u64_unlabeled,
             &self._bitfield,
             121i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u64,
-            self::_puroro::internal::tags::UInt64,
+            self::_pinternal::tags::UInt64,
             7usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.u64_optional,
             &self._bitfield,
             122i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             u64,
-            self::_puroro::internal::tags::UInt64,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+            self::_pinternal::tags::UInt64,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.u64_repeated,
             &self._bitfield,
             123i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        <self::_pinternal::field_type::SingularNumericalField::<
             i32,
-            self::_puroro::internal::tags::SInt32,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+            self::_pinternal::tags::SInt32,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.s32_unlabeled,
             &self._bitfield,
             131i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::SInt32,
+            self::_pinternal::tags::SInt32,
             8usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.s32_optional,
             &self._bitfield,
             132i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             i32,
-            self::_puroro::internal::tags::SInt32,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+            self::_pinternal::tags::SInt32,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.s32_repeated,
             &self._bitfield,
             133i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        <self::_pinternal::field_type::SingularNumericalField::<
             i64,
-            self::_puroro::internal::tags::SInt64,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+            self::_pinternal::tags::SInt64,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.s64_unlabeled,
             &self._bitfield,
             141i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i64,
-            self::_puroro::internal::tags::SInt64,
+            self::_pinternal::tags::SInt64,
             9usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.s64_optional,
             &self._bitfield,
             142i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             i64,
-            self::_puroro::internal::tags::SInt64,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+            self::_pinternal::tags::SInt64,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.s64_repeated,
             &self._bitfield,
             143i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        <self::_pinternal::field_type::SingularNumericalField::<
             u32,
-            self::_puroro::internal::tags::Fixed32,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+            self::_pinternal::tags::Fixed32,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.fixed32_unlabeled,
             &self._bitfield,
             151i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u32,
-            self::_puroro::internal::tags::Fixed32,
+            self::_pinternal::tags::Fixed32,
             10usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.fixed32_optional,
             &self._bitfield,
             152i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             u32,
-            self::_puroro::internal::tags::Fixed32,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+            self::_pinternal::tags::Fixed32,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.fixed32_repeated,
             &self._bitfield,
             153i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        <self::_pinternal::field_type::SingularNumericalField::<
             u64,
-            self::_puroro::internal::tags::Fixed64,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+            self::_pinternal::tags::Fixed64,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.fixed64_unlabeled,
             &self._bitfield,
             161i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        <self::_pinternal::field_type::OptionalNumericalField::<
             u64,
-            self::_puroro::internal::tags::Fixed64,
+            self::_pinternal::tags::Fixed64,
             11usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.fixed64_optional,
             &self._bitfield,
             162i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             u64,
-            self::_puroro::internal::tags::Fixed64,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+            self::_pinternal::tags::Fixed64,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.fixed64_repeated,
             &self._bitfield,
             163i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        <self::_pinternal::field_type::SingularNumericalField::<
             i32,
-            self::_puroro::internal::tags::SFixed32,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+            self::_pinternal::tags::SFixed32,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.sfixed32_unlabeled,
             &self._bitfield,
             171i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::SFixed32,
+            self::_pinternal::tags::SFixed32,
             12usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.sfixed32_optional,
             &self._bitfield,
             172i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             i32,
-            self::_puroro::internal::tags::SFixed32,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+            self::_pinternal::tags::SFixed32,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.sfixed32_repeated,
             &self._bitfield,
             173i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        <self::_pinternal::field_type::SingularNumericalField::<
             i64,
-            self::_puroro::internal::tags::SFixed64,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+            self::_pinternal::tags::SFixed64,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.sfixed64_unlabeled,
             &self._bitfield,
             181i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i64,
-            self::_puroro::internal::tags::SFixed64,
+            self::_pinternal::tags::SFixed64,
             13usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.sfixed64_optional,
             &self._bitfield,
             182i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             i64,
-            self::_puroro::internal::tags::SFixed64,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+            self::_pinternal::tags::SFixed64,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.sfixed64_repeated,
             &self._bitfield,
             183i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        <self::_pinternal::field_type::SingularNumericalField::<
             f64,
-            self::_puroro::internal::tags::Double,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+            self::_pinternal::tags::Double,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.f64_unlabeled,
             &self._bitfield,
             191i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        <self::_pinternal::field_type::OptionalNumericalField::<
             f64,
-            self::_puroro::internal::tags::Double,
+            self::_pinternal::tags::Double,
             14usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.f64_optional,
             &self._bitfield,
             192i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::RepeatedNumericalField::<
+        <self::_pinternal::field_type::RepeatedNumericalField::<
             f64,
-            self::_puroro::internal::tags::Double,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+            self::_pinternal::tags::Double,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.f64_repeated,
             &self._bitfield,
             193i32,
@@ -3205,215 +3173,209 @@ impl self::_puroro::Message for Msg {
 impl ::std::clone::Clone for Msg {
     fn clone(&self) -> Self {
         Self {
-            i32_unlabeled: <self::_puroro::internal::field_type::SingularNumericalField::<
+            i32_unlabeled: <self::_pinternal::field_type::SingularNumericalField::<
                 i32,
-                self::_puroro::internal::tags::Int32,
+                self::_pinternal::tags::Int32,
             > as ::std::clone::Clone>::clone(&self.i32_unlabeled),
-            i32_optional: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            i32_optional: <self::_pinternal::field_type::OptionalNumericalField::<
                 i32,
-                self::_puroro::internal::tags::Int32,
+                self::_pinternal::tags::Int32,
                 0usize,
             > as ::std::clone::Clone>::clone(&self.i32_optional),
-            i32_repeated: <self::_puroro::internal::field_type::RepeatedNumericalField::<
+            i32_repeated: <self::_pinternal::field_type::RepeatedNumericalField::<
                 i32,
-                self::_puroro::internal::tags::Int32,
+                self::_pinternal::tags::Int32,
             > as ::std::clone::Clone>::clone(&self.i32_repeated),
-            float_unlabeled: <self::_puroro::internal::field_type::SingularNumericalField::<
+            float_unlabeled: <self::_pinternal::field_type::SingularNumericalField::<
                 f32,
-                self::_puroro::internal::tags::Float,
+                self::_pinternal::tags::Float,
             > as ::std::clone::Clone>::clone(&self.float_unlabeled),
-            float_optional: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            float_optional: <self::_pinternal::field_type::OptionalNumericalField::<
                 f32,
-                self::_puroro::internal::tags::Float,
+                self::_pinternal::tags::Float,
                 1usize,
             > as ::std::clone::Clone>::clone(&self.float_optional),
-            float_repeated: <self::_puroro::internal::field_type::RepeatedNumericalField::<
+            float_repeated: <self::_pinternal::field_type::RepeatedNumericalField::<
                 f32,
-                self::_puroro::internal::tags::Float,
+                self::_pinternal::tags::Float,
             > as ::std::clone::Clone>::clone(&self.float_repeated),
-            bytes_unlabeled: <self::_puroro::internal::field_type::SingularUnsizedField::<
+            bytes_unlabeled: <self::_pinternal::field_type::SingularUnsizedField::<
                 ::std::vec::Vec<u8>,
-                self::_puroro::internal::tags::Bytes,
+                self::_pinternal::tags::Bytes,
             > as ::std::clone::Clone>::clone(&self.bytes_unlabeled),
-            bytes_optional: <self::_puroro::internal::field_type::OptionalUnsizedField::<
+            bytes_optional: <self::_pinternal::field_type::OptionalUnsizedField::<
                 ::std::vec::Vec<u8>,
-                self::_puroro::internal::tags::Bytes,
+                self::_pinternal::tags::Bytes,
                 2usize,
             > as ::std::clone::Clone>::clone(&self.bytes_optional),
-            bytes_repeated: <self::_puroro::internal::field_type::RepeatedUnsizedField::<
+            bytes_repeated: <self::_pinternal::field_type::RepeatedUnsizedField::<
                 ::std::vec::Vec<u8>,
-                self::_puroro::internal::tags::Bytes,
+                self::_pinternal::tags::Bytes,
             > as ::std::clone::Clone>::clone(&self.bytes_repeated),
-            string_unlabeled: <self::_puroro::internal::field_type::SingularUnsizedField::<
+            string_unlabeled: <self::_pinternal::field_type::SingularUnsizedField::<
                 ::std::string::String,
-                self::_puroro::internal::tags::String,
+                self::_pinternal::tags::String,
             > as ::std::clone::Clone>::clone(&self.string_unlabeled),
-            string_optional: <self::_puroro::internal::field_type::OptionalUnsizedField::<
+            string_optional: <self::_pinternal::field_type::OptionalUnsizedField::<
                 ::std::string::String,
-                self::_puroro::internal::tags::String,
+                self::_pinternal::tags::String,
                 3usize,
             > as ::std::clone::Clone>::clone(&self.string_optional),
-            string_repeated: <self::_puroro::internal::field_type::RepeatedUnsizedField::<
+            string_repeated: <self::_pinternal::field_type::RepeatedUnsizedField::<
                 ::std::string::String,
-                self::_puroro::internal::tags::String,
+                self::_pinternal::tags::String,
             > as ::std::clone::Clone>::clone(&self.string_repeated),
-            enum_unlabeled: <self::_puroro::internal::field_type::SingularNumericalField::<
-                self::_puroro_root::full_coverage3::Enum,
-                self::_puroro::internal::tags::Enum3::<
-                    self::_puroro_root::full_coverage3::Enum,
-                >,
+            enum_unlabeled: <self::_pinternal::field_type::SingularNumericalField::<
+                self::_root::full_coverage3::Enum,
+                self::_pinternal::tags::Enum3::<self::_root::full_coverage3::Enum>,
             > as ::std::clone::Clone>::clone(&self.enum_unlabeled),
-            enum_optional: <self::_puroro::internal::field_type::OptionalNumericalField::<
-                self::_puroro_root::full_coverage3::Enum,
-                self::_puroro::internal::tags::Enum3::<
-                    self::_puroro_root::full_coverage3::Enum,
-                >,
+            enum_optional: <self::_pinternal::field_type::OptionalNumericalField::<
+                self::_root::full_coverage3::Enum,
+                self::_pinternal::tags::Enum3::<self::_root::full_coverage3::Enum>,
                 4usize,
             > as ::std::clone::Clone>::clone(&self.enum_optional),
-            enum_repeated: <self::_puroro::internal::field_type::RepeatedNumericalField::<
-                self::_puroro_root::full_coverage3::Enum,
-                self::_puroro::internal::tags::Enum3::<
-                    self::_puroro_root::full_coverage3::Enum,
-                >,
+            enum_repeated: <self::_pinternal::field_type::RepeatedNumericalField::<
+                self::_root::full_coverage3::Enum,
+                self::_pinternal::tags::Enum3::<self::_root::full_coverage3::Enum>,
             > as ::std::clone::Clone>::clone(&self.enum_repeated),
-            submsg_unlabeled: <self::_puroro::internal::field_type::SingularHeapMessageField::<
-                self::_puroro_root::full_coverage3::msg::Submsg,
+            submsg_unlabeled: <self::_pinternal::field_type::SingularHeapMessageField::<
+                self::_root::full_coverage3::msg::Submsg,
             > as ::std::clone::Clone>::clone(&self.submsg_unlabeled),
-            submsg_optional: <self::_puroro::internal::field_type::SingularHeapMessageField::<
-                self::_puroro_root::full_coverage3::msg::Submsg,
+            submsg_optional: <self::_pinternal::field_type::SingularHeapMessageField::<
+                self::_root::full_coverage3::msg::Submsg,
             > as ::std::clone::Clone>::clone(&self.submsg_optional),
-            submsg_repeated: <self::_puroro::internal::field_type::RepeatedMessageField::<
-                self::_puroro_root::full_coverage3::msg::Submsg,
+            submsg_repeated: <self::_pinternal::field_type::RepeatedMessageField::<
+                self::_root::full_coverage3::msg::Submsg,
             > as ::std::clone::Clone>::clone(&self.submsg_repeated),
-            i64_unlabeled: <self::_puroro::internal::field_type::SingularNumericalField::<
+            i64_unlabeled: <self::_pinternal::field_type::SingularNumericalField::<
                 i64,
-                self::_puroro::internal::tags::Int64,
+                self::_pinternal::tags::Int64,
             > as ::std::clone::Clone>::clone(&self.i64_unlabeled),
-            i64_optional: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            i64_optional: <self::_pinternal::field_type::OptionalNumericalField::<
                 i64,
-                self::_puroro::internal::tags::Int64,
+                self::_pinternal::tags::Int64,
                 5usize,
             > as ::std::clone::Clone>::clone(&self.i64_optional),
-            i64_repeated: <self::_puroro::internal::field_type::RepeatedNumericalField::<
+            i64_repeated: <self::_pinternal::field_type::RepeatedNumericalField::<
                 i64,
-                self::_puroro::internal::tags::Int64,
+                self::_pinternal::tags::Int64,
             > as ::std::clone::Clone>::clone(&self.i64_repeated),
-            u32_unlabeled: <self::_puroro::internal::field_type::SingularNumericalField::<
+            u32_unlabeled: <self::_pinternal::field_type::SingularNumericalField::<
                 u32,
-                self::_puroro::internal::tags::UInt32,
+                self::_pinternal::tags::UInt32,
             > as ::std::clone::Clone>::clone(&self.u32_unlabeled),
-            u32_optional: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            u32_optional: <self::_pinternal::field_type::OptionalNumericalField::<
                 u32,
-                self::_puroro::internal::tags::UInt32,
+                self::_pinternal::tags::UInt32,
                 6usize,
             > as ::std::clone::Clone>::clone(&self.u32_optional),
-            u32_repeated: <self::_puroro::internal::field_type::RepeatedNumericalField::<
+            u32_repeated: <self::_pinternal::field_type::RepeatedNumericalField::<
                 u32,
-                self::_puroro::internal::tags::UInt32,
+                self::_pinternal::tags::UInt32,
             > as ::std::clone::Clone>::clone(&self.u32_repeated),
-            u64_unlabeled: <self::_puroro::internal::field_type::SingularNumericalField::<
+            u64_unlabeled: <self::_pinternal::field_type::SingularNumericalField::<
                 u64,
-                self::_puroro::internal::tags::UInt64,
+                self::_pinternal::tags::UInt64,
             > as ::std::clone::Clone>::clone(&self.u64_unlabeled),
-            u64_optional: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            u64_optional: <self::_pinternal::field_type::OptionalNumericalField::<
                 u64,
-                self::_puroro::internal::tags::UInt64,
+                self::_pinternal::tags::UInt64,
                 7usize,
             > as ::std::clone::Clone>::clone(&self.u64_optional),
-            u64_repeated: <self::_puroro::internal::field_type::RepeatedNumericalField::<
+            u64_repeated: <self::_pinternal::field_type::RepeatedNumericalField::<
                 u64,
-                self::_puroro::internal::tags::UInt64,
+                self::_pinternal::tags::UInt64,
             > as ::std::clone::Clone>::clone(&self.u64_repeated),
-            s32_unlabeled: <self::_puroro::internal::field_type::SingularNumericalField::<
+            s32_unlabeled: <self::_pinternal::field_type::SingularNumericalField::<
                 i32,
-                self::_puroro::internal::tags::SInt32,
+                self::_pinternal::tags::SInt32,
             > as ::std::clone::Clone>::clone(&self.s32_unlabeled),
-            s32_optional: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            s32_optional: <self::_pinternal::field_type::OptionalNumericalField::<
                 i32,
-                self::_puroro::internal::tags::SInt32,
+                self::_pinternal::tags::SInt32,
                 8usize,
             > as ::std::clone::Clone>::clone(&self.s32_optional),
-            s32_repeated: <self::_puroro::internal::field_type::RepeatedNumericalField::<
+            s32_repeated: <self::_pinternal::field_type::RepeatedNumericalField::<
                 i32,
-                self::_puroro::internal::tags::SInt32,
+                self::_pinternal::tags::SInt32,
             > as ::std::clone::Clone>::clone(&self.s32_repeated),
-            s64_unlabeled: <self::_puroro::internal::field_type::SingularNumericalField::<
+            s64_unlabeled: <self::_pinternal::field_type::SingularNumericalField::<
                 i64,
-                self::_puroro::internal::tags::SInt64,
+                self::_pinternal::tags::SInt64,
             > as ::std::clone::Clone>::clone(&self.s64_unlabeled),
-            s64_optional: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            s64_optional: <self::_pinternal::field_type::OptionalNumericalField::<
                 i64,
-                self::_puroro::internal::tags::SInt64,
+                self::_pinternal::tags::SInt64,
                 9usize,
             > as ::std::clone::Clone>::clone(&self.s64_optional),
-            s64_repeated: <self::_puroro::internal::field_type::RepeatedNumericalField::<
+            s64_repeated: <self::_pinternal::field_type::RepeatedNumericalField::<
                 i64,
-                self::_puroro::internal::tags::SInt64,
+                self::_pinternal::tags::SInt64,
             > as ::std::clone::Clone>::clone(&self.s64_repeated),
-            fixed32_unlabeled: <self::_puroro::internal::field_type::SingularNumericalField::<
+            fixed32_unlabeled: <self::_pinternal::field_type::SingularNumericalField::<
                 u32,
-                self::_puroro::internal::tags::Fixed32,
+                self::_pinternal::tags::Fixed32,
             > as ::std::clone::Clone>::clone(&self.fixed32_unlabeled),
-            fixed32_optional: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            fixed32_optional: <self::_pinternal::field_type::OptionalNumericalField::<
                 u32,
-                self::_puroro::internal::tags::Fixed32,
+                self::_pinternal::tags::Fixed32,
                 10usize,
             > as ::std::clone::Clone>::clone(&self.fixed32_optional),
-            fixed32_repeated: <self::_puroro::internal::field_type::RepeatedNumericalField::<
+            fixed32_repeated: <self::_pinternal::field_type::RepeatedNumericalField::<
                 u32,
-                self::_puroro::internal::tags::Fixed32,
+                self::_pinternal::tags::Fixed32,
             > as ::std::clone::Clone>::clone(&self.fixed32_repeated),
-            fixed64_unlabeled: <self::_puroro::internal::field_type::SingularNumericalField::<
+            fixed64_unlabeled: <self::_pinternal::field_type::SingularNumericalField::<
                 u64,
-                self::_puroro::internal::tags::Fixed64,
+                self::_pinternal::tags::Fixed64,
             > as ::std::clone::Clone>::clone(&self.fixed64_unlabeled),
-            fixed64_optional: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            fixed64_optional: <self::_pinternal::field_type::OptionalNumericalField::<
                 u64,
-                self::_puroro::internal::tags::Fixed64,
+                self::_pinternal::tags::Fixed64,
                 11usize,
             > as ::std::clone::Clone>::clone(&self.fixed64_optional),
-            fixed64_repeated: <self::_puroro::internal::field_type::RepeatedNumericalField::<
+            fixed64_repeated: <self::_pinternal::field_type::RepeatedNumericalField::<
                 u64,
-                self::_puroro::internal::tags::Fixed64,
+                self::_pinternal::tags::Fixed64,
             > as ::std::clone::Clone>::clone(&self.fixed64_repeated),
-            sfixed32_unlabeled: <self::_puroro::internal::field_type::SingularNumericalField::<
+            sfixed32_unlabeled: <self::_pinternal::field_type::SingularNumericalField::<
                 i32,
-                self::_puroro::internal::tags::SFixed32,
+                self::_pinternal::tags::SFixed32,
             > as ::std::clone::Clone>::clone(&self.sfixed32_unlabeled),
-            sfixed32_optional: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            sfixed32_optional: <self::_pinternal::field_type::OptionalNumericalField::<
                 i32,
-                self::_puroro::internal::tags::SFixed32,
+                self::_pinternal::tags::SFixed32,
                 12usize,
             > as ::std::clone::Clone>::clone(&self.sfixed32_optional),
-            sfixed32_repeated: <self::_puroro::internal::field_type::RepeatedNumericalField::<
+            sfixed32_repeated: <self::_pinternal::field_type::RepeatedNumericalField::<
                 i32,
-                self::_puroro::internal::tags::SFixed32,
+                self::_pinternal::tags::SFixed32,
             > as ::std::clone::Clone>::clone(&self.sfixed32_repeated),
-            sfixed64_unlabeled: <self::_puroro::internal::field_type::SingularNumericalField::<
+            sfixed64_unlabeled: <self::_pinternal::field_type::SingularNumericalField::<
                 i64,
-                self::_puroro::internal::tags::SFixed64,
+                self::_pinternal::tags::SFixed64,
             > as ::std::clone::Clone>::clone(&self.sfixed64_unlabeled),
-            sfixed64_optional: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            sfixed64_optional: <self::_pinternal::field_type::OptionalNumericalField::<
                 i64,
-                self::_puroro::internal::tags::SFixed64,
+                self::_pinternal::tags::SFixed64,
                 13usize,
             > as ::std::clone::Clone>::clone(&self.sfixed64_optional),
-            sfixed64_repeated: <self::_puroro::internal::field_type::RepeatedNumericalField::<
+            sfixed64_repeated: <self::_pinternal::field_type::RepeatedNumericalField::<
                 i64,
-                self::_puroro::internal::tags::SFixed64,
+                self::_pinternal::tags::SFixed64,
             > as ::std::clone::Clone>::clone(&self.sfixed64_repeated),
-            f64_unlabeled: <self::_puroro::internal::field_type::SingularNumericalField::<
+            f64_unlabeled: <self::_pinternal::field_type::SingularNumericalField::<
                 f64,
-                self::_puroro::internal::tags::Double,
+                self::_pinternal::tags::Double,
             > as ::std::clone::Clone>::clone(&self.f64_unlabeled),
-            f64_optional: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            f64_optional: <self::_pinternal::field_type::OptionalNumericalField::<
                 f64,
-                self::_puroro::internal::tags::Double,
+                self::_pinternal::tags::Double,
                 14usize,
             > as ::std::clone::Clone>::clone(&self.f64_optional),
-            f64_repeated: <self::_puroro::internal::field_type::RepeatedNumericalField::<
+            f64_repeated: <self::_pinternal::field_type::RepeatedNumericalField::<
                 f64,
-                self::_puroro::internal::tags::Double,
+                self::_pinternal::tags::Double,
             > as ::std::clone::Clone>::clone(&self.f64_repeated),
             _bitfield: ::std::clone::Clone::clone(&self._bitfield),
         }
@@ -3422,7 +3384,7 @@ impl ::std::clone::Clone for Msg {
 impl ::std::ops::Drop for Msg {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for Msg {
@@ -3485,7 +3447,7 @@ impl ::std::fmt::Debug for Msg {
 impl ::std::cmp::PartialEq for Msg {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         true && self.i32_unlabeled_opt() == rhs.i32_unlabeled_opt()
             && self.i32_optional_opt() == rhs.i32_optional_opt()
             && self.i32_repeated() == rhs.i32_repeated()

--- a/tests-pb/src/full_coverage3.rs
+++ b/tests-pb/src/full_coverage3.rs
@@ -13,216 +13,216 @@ mod _pinternal {
 pub mod msg;
 #[derive(::std::default::Default)]
 pub struct Msg {
-    i32_unlabeled: self::_pinternal::field_type::SingularNumericalField::<
+    i32_unlabeled: self::_pinternal::SingularNumericalField::<
         i32,
         self::_pinternal::tags::Int32,
     >,
-    i32_optional: self::_pinternal::field_type::OptionalNumericalField::<
+    i32_optional: self::_pinternal::OptionalNumericalField::<
         i32,
         self::_pinternal::tags::Int32,
         0usize,
     >,
-    i32_repeated: self::_pinternal::field_type::RepeatedNumericalField::<
+    i32_repeated: self::_pinternal::RepeatedNumericalField::<
         i32,
         self::_pinternal::tags::Int32,
     >,
-    float_unlabeled: self::_pinternal::field_type::SingularNumericalField::<
+    float_unlabeled: self::_pinternal::SingularNumericalField::<
         f32,
         self::_pinternal::tags::Float,
     >,
-    float_optional: self::_pinternal::field_type::OptionalNumericalField::<
+    float_optional: self::_pinternal::OptionalNumericalField::<
         f32,
         self::_pinternal::tags::Float,
         1usize,
     >,
-    float_repeated: self::_pinternal::field_type::RepeatedNumericalField::<
+    float_repeated: self::_pinternal::RepeatedNumericalField::<
         f32,
         self::_pinternal::tags::Float,
     >,
-    bytes_unlabeled: self::_pinternal::field_type::SingularUnsizedField::<
+    bytes_unlabeled: self::_pinternal::SingularUnsizedField::<
         ::std::vec::Vec<u8>,
         self::_pinternal::tags::Bytes,
     >,
-    bytes_optional: self::_pinternal::field_type::OptionalUnsizedField::<
+    bytes_optional: self::_pinternal::OptionalUnsizedField::<
         ::std::vec::Vec<u8>,
         self::_pinternal::tags::Bytes,
         2usize,
     >,
-    bytes_repeated: self::_pinternal::field_type::RepeatedUnsizedField::<
+    bytes_repeated: self::_pinternal::RepeatedUnsizedField::<
         ::std::vec::Vec<u8>,
         self::_pinternal::tags::Bytes,
     >,
-    string_unlabeled: self::_pinternal::field_type::SingularUnsizedField::<
+    string_unlabeled: self::_pinternal::SingularUnsizedField::<
         ::std::string::String,
         self::_pinternal::tags::String,
     >,
-    string_optional: self::_pinternal::field_type::OptionalUnsizedField::<
+    string_optional: self::_pinternal::OptionalUnsizedField::<
         ::std::string::String,
         self::_pinternal::tags::String,
         3usize,
     >,
-    string_repeated: self::_pinternal::field_type::RepeatedUnsizedField::<
+    string_repeated: self::_pinternal::RepeatedUnsizedField::<
         ::std::string::String,
         self::_pinternal::tags::String,
     >,
-    enum_unlabeled: self::_pinternal::field_type::SingularNumericalField::<
+    enum_unlabeled: self::_pinternal::SingularNumericalField::<
         self::_root::full_coverage3::Enum,
         self::_pinternal::tags::Enum3::<self::_root::full_coverage3::Enum>,
     >,
-    enum_optional: self::_pinternal::field_type::OptionalNumericalField::<
+    enum_optional: self::_pinternal::OptionalNumericalField::<
         self::_root::full_coverage3::Enum,
         self::_pinternal::tags::Enum3::<self::_root::full_coverage3::Enum>,
         4usize,
     >,
-    enum_repeated: self::_pinternal::field_type::RepeatedNumericalField::<
+    enum_repeated: self::_pinternal::RepeatedNumericalField::<
         self::_root::full_coverage3::Enum,
         self::_pinternal::tags::Enum3::<self::_root::full_coverage3::Enum>,
     >,
-    submsg_unlabeled: self::_pinternal::field_type::SingularHeapMessageField::<
+    submsg_unlabeled: self::_pinternal::SingularHeapMessageField::<
         self::_root::full_coverage3::msg::Submsg,
     >,
-    submsg_optional: self::_pinternal::field_type::SingularHeapMessageField::<
+    submsg_optional: self::_pinternal::SingularHeapMessageField::<
         self::_root::full_coverage3::msg::Submsg,
     >,
-    submsg_repeated: self::_pinternal::field_type::RepeatedMessageField::<
+    submsg_repeated: self::_pinternal::RepeatedMessageField::<
         self::_root::full_coverage3::msg::Submsg,
     >,
-    i64_unlabeled: self::_pinternal::field_type::SingularNumericalField::<
+    i64_unlabeled: self::_pinternal::SingularNumericalField::<
         i64,
         self::_pinternal::tags::Int64,
     >,
-    i64_optional: self::_pinternal::field_type::OptionalNumericalField::<
+    i64_optional: self::_pinternal::OptionalNumericalField::<
         i64,
         self::_pinternal::tags::Int64,
         5usize,
     >,
-    i64_repeated: self::_pinternal::field_type::RepeatedNumericalField::<
+    i64_repeated: self::_pinternal::RepeatedNumericalField::<
         i64,
         self::_pinternal::tags::Int64,
     >,
-    u32_unlabeled: self::_pinternal::field_type::SingularNumericalField::<
+    u32_unlabeled: self::_pinternal::SingularNumericalField::<
         u32,
         self::_pinternal::tags::UInt32,
     >,
-    u32_optional: self::_pinternal::field_type::OptionalNumericalField::<
+    u32_optional: self::_pinternal::OptionalNumericalField::<
         u32,
         self::_pinternal::tags::UInt32,
         6usize,
     >,
-    u32_repeated: self::_pinternal::field_type::RepeatedNumericalField::<
+    u32_repeated: self::_pinternal::RepeatedNumericalField::<
         u32,
         self::_pinternal::tags::UInt32,
     >,
-    u64_unlabeled: self::_pinternal::field_type::SingularNumericalField::<
+    u64_unlabeled: self::_pinternal::SingularNumericalField::<
         u64,
         self::_pinternal::tags::UInt64,
     >,
-    u64_optional: self::_pinternal::field_type::OptionalNumericalField::<
+    u64_optional: self::_pinternal::OptionalNumericalField::<
         u64,
         self::_pinternal::tags::UInt64,
         7usize,
     >,
-    u64_repeated: self::_pinternal::field_type::RepeatedNumericalField::<
+    u64_repeated: self::_pinternal::RepeatedNumericalField::<
         u64,
         self::_pinternal::tags::UInt64,
     >,
-    s32_unlabeled: self::_pinternal::field_type::SingularNumericalField::<
+    s32_unlabeled: self::_pinternal::SingularNumericalField::<
         i32,
         self::_pinternal::tags::SInt32,
     >,
-    s32_optional: self::_pinternal::field_type::OptionalNumericalField::<
+    s32_optional: self::_pinternal::OptionalNumericalField::<
         i32,
         self::_pinternal::tags::SInt32,
         8usize,
     >,
-    s32_repeated: self::_pinternal::field_type::RepeatedNumericalField::<
+    s32_repeated: self::_pinternal::RepeatedNumericalField::<
         i32,
         self::_pinternal::tags::SInt32,
     >,
-    s64_unlabeled: self::_pinternal::field_type::SingularNumericalField::<
+    s64_unlabeled: self::_pinternal::SingularNumericalField::<
         i64,
         self::_pinternal::tags::SInt64,
     >,
-    s64_optional: self::_pinternal::field_type::OptionalNumericalField::<
+    s64_optional: self::_pinternal::OptionalNumericalField::<
         i64,
         self::_pinternal::tags::SInt64,
         9usize,
     >,
-    s64_repeated: self::_pinternal::field_type::RepeatedNumericalField::<
+    s64_repeated: self::_pinternal::RepeatedNumericalField::<
         i64,
         self::_pinternal::tags::SInt64,
     >,
-    fixed32_unlabeled: self::_pinternal::field_type::SingularNumericalField::<
+    fixed32_unlabeled: self::_pinternal::SingularNumericalField::<
         u32,
         self::_pinternal::tags::Fixed32,
     >,
-    fixed32_optional: self::_pinternal::field_type::OptionalNumericalField::<
+    fixed32_optional: self::_pinternal::OptionalNumericalField::<
         u32,
         self::_pinternal::tags::Fixed32,
         10usize,
     >,
-    fixed32_repeated: self::_pinternal::field_type::RepeatedNumericalField::<
+    fixed32_repeated: self::_pinternal::RepeatedNumericalField::<
         u32,
         self::_pinternal::tags::Fixed32,
     >,
-    fixed64_unlabeled: self::_pinternal::field_type::SingularNumericalField::<
+    fixed64_unlabeled: self::_pinternal::SingularNumericalField::<
         u64,
         self::_pinternal::tags::Fixed64,
     >,
-    fixed64_optional: self::_pinternal::field_type::OptionalNumericalField::<
+    fixed64_optional: self::_pinternal::OptionalNumericalField::<
         u64,
         self::_pinternal::tags::Fixed64,
         11usize,
     >,
-    fixed64_repeated: self::_pinternal::field_type::RepeatedNumericalField::<
+    fixed64_repeated: self::_pinternal::RepeatedNumericalField::<
         u64,
         self::_pinternal::tags::Fixed64,
     >,
-    sfixed32_unlabeled: self::_pinternal::field_type::SingularNumericalField::<
+    sfixed32_unlabeled: self::_pinternal::SingularNumericalField::<
         i32,
         self::_pinternal::tags::SFixed32,
     >,
-    sfixed32_optional: self::_pinternal::field_type::OptionalNumericalField::<
+    sfixed32_optional: self::_pinternal::OptionalNumericalField::<
         i32,
         self::_pinternal::tags::SFixed32,
         12usize,
     >,
-    sfixed32_repeated: self::_pinternal::field_type::RepeatedNumericalField::<
+    sfixed32_repeated: self::_pinternal::RepeatedNumericalField::<
         i32,
         self::_pinternal::tags::SFixed32,
     >,
-    sfixed64_unlabeled: self::_pinternal::field_type::SingularNumericalField::<
+    sfixed64_unlabeled: self::_pinternal::SingularNumericalField::<
         i64,
         self::_pinternal::tags::SFixed64,
     >,
-    sfixed64_optional: self::_pinternal::field_type::OptionalNumericalField::<
+    sfixed64_optional: self::_pinternal::OptionalNumericalField::<
         i64,
         self::_pinternal::tags::SFixed64,
         13usize,
     >,
-    sfixed64_repeated: self::_pinternal::field_type::RepeatedNumericalField::<
+    sfixed64_repeated: self::_pinternal::RepeatedNumericalField::<
         i64,
         self::_pinternal::tags::SFixed64,
     >,
-    f64_unlabeled: self::_pinternal::field_type::SingularNumericalField::<
+    f64_unlabeled: self::_pinternal::SingularNumericalField::<
         f64,
         self::_pinternal::tags::Double,
     >,
-    f64_optional: self::_pinternal::field_type::OptionalNumericalField::<
+    f64_optional: self::_pinternal::OptionalNumericalField::<
         f64,
         self::_pinternal::tags::Double,
         14usize,
     >,
-    f64_repeated: self::_pinternal::field_type::RepeatedNumericalField::<
+    f64_repeated: self::_pinternal::RepeatedNumericalField::<
         f64,
         self::_pinternal::tags::Double,
     >,
-    _bitfield: self::_pinternal::bitvec::BitArray<1usize>,
+    _bitfield: self::_pinternal::BitArray<1usize>,
 }
 impl Msg {
     pub fn i32_unlabeled(&self) -> i32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
         > as NonRepeatedFieldType>::get_field_or_else(
@@ -232,15 +232,15 @@ impl Msg {
         )
     }
     pub fn i32_unlabeled_opt(&self) -> ::std::option::Option::<i32> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
         > as NonRepeatedFieldType>::get_field_opt(&self.i32_unlabeled, &self._bitfield)
     }
     pub fn i32_unlabeled_mut(&mut self) -> &mut i32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
         > as NonRepeatedFieldType>::get_field_mut(
@@ -250,23 +250,23 @@ impl Msg {
         )
     }
     pub fn has_i32_unlabeled(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
         > as NonRepeatedFieldType>::get_field_opt(&self.i32_unlabeled, &self._bitfield)
             .is_some()
     }
     pub fn clear_i32_unlabeled(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
         > as NonRepeatedFieldType>::clear(&mut self.i32_unlabeled, &mut self._bitfield)
     }
     pub fn i32_optional(&self) -> i32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             0usize,
@@ -277,16 +277,16 @@ impl Msg {
         )
     }
     pub fn i32_optional_opt(&self) -> ::std::option::Option::<i32> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.i32_optional, &self._bitfield)
     }
     pub fn i32_optional_mut(&mut self) -> &mut i32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             0usize,
@@ -297,8 +297,8 @@ impl Msg {
         )
     }
     pub fn has_i32_optional(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             0usize,
@@ -306,23 +306,23 @@ impl Msg {
             .is_some()
     }
     pub fn clear_i32_optional(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             0usize,
         > as NonRepeatedFieldType>::clear(&mut self.i32_optional, &mut self._bitfield)
     }
     pub fn i32_repeated(&self) -> &[i32] {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
         > as RepeatedFieldType>::get_field(&self.i32_repeated, &self._bitfield)
     }
     pub fn i32_repeated_mut(&mut self) -> &mut ::std::vec::Vec::<i32> {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
         > as RepeatedFieldType>::get_field_mut(
@@ -331,15 +331,15 @@ impl Msg {
         )
     }
     pub fn clear_i32_repeated(&mut self) {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
         > as RepeatedFieldType>::clear(&mut self.i32_repeated, &mut self._bitfield)
     }
     pub fn float_unlabeled(&self) -> f32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             f32,
             self::_pinternal::tags::Float,
         > as NonRepeatedFieldType>::get_field_or_else(
@@ -349,15 +349,15 @@ impl Msg {
         )
     }
     pub fn float_unlabeled_opt(&self) -> ::std::option::Option::<f32> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             f32,
             self::_pinternal::tags::Float,
         > as NonRepeatedFieldType>::get_field_opt(&self.float_unlabeled, &self._bitfield)
     }
     pub fn float_unlabeled_mut(&mut self) -> &mut f32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             f32,
             self::_pinternal::tags::Float,
         > as NonRepeatedFieldType>::get_field_mut(
@@ -367,23 +367,23 @@ impl Msg {
         )
     }
     pub fn has_float_unlabeled(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             f32,
             self::_pinternal::tags::Float,
         > as NonRepeatedFieldType>::get_field_opt(&self.float_unlabeled, &self._bitfield)
             .is_some()
     }
     pub fn clear_float_unlabeled(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             f32,
             self::_pinternal::tags::Float,
         > as NonRepeatedFieldType>::clear(&mut self.float_unlabeled, &mut self._bitfield)
     }
     pub fn float_optional(&self) -> f32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             f32,
             self::_pinternal::tags::Float,
             1usize,
@@ -394,16 +394,16 @@ impl Msg {
         )
     }
     pub fn float_optional_opt(&self) -> ::std::option::Option::<f32> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             f32,
             self::_pinternal::tags::Float,
             1usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.float_optional, &self._bitfield)
     }
     pub fn float_optional_mut(&mut self) -> &mut f32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             f32,
             self::_pinternal::tags::Float,
             1usize,
@@ -414,8 +414,8 @@ impl Msg {
         )
     }
     pub fn has_float_optional(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             f32,
             self::_pinternal::tags::Float,
             1usize,
@@ -423,23 +423,23 @@ impl Msg {
             .is_some()
     }
     pub fn clear_float_optional(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             f32,
             self::_pinternal::tags::Float,
             1usize,
         > as NonRepeatedFieldType>::clear(&mut self.float_optional, &mut self._bitfield)
     }
     pub fn float_repeated(&self) -> &[f32] {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             f32,
             self::_pinternal::tags::Float,
         > as RepeatedFieldType>::get_field(&self.float_repeated, &self._bitfield)
     }
     pub fn float_repeated_mut(&mut self) -> &mut ::std::vec::Vec::<f32> {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             f32,
             self::_pinternal::tags::Float,
         > as RepeatedFieldType>::get_field_mut(
@@ -448,15 +448,15 @@ impl Msg {
         )
     }
     pub fn clear_float_repeated(&mut self) {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             f32,
             self::_pinternal::tags::Float,
         > as RepeatedFieldType>::clear(&mut self.float_repeated, &mut self._bitfield)
     }
     pub fn bytes_unlabeled(&self) -> &[u8] {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularUnsizedField::<
             ::std::vec::Vec<u8>,
             self::_pinternal::tags::Bytes,
         > as NonRepeatedFieldType>::get_field_or_else(
@@ -466,15 +466,15 @@ impl Msg {
         )
     }
     pub fn bytes_unlabeled_opt(&self) -> ::std::option::Option::<&[u8]> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularUnsizedField::<
             ::std::vec::Vec<u8>,
             self::_pinternal::tags::Bytes,
         > as NonRepeatedFieldType>::get_field_opt(&self.bytes_unlabeled, &self._bitfield)
     }
     pub fn bytes_unlabeled_mut(&mut self) -> &mut ::std::vec::Vec::<u8> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularUnsizedField::<
             ::std::vec::Vec<u8>,
             self::_pinternal::tags::Bytes,
         > as NonRepeatedFieldType>::get_field_mut(
@@ -484,23 +484,23 @@ impl Msg {
         )
     }
     pub fn has_bytes_unlabeled(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularUnsizedField::<
             ::std::vec::Vec<u8>,
             self::_pinternal::tags::Bytes,
         > as NonRepeatedFieldType>::get_field_opt(&self.bytes_unlabeled, &self._bitfield)
             .is_some()
     }
     pub fn clear_bytes_unlabeled(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularUnsizedField::<
             ::std::vec::Vec<u8>,
             self::_pinternal::tags::Bytes,
         > as NonRepeatedFieldType>::clear(&mut self.bytes_unlabeled, &mut self._bitfield)
     }
     pub fn bytes_optional(&self) -> &[u8] {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::vec::Vec<u8>,
             self::_pinternal::tags::Bytes,
             2usize,
@@ -511,16 +511,16 @@ impl Msg {
         )
     }
     pub fn bytes_optional_opt(&self) -> ::std::option::Option::<&[u8]> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::vec::Vec<u8>,
             self::_pinternal::tags::Bytes,
             2usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.bytes_optional, &self._bitfield)
     }
     pub fn bytes_optional_mut(&mut self) -> &mut ::std::vec::Vec::<u8> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::vec::Vec<u8>,
             self::_pinternal::tags::Bytes,
             2usize,
@@ -531,8 +531,8 @@ impl Msg {
         )
     }
     pub fn has_bytes_optional(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::vec::Vec<u8>,
             self::_pinternal::tags::Bytes,
             2usize,
@@ -540,8 +540,8 @@ impl Msg {
             .is_some()
     }
     pub fn clear_bytes_optional(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::vec::Vec<u8>,
             self::_pinternal::tags::Bytes,
             2usize,
@@ -552,15 +552,15 @@ impl Msg {
     ) -> &[impl ::std::ops::Deref::<
         Target = [u8],
     > + ::std::fmt::Debug + ::std::cmp::PartialEq] {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedUnsizedField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedUnsizedField::<
             ::std::vec::Vec<u8>,
             self::_pinternal::tags::Bytes,
         > as RepeatedFieldType>::get_field(&self.bytes_repeated, &self._bitfield)
     }
     pub fn bytes_repeated_mut(&mut self) -> &mut ::std::vec::Vec::<::std::vec::Vec<u8>> {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedUnsizedField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedUnsizedField::<
             ::std::vec::Vec<u8>,
             self::_pinternal::tags::Bytes,
         > as RepeatedFieldType>::get_field_mut(
@@ -569,15 +569,15 @@ impl Msg {
         )
     }
     pub fn clear_bytes_repeated(&mut self) {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedUnsizedField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedUnsizedField::<
             ::std::vec::Vec<u8>,
             self::_pinternal::tags::Bytes,
         > as RepeatedFieldType>::clear(&mut self.bytes_repeated, &mut self._bitfield)
     }
     pub fn string_unlabeled(&self) -> &str {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
         > as NonRepeatedFieldType>::get_field_or_else(
@@ -587,8 +587,8 @@ impl Msg {
         )
     }
     pub fn string_unlabeled_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
         > as NonRepeatedFieldType>::get_field_opt(
@@ -597,8 +597,8 @@ impl Msg {
         )
     }
     pub fn string_unlabeled_mut(&mut self) -> &mut ::std::string::String {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
         > as NonRepeatedFieldType>::get_field_mut(
@@ -608,8 +608,8 @@ impl Msg {
         )
     }
     pub fn has_string_unlabeled(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
         > as NonRepeatedFieldType>::get_field_opt(
@@ -619,8 +619,8 @@ impl Msg {
             .is_some()
     }
     pub fn clear_string_unlabeled(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
         > as NonRepeatedFieldType>::clear(
@@ -629,8 +629,8 @@ impl Msg {
         )
     }
     pub fn string_optional(&self) -> &str {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             3usize,
@@ -641,16 +641,16 @@ impl Msg {
         )
     }
     pub fn string_optional_opt(&self) -> ::std::option::Option::<&str> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             3usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.string_optional, &self._bitfield)
     }
     pub fn string_optional_mut(&mut self) -> &mut ::std::string::String {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             3usize,
@@ -661,8 +661,8 @@ impl Msg {
         )
     }
     pub fn has_string_optional(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             3usize,
@@ -670,8 +670,8 @@ impl Msg {
             .is_some()
     }
     pub fn clear_string_optional(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             3usize,
@@ -682,8 +682,8 @@ impl Msg {
     ) -> &[impl ::std::ops::Deref::<
         Target = str,
     > + ::std::fmt::Debug + ::std::cmp::PartialEq] {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedUnsizedField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
         > as RepeatedFieldType>::get_field(&self.string_repeated, &self._bitfield)
@@ -691,8 +691,8 @@ impl Msg {
     pub fn string_repeated_mut(
         &mut self,
     ) -> &mut ::std::vec::Vec::<::std::string::String> {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedUnsizedField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
         > as RepeatedFieldType>::get_field_mut(
@@ -701,15 +701,15 @@ impl Msg {
         )
     }
     pub fn clear_string_repeated(&mut self) {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedUnsizedField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
         > as RepeatedFieldType>::clear(&mut self.string_repeated, &mut self._bitfield)
     }
     pub fn enum_unlabeled(&self) -> self::_root::full_coverage3::Enum {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             self::_root::full_coverage3::Enum,
             self::_pinternal::tags::Enum3::<self::_root::full_coverage3::Enum>,
         > as NonRepeatedFieldType>::get_field_or_else(
@@ -721,15 +721,15 @@ impl Msg {
     pub fn enum_unlabeled_opt(
         &self,
     ) -> ::std::option::Option::<self::_root::full_coverage3::Enum> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             self::_root::full_coverage3::Enum,
             self::_pinternal::tags::Enum3::<self::_root::full_coverage3::Enum>,
         > as NonRepeatedFieldType>::get_field_opt(&self.enum_unlabeled, &self._bitfield)
     }
     pub fn enum_unlabeled_mut(&mut self) -> &mut self::_root::full_coverage3::Enum {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             self::_root::full_coverage3::Enum,
             self::_pinternal::tags::Enum3::<self::_root::full_coverage3::Enum>,
         > as NonRepeatedFieldType>::get_field_mut(
@@ -739,23 +739,23 @@ impl Msg {
         )
     }
     pub fn has_enum_unlabeled(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             self::_root::full_coverage3::Enum,
             self::_pinternal::tags::Enum3::<self::_root::full_coverage3::Enum>,
         > as NonRepeatedFieldType>::get_field_opt(&self.enum_unlabeled, &self._bitfield)
             .is_some()
     }
     pub fn clear_enum_unlabeled(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             self::_root::full_coverage3::Enum,
             self::_pinternal::tags::Enum3::<self::_root::full_coverage3::Enum>,
         > as NonRepeatedFieldType>::clear(&mut self.enum_unlabeled, &mut self._bitfield)
     }
     pub fn enum_optional(&self) -> self::_root::full_coverage3::Enum {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             self::_root::full_coverage3::Enum,
             self::_pinternal::tags::Enum3::<self::_root::full_coverage3::Enum>,
             4usize,
@@ -768,16 +768,16 @@ impl Msg {
     pub fn enum_optional_opt(
         &self,
     ) -> ::std::option::Option::<self::_root::full_coverage3::Enum> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             self::_root::full_coverage3::Enum,
             self::_pinternal::tags::Enum3::<self::_root::full_coverage3::Enum>,
             4usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.enum_optional, &self._bitfield)
     }
     pub fn enum_optional_mut(&mut self) -> &mut self::_root::full_coverage3::Enum {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             self::_root::full_coverage3::Enum,
             self::_pinternal::tags::Enum3::<self::_root::full_coverage3::Enum>,
             4usize,
@@ -788,8 +788,8 @@ impl Msg {
         )
     }
     pub fn has_enum_optional(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             self::_root::full_coverage3::Enum,
             self::_pinternal::tags::Enum3::<self::_root::full_coverage3::Enum>,
             4usize,
@@ -797,16 +797,16 @@ impl Msg {
             .is_some()
     }
     pub fn clear_enum_optional(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             self::_root::full_coverage3::Enum,
             self::_pinternal::tags::Enum3::<self::_root::full_coverage3::Enum>,
             4usize,
         > as NonRepeatedFieldType>::clear(&mut self.enum_optional, &mut self._bitfield)
     }
     pub fn enum_repeated(&self) -> &[self::_root::full_coverage3::Enum] {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             self::_root::full_coverage3::Enum,
             self::_pinternal::tags::Enum3::<self::_root::full_coverage3::Enum>,
         > as RepeatedFieldType>::get_field(&self.enum_repeated, &self._bitfield)
@@ -814,8 +814,8 @@ impl Msg {
     pub fn enum_repeated_mut(
         &mut self,
     ) -> &mut ::std::vec::Vec::<self::_root::full_coverage3::Enum> {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             self::_root::full_coverage3::Enum,
             self::_pinternal::tags::Enum3::<self::_root::full_coverage3::Enum>,
         > as RepeatedFieldType>::get_field_mut(
@@ -824,8 +824,8 @@ impl Msg {
         )
     }
     pub fn clear_enum_repeated(&mut self) {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             self::_root::full_coverage3::Enum,
             self::_pinternal::tags::Enum3::<self::_root::full_coverage3::Enum>,
         > as RepeatedFieldType>::clear(&mut self.enum_repeated, &mut self._bitfield)
@@ -833,8 +833,8 @@ impl Msg {
     pub fn submsg_unlabeled(
         &self,
     ) -> ::std::option::Option::<&self::_root::full_coverage3::msg::Submsg> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::full_coverage3::msg::Submsg,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.submsg_unlabeled,
@@ -845,8 +845,8 @@ impl Msg {
     pub fn submsg_unlabeled_opt(
         &self,
     ) -> ::std::option::Option::<&self::_root::full_coverage3::msg::Submsg> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::full_coverage3::msg::Submsg,
         > as NonRepeatedFieldType>::get_field_opt(
             &self.submsg_unlabeled,
@@ -856,8 +856,8 @@ impl Msg {
     pub fn submsg_unlabeled_mut(
         &mut self,
     ) -> &mut self::_root::full_coverage3::msg::Submsg {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::full_coverage3::msg::Submsg,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.submsg_unlabeled,
@@ -866,8 +866,8 @@ impl Msg {
         )
     }
     pub fn has_submsg_unlabeled(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::full_coverage3::msg::Submsg,
         > as NonRepeatedFieldType>::get_field_opt(
                 &self.submsg_unlabeled,
@@ -876,8 +876,8 @@ impl Msg {
             .is_some()
     }
     pub fn clear_submsg_unlabeled(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::full_coverage3::msg::Submsg,
         > as NonRepeatedFieldType>::clear(
             &mut self.submsg_unlabeled,
@@ -887,8 +887,8 @@ impl Msg {
     pub fn submsg_optional(
         &self,
     ) -> ::std::option::Option::<&self::_root::full_coverage3::msg::Submsg> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::full_coverage3::msg::Submsg,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.submsg_optional,
@@ -899,16 +899,16 @@ impl Msg {
     pub fn submsg_optional_opt(
         &self,
     ) -> ::std::option::Option::<&self::_root::full_coverage3::msg::Submsg> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::full_coverage3::msg::Submsg,
         > as NonRepeatedFieldType>::get_field_opt(&self.submsg_optional, &self._bitfield)
     }
     pub fn submsg_optional_mut(
         &mut self,
     ) -> &mut self::_root::full_coverage3::msg::Submsg {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::full_coverage3::msg::Submsg,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.submsg_optional,
@@ -917,29 +917,29 @@ impl Msg {
         )
     }
     pub fn has_submsg_optional(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::full_coverage3::msg::Submsg,
         > as NonRepeatedFieldType>::get_field_opt(&self.submsg_optional, &self._bitfield)
             .is_some()
     }
     pub fn clear_submsg_optional(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::full_coverage3::msg::Submsg,
         > as NonRepeatedFieldType>::clear(&mut self.submsg_optional, &mut self._bitfield)
     }
     pub fn submsg_repeated(&self) -> &[self::_root::full_coverage3::msg::Submsg] {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::full_coverage3::msg::Submsg,
         > as RepeatedFieldType>::get_field(&self.submsg_repeated, &self._bitfield)
     }
     pub fn submsg_repeated_mut(
         &mut self,
     ) -> &mut ::std::vec::Vec::<self::_root::full_coverage3::msg::Submsg> {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::full_coverage3::msg::Submsg,
         > as RepeatedFieldType>::get_field_mut(
             &mut self.submsg_repeated,
@@ -947,14 +947,14 @@ impl Msg {
         )
     }
     pub fn clear_submsg_repeated(&mut self) {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::full_coverage3::msg::Submsg,
         > as RepeatedFieldType>::clear(&mut self.submsg_repeated, &mut self._bitfield)
     }
     pub fn i64_unlabeled(&self) -> i64 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             i64,
             self::_pinternal::tags::Int64,
         > as NonRepeatedFieldType>::get_field_or_else(
@@ -964,15 +964,15 @@ impl Msg {
         )
     }
     pub fn i64_unlabeled_opt(&self) -> ::std::option::Option::<i64> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             i64,
             self::_pinternal::tags::Int64,
         > as NonRepeatedFieldType>::get_field_opt(&self.i64_unlabeled, &self._bitfield)
     }
     pub fn i64_unlabeled_mut(&mut self) -> &mut i64 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             i64,
             self::_pinternal::tags::Int64,
         > as NonRepeatedFieldType>::get_field_mut(
@@ -982,23 +982,23 @@ impl Msg {
         )
     }
     pub fn has_i64_unlabeled(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             i64,
             self::_pinternal::tags::Int64,
         > as NonRepeatedFieldType>::get_field_opt(&self.i64_unlabeled, &self._bitfield)
             .is_some()
     }
     pub fn clear_i64_unlabeled(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             i64,
             self::_pinternal::tags::Int64,
         > as NonRepeatedFieldType>::clear(&mut self.i64_unlabeled, &mut self._bitfield)
     }
     pub fn i64_optional(&self) -> i64 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i64,
             self::_pinternal::tags::Int64,
             5usize,
@@ -1009,16 +1009,16 @@ impl Msg {
         )
     }
     pub fn i64_optional_opt(&self) -> ::std::option::Option::<i64> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i64,
             self::_pinternal::tags::Int64,
             5usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.i64_optional, &self._bitfield)
     }
     pub fn i64_optional_mut(&mut self) -> &mut i64 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i64,
             self::_pinternal::tags::Int64,
             5usize,
@@ -1029,8 +1029,8 @@ impl Msg {
         )
     }
     pub fn has_i64_optional(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i64,
             self::_pinternal::tags::Int64,
             5usize,
@@ -1038,23 +1038,23 @@ impl Msg {
             .is_some()
     }
     pub fn clear_i64_optional(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i64,
             self::_pinternal::tags::Int64,
             5usize,
         > as NonRepeatedFieldType>::clear(&mut self.i64_optional, &mut self._bitfield)
     }
     pub fn i64_repeated(&self) -> &[i64] {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             i64,
             self::_pinternal::tags::Int64,
         > as RepeatedFieldType>::get_field(&self.i64_repeated, &self._bitfield)
     }
     pub fn i64_repeated_mut(&mut self) -> &mut ::std::vec::Vec::<i64> {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             i64,
             self::_pinternal::tags::Int64,
         > as RepeatedFieldType>::get_field_mut(
@@ -1063,15 +1063,15 @@ impl Msg {
         )
     }
     pub fn clear_i64_repeated(&mut self) {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             i64,
             self::_pinternal::tags::Int64,
         > as RepeatedFieldType>::clear(&mut self.i64_repeated, &mut self._bitfield)
     }
     pub fn u32_unlabeled(&self) -> u32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             u32,
             self::_pinternal::tags::UInt32,
         > as NonRepeatedFieldType>::get_field_or_else(
@@ -1081,15 +1081,15 @@ impl Msg {
         )
     }
     pub fn u32_unlabeled_opt(&self) -> ::std::option::Option::<u32> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             u32,
             self::_pinternal::tags::UInt32,
         > as NonRepeatedFieldType>::get_field_opt(&self.u32_unlabeled, &self._bitfield)
     }
     pub fn u32_unlabeled_mut(&mut self) -> &mut u32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             u32,
             self::_pinternal::tags::UInt32,
         > as NonRepeatedFieldType>::get_field_mut(
@@ -1099,23 +1099,23 @@ impl Msg {
         )
     }
     pub fn has_u32_unlabeled(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             u32,
             self::_pinternal::tags::UInt32,
         > as NonRepeatedFieldType>::get_field_opt(&self.u32_unlabeled, &self._bitfield)
             .is_some()
     }
     pub fn clear_u32_unlabeled(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             u32,
             self::_pinternal::tags::UInt32,
         > as NonRepeatedFieldType>::clear(&mut self.u32_unlabeled, &mut self._bitfield)
     }
     pub fn u32_optional(&self) -> u32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             u32,
             self::_pinternal::tags::UInt32,
             6usize,
@@ -1126,16 +1126,16 @@ impl Msg {
         )
     }
     pub fn u32_optional_opt(&self) -> ::std::option::Option::<u32> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             u32,
             self::_pinternal::tags::UInt32,
             6usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.u32_optional, &self._bitfield)
     }
     pub fn u32_optional_mut(&mut self) -> &mut u32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             u32,
             self::_pinternal::tags::UInt32,
             6usize,
@@ -1146,8 +1146,8 @@ impl Msg {
         )
     }
     pub fn has_u32_optional(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             u32,
             self::_pinternal::tags::UInt32,
             6usize,
@@ -1155,23 +1155,23 @@ impl Msg {
             .is_some()
     }
     pub fn clear_u32_optional(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             u32,
             self::_pinternal::tags::UInt32,
             6usize,
         > as NonRepeatedFieldType>::clear(&mut self.u32_optional, &mut self._bitfield)
     }
     pub fn u32_repeated(&self) -> &[u32] {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             u32,
             self::_pinternal::tags::UInt32,
         > as RepeatedFieldType>::get_field(&self.u32_repeated, &self._bitfield)
     }
     pub fn u32_repeated_mut(&mut self) -> &mut ::std::vec::Vec::<u32> {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             u32,
             self::_pinternal::tags::UInt32,
         > as RepeatedFieldType>::get_field_mut(
@@ -1180,15 +1180,15 @@ impl Msg {
         )
     }
     pub fn clear_u32_repeated(&mut self) {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             u32,
             self::_pinternal::tags::UInt32,
         > as RepeatedFieldType>::clear(&mut self.u32_repeated, &mut self._bitfield)
     }
     pub fn u64_unlabeled(&self) -> u64 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             u64,
             self::_pinternal::tags::UInt64,
         > as NonRepeatedFieldType>::get_field_or_else(
@@ -1198,15 +1198,15 @@ impl Msg {
         )
     }
     pub fn u64_unlabeled_opt(&self) -> ::std::option::Option::<u64> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             u64,
             self::_pinternal::tags::UInt64,
         > as NonRepeatedFieldType>::get_field_opt(&self.u64_unlabeled, &self._bitfield)
     }
     pub fn u64_unlabeled_mut(&mut self) -> &mut u64 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             u64,
             self::_pinternal::tags::UInt64,
         > as NonRepeatedFieldType>::get_field_mut(
@@ -1216,23 +1216,23 @@ impl Msg {
         )
     }
     pub fn has_u64_unlabeled(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             u64,
             self::_pinternal::tags::UInt64,
         > as NonRepeatedFieldType>::get_field_opt(&self.u64_unlabeled, &self._bitfield)
             .is_some()
     }
     pub fn clear_u64_unlabeled(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             u64,
             self::_pinternal::tags::UInt64,
         > as NonRepeatedFieldType>::clear(&mut self.u64_unlabeled, &mut self._bitfield)
     }
     pub fn u64_optional(&self) -> u64 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             u64,
             self::_pinternal::tags::UInt64,
             7usize,
@@ -1243,16 +1243,16 @@ impl Msg {
         )
     }
     pub fn u64_optional_opt(&self) -> ::std::option::Option::<u64> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             u64,
             self::_pinternal::tags::UInt64,
             7usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.u64_optional, &self._bitfield)
     }
     pub fn u64_optional_mut(&mut self) -> &mut u64 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             u64,
             self::_pinternal::tags::UInt64,
             7usize,
@@ -1263,8 +1263,8 @@ impl Msg {
         )
     }
     pub fn has_u64_optional(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             u64,
             self::_pinternal::tags::UInt64,
             7usize,
@@ -1272,23 +1272,23 @@ impl Msg {
             .is_some()
     }
     pub fn clear_u64_optional(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             u64,
             self::_pinternal::tags::UInt64,
             7usize,
         > as NonRepeatedFieldType>::clear(&mut self.u64_optional, &mut self._bitfield)
     }
     pub fn u64_repeated(&self) -> &[u64] {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             u64,
             self::_pinternal::tags::UInt64,
         > as RepeatedFieldType>::get_field(&self.u64_repeated, &self._bitfield)
     }
     pub fn u64_repeated_mut(&mut self) -> &mut ::std::vec::Vec::<u64> {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             u64,
             self::_pinternal::tags::UInt64,
         > as RepeatedFieldType>::get_field_mut(
@@ -1297,15 +1297,15 @@ impl Msg {
         )
     }
     pub fn clear_u64_repeated(&mut self) {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             u64,
             self::_pinternal::tags::UInt64,
         > as RepeatedFieldType>::clear(&mut self.u64_repeated, &mut self._bitfield)
     }
     pub fn s32_unlabeled(&self) -> i32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             i32,
             self::_pinternal::tags::SInt32,
         > as NonRepeatedFieldType>::get_field_or_else(
@@ -1315,15 +1315,15 @@ impl Msg {
         )
     }
     pub fn s32_unlabeled_opt(&self) -> ::std::option::Option::<i32> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             i32,
             self::_pinternal::tags::SInt32,
         > as NonRepeatedFieldType>::get_field_opt(&self.s32_unlabeled, &self._bitfield)
     }
     pub fn s32_unlabeled_mut(&mut self) -> &mut i32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             i32,
             self::_pinternal::tags::SInt32,
         > as NonRepeatedFieldType>::get_field_mut(
@@ -1333,23 +1333,23 @@ impl Msg {
         )
     }
     pub fn has_s32_unlabeled(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             i32,
             self::_pinternal::tags::SInt32,
         > as NonRepeatedFieldType>::get_field_opt(&self.s32_unlabeled, &self._bitfield)
             .is_some()
     }
     pub fn clear_s32_unlabeled(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             i32,
             self::_pinternal::tags::SInt32,
         > as NonRepeatedFieldType>::clear(&mut self.s32_unlabeled, &mut self._bitfield)
     }
     pub fn s32_optional(&self) -> i32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::SInt32,
             8usize,
@@ -1360,16 +1360,16 @@ impl Msg {
         )
     }
     pub fn s32_optional_opt(&self) -> ::std::option::Option::<i32> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::SInt32,
             8usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.s32_optional, &self._bitfield)
     }
     pub fn s32_optional_mut(&mut self) -> &mut i32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::SInt32,
             8usize,
@@ -1380,8 +1380,8 @@ impl Msg {
         )
     }
     pub fn has_s32_optional(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::SInt32,
             8usize,
@@ -1389,23 +1389,23 @@ impl Msg {
             .is_some()
     }
     pub fn clear_s32_optional(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::SInt32,
             8usize,
         > as NonRepeatedFieldType>::clear(&mut self.s32_optional, &mut self._bitfield)
     }
     pub fn s32_repeated(&self) -> &[i32] {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             i32,
             self::_pinternal::tags::SInt32,
         > as RepeatedFieldType>::get_field(&self.s32_repeated, &self._bitfield)
     }
     pub fn s32_repeated_mut(&mut self) -> &mut ::std::vec::Vec::<i32> {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             i32,
             self::_pinternal::tags::SInt32,
         > as RepeatedFieldType>::get_field_mut(
@@ -1414,15 +1414,15 @@ impl Msg {
         )
     }
     pub fn clear_s32_repeated(&mut self) {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             i32,
             self::_pinternal::tags::SInt32,
         > as RepeatedFieldType>::clear(&mut self.s32_repeated, &mut self._bitfield)
     }
     pub fn s64_unlabeled(&self) -> i64 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             i64,
             self::_pinternal::tags::SInt64,
         > as NonRepeatedFieldType>::get_field_or_else(
@@ -1432,15 +1432,15 @@ impl Msg {
         )
     }
     pub fn s64_unlabeled_opt(&self) -> ::std::option::Option::<i64> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             i64,
             self::_pinternal::tags::SInt64,
         > as NonRepeatedFieldType>::get_field_opt(&self.s64_unlabeled, &self._bitfield)
     }
     pub fn s64_unlabeled_mut(&mut self) -> &mut i64 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             i64,
             self::_pinternal::tags::SInt64,
         > as NonRepeatedFieldType>::get_field_mut(
@@ -1450,23 +1450,23 @@ impl Msg {
         )
     }
     pub fn has_s64_unlabeled(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             i64,
             self::_pinternal::tags::SInt64,
         > as NonRepeatedFieldType>::get_field_opt(&self.s64_unlabeled, &self._bitfield)
             .is_some()
     }
     pub fn clear_s64_unlabeled(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             i64,
             self::_pinternal::tags::SInt64,
         > as NonRepeatedFieldType>::clear(&mut self.s64_unlabeled, &mut self._bitfield)
     }
     pub fn s64_optional(&self) -> i64 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i64,
             self::_pinternal::tags::SInt64,
             9usize,
@@ -1477,16 +1477,16 @@ impl Msg {
         )
     }
     pub fn s64_optional_opt(&self) -> ::std::option::Option::<i64> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i64,
             self::_pinternal::tags::SInt64,
             9usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.s64_optional, &self._bitfield)
     }
     pub fn s64_optional_mut(&mut self) -> &mut i64 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i64,
             self::_pinternal::tags::SInt64,
             9usize,
@@ -1497,8 +1497,8 @@ impl Msg {
         )
     }
     pub fn has_s64_optional(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i64,
             self::_pinternal::tags::SInt64,
             9usize,
@@ -1506,23 +1506,23 @@ impl Msg {
             .is_some()
     }
     pub fn clear_s64_optional(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i64,
             self::_pinternal::tags::SInt64,
             9usize,
         > as NonRepeatedFieldType>::clear(&mut self.s64_optional, &mut self._bitfield)
     }
     pub fn s64_repeated(&self) -> &[i64] {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             i64,
             self::_pinternal::tags::SInt64,
         > as RepeatedFieldType>::get_field(&self.s64_repeated, &self._bitfield)
     }
     pub fn s64_repeated_mut(&mut self) -> &mut ::std::vec::Vec::<i64> {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             i64,
             self::_pinternal::tags::SInt64,
         > as RepeatedFieldType>::get_field_mut(
@@ -1531,15 +1531,15 @@ impl Msg {
         )
     }
     pub fn clear_s64_repeated(&mut self) {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             i64,
             self::_pinternal::tags::SInt64,
         > as RepeatedFieldType>::clear(&mut self.s64_repeated, &mut self._bitfield)
     }
     pub fn fixed32_unlabeled(&self) -> u32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             u32,
             self::_pinternal::tags::Fixed32,
         > as NonRepeatedFieldType>::get_field_or_else(
@@ -1549,8 +1549,8 @@ impl Msg {
         )
     }
     pub fn fixed32_unlabeled_opt(&self) -> ::std::option::Option::<u32> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             u32,
             self::_pinternal::tags::Fixed32,
         > as NonRepeatedFieldType>::get_field_opt(
@@ -1559,8 +1559,8 @@ impl Msg {
         )
     }
     pub fn fixed32_unlabeled_mut(&mut self) -> &mut u32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             u32,
             self::_pinternal::tags::Fixed32,
         > as NonRepeatedFieldType>::get_field_mut(
@@ -1570,8 +1570,8 @@ impl Msg {
         )
     }
     pub fn has_fixed32_unlabeled(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             u32,
             self::_pinternal::tags::Fixed32,
         > as NonRepeatedFieldType>::get_field_opt(
@@ -1581,8 +1581,8 @@ impl Msg {
             .is_some()
     }
     pub fn clear_fixed32_unlabeled(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             u32,
             self::_pinternal::tags::Fixed32,
         > as NonRepeatedFieldType>::clear(
@@ -1591,8 +1591,8 @@ impl Msg {
         )
     }
     pub fn fixed32_optional(&self) -> u32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             u32,
             self::_pinternal::tags::Fixed32,
             10usize,
@@ -1603,8 +1603,8 @@ impl Msg {
         )
     }
     pub fn fixed32_optional_opt(&self) -> ::std::option::Option::<u32> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             u32,
             self::_pinternal::tags::Fixed32,
             10usize,
@@ -1614,8 +1614,8 @@ impl Msg {
         )
     }
     pub fn fixed32_optional_mut(&mut self) -> &mut u32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             u32,
             self::_pinternal::tags::Fixed32,
             10usize,
@@ -1626,8 +1626,8 @@ impl Msg {
         )
     }
     pub fn has_fixed32_optional(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             u32,
             self::_pinternal::tags::Fixed32,
             10usize,
@@ -1638,8 +1638,8 @@ impl Msg {
             .is_some()
     }
     pub fn clear_fixed32_optional(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             u32,
             self::_pinternal::tags::Fixed32,
             10usize,
@@ -1649,15 +1649,15 @@ impl Msg {
         )
     }
     pub fn fixed32_repeated(&self) -> &[u32] {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             u32,
             self::_pinternal::tags::Fixed32,
         > as RepeatedFieldType>::get_field(&self.fixed32_repeated, &self._bitfield)
     }
     pub fn fixed32_repeated_mut(&mut self) -> &mut ::std::vec::Vec::<u32> {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             u32,
             self::_pinternal::tags::Fixed32,
         > as RepeatedFieldType>::get_field_mut(
@@ -1666,15 +1666,15 @@ impl Msg {
         )
     }
     pub fn clear_fixed32_repeated(&mut self) {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             u32,
             self::_pinternal::tags::Fixed32,
         > as RepeatedFieldType>::clear(&mut self.fixed32_repeated, &mut self._bitfield)
     }
     pub fn fixed64_unlabeled(&self) -> u64 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             u64,
             self::_pinternal::tags::Fixed64,
         > as NonRepeatedFieldType>::get_field_or_else(
@@ -1684,8 +1684,8 @@ impl Msg {
         )
     }
     pub fn fixed64_unlabeled_opt(&self) -> ::std::option::Option::<u64> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             u64,
             self::_pinternal::tags::Fixed64,
         > as NonRepeatedFieldType>::get_field_opt(
@@ -1694,8 +1694,8 @@ impl Msg {
         )
     }
     pub fn fixed64_unlabeled_mut(&mut self) -> &mut u64 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             u64,
             self::_pinternal::tags::Fixed64,
         > as NonRepeatedFieldType>::get_field_mut(
@@ -1705,8 +1705,8 @@ impl Msg {
         )
     }
     pub fn has_fixed64_unlabeled(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             u64,
             self::_pinternal::tags::Fixed64,
         > as NonRepeatedFieldType>::get_field_opt(
@@ -1716,8 +1716,8 @@ impl Msg {
             .is_some()
     }
     pub fn clear_fixed64_unlabeled(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             u64,
             self::_pinternal::tags::Fixed64,
         > as NonRepeatedFieldType>::clear(
@@ -1726,8 +1726,8 @@ impl Msg {
         )
     }
     pub fn fixed64_optional(&self) -> u64 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             u64,
             self::_pinternal::tags::Fixed64,
             11usize,
@@ -1738,8 +1738,8 @@ impl Msg {
         )
     }
     pub fn fixed64_optional_opt(&self) -> ::std::option::Option::<u64> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             u64,
             self::_pinternal::tags::Fixed64,
             11usize,
@@ -1749,8 +1749,8 @@ impl Msg {
         )
     }
     pub fn fixed64_optional_mut(&mut self) -> &mut u64 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             u64,
             self::_pinternal::tags::Fixed64,
             11usize,
@@ -1761,8 +1761,8 @@ impl Msg {
         )
     }
     pub fn has_fixed64_optional(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             u64,
             self::_pinternal::tags::Fixed64,
             11usize,
@@ -1773,8 +1773,8 @@ impl Msg {
             .is_some()
     }
     pub fn clear_fixed64_optional(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             u64,
             self::_pinternal::tags::Fixed64,
             11usize,
@@ -1784,15 +1784,15 @@ impl Msg {
         )
     }
     pub fn fixed64_repeated(&self) -> &[u64] {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             u64,
             self::_pinternal::tags::Fixed64,
         > as RepeatedFieldType>::get_field(&self.fixed64_repeated, &self._bitfield)
     }
     pub fn fixed64_repeated_mut(&mut self) -> &mut ::std::vec::Vec::<u64> {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             u64,
             self::_pinternal::tags::Fixed64,
         > as RepeatedFieldType>::get_field_mut(
@@ -1801,15 +1801,15 @@ impl Msg {
         )
     }
     pub fn clear_fixed64_repeated(&mut self) {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             u64,
             self::_pinternal::tags::Fixed64,
         > as RepeatedFieldType>::clear(&mut self.fixed64_repeated, &mut self._bitfield)
     }
     pub fn sfixed32_unlabeled(&self) -> i32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             i32,
             self::_pinternal::tags::SFixed32,
         > as NonRepeatedFieldType>::get_field_or_else(
@@ -1819,8 +1819,8 @@ impl Msg {
         )
     }
     pub fn sfixed32_unlabeled_opt(&self) -> ::std::option::Option::<i32> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             i32,
             self::_pinternal::tags::SFixed32,
         > as NonRepeatedFieldType>::get_field_opt(
@@ -1829,8 +1829,8 @@ impl Msg {
         )
     }
     pub fn sfixed32_unlabeled_mut(&mut self) -> &mut i32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             i32,
             self::_pinternal::tags::SFixed32,
         > as NonRepeatedFieldType>::get_field_mut(
@@ -1840,8 +1840,8 @@ impl Msg {
         )
     }
     pub fn has_sfixed32_unlabeled(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             i32,
             self::_pinternal::tags::SFixed32,
         > as NonRepeatedFieldType>::get_field_opt(
@@ -1851,8 +1851,8 @@ impl Msg {
             .is_some()
     }
     pub fn clear_sfixed32_unlabeled(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             i32,
             self::_pinternal::tags::SFixed32,
         > as NonRepeatedFieldType>::clear(
@@ -1861,8 +1861,8 @@ impl Msg {
         )
     }
     pub fn sfixed32_optional(&self) -> i32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::SFixed32,
             12usize,
@@ -1873,8 +1873,8 @@ impl Msg {
         )
     }
     pub fn sfixed32_optional_opt(&self) -> ::std::option::Option::<i32> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::SFixed32,
             12usize,
@@ -1884,8 +1884,8 @@ impl Msg {
         )
     }
     pub fn sfixed32_optional_mut(&mut self) -> &mut i32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::SFixed32,
             12usize,
@@ -1896,8 +1896,8 @@ impl Msg {
         )
     }
     pub fn has_sfixed32_optional(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::SFixed32,
             12usize,
@@ -1908,8 +1908,8 @@ impl Msg {
             .is_some()
     }
     pub fn clear_sfixed32_optional(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::SFixed32,
             12usize,
@@ -1919,15 +1919,15 @@ impl Msg {
         )
     }
     pub fn sfixed32_repeated(&self) -> &[i32] {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             i32,
             self::_pinternal::tags::SFixed32,
         > as RepeatedFieldType>::get_field(&self.sfixed32_repeated, &self._bitfield)
     }
     pub fn sfixed32_repeated_mut(&mut self) -> &mut ::std::vec::Vec::<i32> {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             i32,
             self::_pinternal::tags::SFixed32,
         > as RepeatedFieldType>::get_field_mut(
@@ -1936,15 +1936,15 @@ impl Msg {
         )
     }
     pub fn clear_sfixed32_repeated(&mut self) {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             i32,
             self::_pinternal::tags::SFixed32,
         > as RepeatedFieldType>::clear(&mut self.sfixed32_repeated, &mut self._bitfield)
     }
     pub fn sfixed64_unlabeled(&self) -> i64 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             i64,
             self::_pinternal::tags::SFixed64,
         > as NonRepeatedFieldType>::get_field_or_else(
@@ -1954,8 +1954,8 @@ impl Msg {
         )
     }
     pub fn sfixed64_unlabeled_opt(&self) -> ::std::option::Option::<i64> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             i64,
             self::_pinternal::tags::SFixed64,
         > as NonRepeatedFieldType>::get_field_opt(
@@ -1964,8 +1964,8 @@ impl Msg {
         )
     }
     pub fn sfixed64_unlabeled_mut(&mut self) -> &mut i64 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             i64,
             self::_pinternal::tags::SFixed64,
         > as NonRepeatedFieldType>::get_field_mut(
@@ -1975,8 +1975,8 @@ impl Msg {
         )
     }
     pub fn has_sfixed64_unlabeled(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             i64,
             self::_pinternal::tags::SFixed64,
         > as NonRepeatedFieldType>::get_field_opt(
@@ -1986,8 +1986,8 @@ impl Msg {
             .is_some()
     }
     pub fn clear_sfixed64_unlabeled(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             i64,
             self::_pinternal::tags::SFixed64,
         > as NonRepeatedFieldType>::clear(
@@ -1996,8 +1996,8 @@ impl Msg {
         )
     }
     pub fn sfixed64_optional(&self) -> i64 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i64,
             self::_pinternal::tags::SFixed64,
             13usize,
@@ -2008,8 +2008,8 @@ impl Msg {
         )
     }
     pub fn sfixed64_optional_opt(&self) -> ::std::option::Option::<i64> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i64,
             self::_pinternal::tags::SFixed64,
             13usize,
@@ -2019,8 +2019,8 @@ impl Msg {
         )
     }
     pub fn sfixed64_optional_mut(&mut self) -> &mut i64 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i64,
             self::_pinternal::tags::SFixed64,
             13usize,
@@ -2031,8 +2031,8 @@ impl Msg {
         )
     }
     pub fn has_sfixed64_optional(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i64,
             self::_pinternal::tags::SFixed64,
             13usize,
@@ -2043,8 +2043,8 @@ impl Msg {
             .is_some()
     }
     pub fn clear_sfixed64_optional(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i64,
             self::_pinternal::tags::SFixed64,
             13usize,
@@ -2054,15 +2054,15 @@ impl Msg {
         )
     }
     pub fn sfixed64_repeated(&self) -> &[i64] {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             i64,
             self::_pinternal::tags::SFixed64,
         > as RepeatedFieldType>::get_field(&self.sfixed64_repeated, &self._bitfield)
     }
     pub fn sfixed64_repeated_mut(&mut self) -> &mut ::std::vec::Vec::<i64> {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             i64,
             self::_pinternal::tags::SFixed64,
         > as RepeatedFieldType>::get_field_mut(
@@ -2071,15 +2071,15 @@ impl Msg {
         )
     }
     pub fn clear_sfixed64_repeated(&mut self) {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             i64,
             self::_pinternal::tags::SFixed64,
         > as RepeatedFieldType>::clear(&mut self.sfixed64_repeated, &mut self._bitfield)
     }
     pub fn f64_unlabeled(&self) -> f64 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             f64,
             self::_pinternal::tags::Double,
         > as NonRepeatedFieldType>::get_field_or_else(
@@ -2089,15 +2089,15 @@ impl Msg {
         )
     }
     pub fn f64_unlabeled_opt(&self) -> ::std::option::Option::<f64> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             f64,
             self::_pinternal::tags::Double,
         > as NonRepeatedFieldType>::get_field_opt(&self.f64_unlabeled, &self._bitfield)
     }
     pub fn f64_unlabeled_mut(&mut self) -> &mut f64 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             f64,
             self::_pinternal::tags::Double,
         > as NonRepeatedFieldType>::get_field_mut(
@@ -2107,23 +2107,23 @@ impl Msg {
         )
     }
     pub fn has_f64_unlabeled(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             f64,
             self::_pinternal::tags::Double,
         > as NonRepeatedFieldType>::get_field_opt(&self.f64_unlabeled, &self._bitfield)
             .is_some()
     }
     pub fn clear_f64_unlabeled(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             f64,
             self::_pinternal::tags::Double,
         > as NonRepeatedFieldType>::clear(&mut self.f64_unlabeled, &mut self._bitfield)
     }
     pub fn f64_optional(&self) -> f64 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             f64,
             self::_pinternal::tags::Double,
             14usize,
@@ -2134,16 +2134,16 @@ impl Msg {
         )
     }
     pub fn f64_optional_opt(&self) -> ::std::option::Option::<f64> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             f64,
             self::_pinternal::tags::Double,
             14usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.f64_optional, &self._bitfield)
     }
     pub fn f64_optional_mut(&mut self) -> &mut f64 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             f64,
             self::_pinternal::tags::Double,
             14usize,
@@ -2154,8 +2154,8 @@ impl Msg {
         )
     }
     pub fn has_f64_optional(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             f64,
             self::_pinternal::tags::Double,
             14usize,
@@ -2163,23 +2163,23 @@ impl Msg {
             .is_some()
     }
     pub fn clear_f64_optional(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             f64,
             self::_pinternal::tags::Double,
             14usize,
         > as NonRepeatedFieldType>::clear(&mut self.f64_optional, &mut self._bitfield)
     }
     pub fn f64_repeated(&self) -> &[f64] {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             f64,
             self::_pinternal::tags::Double,
         > as RepeatedFieldType>::get_field(&self.f64_repeated, &self._bitfield)
     }
     pub fn f64_repeated_mut(&mut self) -> &mut ::std::vec::Vec::<f64> {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             f64,
             self::_pinternal::tags::Double,
         > as RepeatedFieldType>::get_field_mut(
@@ -2188,8 +2188,8 @@ impl Msg {
         )
     }
     pub fn clear_f64_repeated(&mut self) {
-        use self::_pinternal::field_type::RepeatedFieldType;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        use self::_pinternal::RepeatedFieldType;
+        <self::_pinternal::RepeatedNumericalField::<
             f64,
             self::_pinternal::tags::Double,
         > as RepeatedFieldType>::clear(&mut self.f64_repeated, &mut self._bitfield)
@@ -2209,503 +2209,503 @@ impl self::_puroro::Message for Msg {
     ) -> self::_puroro::Result<()> {
         use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 1i32 => {
-                    <self::_pinternal::field_type::SingularNumericalField::<
+                    <self::_pinternal::SingularNumericalField::<
                         i32,
                         self::_pinternal::tags::Int32,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.i32_unlabeled,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 2i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         i32,
                         self::_pinternal::tags::Int32,
                         0usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.i32_optional,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 3i32 => {
-                    <self::_pinternal::field_type::RepeatedNumericalField::<
+                    <self::_pinternal::RepeatedNumericalField::<
                         i32,
                         self::_pinternal::tags::Int32,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.i32_repeated,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 11i32 => {
-                    <self::_pinternal::field_type::SingularNumericalField::<
+                    <self::_pinternal::SingularNumericalField::<
                         f32,
                         self::_pinternal::tags::Float,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.float_unlabeled,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 12i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         f32,
                         self::_pinternal::tags::Float,
                         1usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.float_optional,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 13i32 => {
-                    <self::_pinternal::field_type::RepeatedNumericalField::<
+                    <self::_pinternal::RepeatedNumericalField::<
                         f32,
                         self::_pinternal::tags::Float,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.float_repeated,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 21i32 => {
-                    <self::_pinternal::field_type::SingularUnsizedField::<
+                    <self::_pinternal::SingularUnsizedField::<
                         ::std::vec::Vec<u8>,
                         self::_pinternal::tags::Bytes,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.bytes_unlabeled,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 22i32 => {
-                    <self::_pinternal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::OptionalUnsizedField::<
                         ::std::vec::Vec<u8>,
                         self::_pinternal::tags::Bytes,
                         2usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.bytes_optional,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 23i32 => {
-                    <self::_pinternal::field_type::RepeatedUnsizedField::<
+                    <self::_pinternal::RepeatedUnsizedField::<
                         ::std::vec::Vec<u8>,
                         self::_pinternal::tags::Bytes,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.bytes_repeated,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 31i32 => {
-                    <self::_pinternal::field_type::SingularUnsizedField::<
+                    <self::_pinternal::SingularUnsizedField::<
                         ::std::string::String,
                         self::_pinternal::tags::String,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.string_unlabeled,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 32i32 => {
-                    <self::_pinternal::field_type::OptionalUnsizedField::<
+                    <self::_pinternal::OptionalUnsizedField::<
                         ::std::string::String,
                         self::_pinternal::tags::String,
                         3usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.string_optional,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 33i32 => {
-                    <self::_pinternal::field_type::RepeatedUnsizedField::<
+                    <self::_pinternal::RepeatedUnsizedField::<
                         ::std::string::String,
                         self::_pinternal::tags::String,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.string_repeated,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 41i32 => {
-                    <self::_pinternal::field_type::SingularNumericalField::<
+                    <self::_pinternal::SingularNumericalField::<
                         self::_root::full_coverage3::Enum,
                         self::_pinternal::tags::Enum3::<
                             self::_root::full_coverage3::Enum,
                         >,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.enum_unlabeled,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 42i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         self::_root::full_coverage3::Enum,
                         self::_pinternal::tags::Enum3::<
                             self::_root::full_coverage3::Enum,
                         >,
                         4usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.enum_optional,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 43i32 => {
-                    <self::_pinternal::field_type::RepeatedNumericalField::<
+                    <self::_pinternal::RepeatedNumericalField::<
                         self::_root::full_coverage3::Enum,
                         self::_pinternal::tags::Enum3::<
                             self::_root::full_coverage3::Enum,
                         >,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.enum_repeated,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 51i32 => {
-                    <self::_pinternal::field_type::SingularHeapMessageField::<
+                    <self::_pinternal::SingularHeapMessageField::<
                         self::_root::full_coverage3::msg::Submsg,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.submsg_unlabeled,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 52i32 => {
-                    <self::_pinternal::field_type::SingularHeapMessageField::<
+                    <self::_pinternal::SingularHeapMessageField::<
                         self::_root::full_coverage3::msg::Submsg,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.submsg_optional,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 53i32 => {
-                    <self::_pinternal::field_type::RepeatedMessageField::<
+                    <self::_pinternal::RepeatedMessageField::<
                         self::_root::full_coverage3::msg::Submsg,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.submsg_repeated,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 101i32 => {
-                    <self::_pinternal::field_type::SingularNumericalField::<
+                    <self::_pinternal::SingularNumericalField::<
                         i64,
                         self::_pinternal::tags::Int64,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.i64_unlabeled,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 102i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         i64,
                         self::_pinternal::tags::Int64,
                         5usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.i64_optional,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 103i32 => {
-                    <self::_pinternal::field_type::RepeatedNumericalField::<
+                    <self::_pinternal::RepeatedNumericalField::<
                         i64,
                         self::_pinternal::tags::Int64,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.i64_repeated,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 111i32 => {
-                    <self::_pinternal::field_type::SingularNumericalField::<
+                    <self::_pinternal::SingularNumericalField::<
                         u32,
                         self::_pinternal::tags::UInt32,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.u32_unlabeled,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 112i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         u32,
                         self::_pinternal::tags::UInt32,
                         6usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.u32_optional,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 113i32 => {
-                    <self::_pinternal::field_type::RepeatedNumericalField::<
+                    <self::_pinternal::RepeatedNumericalField::<
                         u32,
                         self::_pinternal::tags::UInt32,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.u32_repeated,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 121i32 => {
-                    <self::_pinternal::field_type::SingularNumericalField::<
+                    <self::_pinternal::SingularNumericalField::<
                         u64,
                         self::_pinternal::tags::UInt64,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.u64_unlabeled,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 122i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         u64,
                         self::_pinternal::tags::UInt64,
                         7usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.u64_optional,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 123i32 => {
-                    <self::_pinternal::field_type::RepeatedNumericalField::<
+                    <self::_pinternal::RepeatedNumericalField::<
                         u64,
                         self::_pinternal::tags::UInt64,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.u64_repeated,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 131i32 => {
-                    <self::_pinternal::field_type::SingularNumericalField::<
+                    <self::_pinternal::SingularNumericalField::<
                         i32,
                         self::_pinternal::tags::SInt32,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.s32_unlabeled,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 132i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         i32,
                         self::_pinternal::tags::SInt32,
                         8usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.s32_optional,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 133i32 => {
-                    <self::_pinternal::field_type::RepeatedNumericalField::<
+                    <self::_pinternal::RepeatedNumericalField::<
                         i32,
                         self::_pinternal::tags::SInt32,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.s32_repeated,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 141i32 => {
-                    <self::_pinternal::field_type::SingularNumericalField::<
+                    <self::_pinternal::SingularNumericalField::<
                         i64,
                         self::_pinternal::tags::SInt64,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.s64_unlabeled,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 142i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         i64,
                         self::_pinternal::tags::SInt64,
                         9usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.s64_optional,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 143i32 => {
-                    <self::_pinternal::field_type::RepeatedNumericalField::<
+                    <self::_pinternal::RepeatedNumericalField::<
                         i64,
                         self::_pinternal::tags::SInt64,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.s64_repeated,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 151i32 => {
-                    <self::_pinternal::field_type::SingularNumericalField::<
+                    <self::_pinternal::SingularNumericalField::<
                         u32,
                         self::_pinternal::tags::Fixed32,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.fixed32_unlabeled,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 152i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         u32,
                         self::_pinternal::tags::Fixed32,
                         10usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.fixed32_optional,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 153i32 => {
-                    <self::_pinternal::field_type::RepeatedNumericalField::<
+                    <self::_pinternal::RepeatedNumericalField::<
                         u32,
                         self::_pinternal::tags::Fixed32,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.fixed32_repeated,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 161i32 => {
-                    <self::_pinternal::field_type::SingularNumericalField::<
+                    <self::_pinternal::SingularNumericalField::<
                         u64,
                         self::_pinternal::tags::Fixed64,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.fixed64_unlabeled,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 162i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         u64,
                         self::_pinternal::tags::Fixed64,
                         11usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.fixed64_optional,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 163i32 => {
-                    <self::_pinternal::field_type::RepeatedNumericalField::<
+                    <self::_pinternal::RepeatedNumericalField::<
                         u64,
                         self::_pinternal::tags::Fixed64,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.fixed64_repeated,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 171i32 => {
-                    <self::_pinternal::field_type::SingularNumericalField::<
+                    <self::_pinternal::SingularNumericalField::<
                         i32,
                         self::_pinternal::tags::SFixed32,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.sfixed32_unlabeled,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 172i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         i32,
                         self::_pinternal::tags::SFixed32,
                         12usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.sfixed32_optional,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 173i32 => {
-                    <self::_pinternal::field_type::RepeatedNumericalField::<
+                    <self::_pinternal::RepeatedNumericalField::<
                         i32,
                         self::_pinternal::tags::SFixed32,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.sfixed32_repeated,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 181i32 => {
-                    <self::_pinternal::field_type::SingularNumericalField::<
+                    <self::_pinternal::SingularNumericalField::<
                         i64,
                         self::_pinternal::tags::SFixed64,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.sfixed64_unlabeled,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 182i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         i64,
                         self::_pinternal::tags::SFixed64,
                         13usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.sfixed64_optional,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 183i32 => {
-                    <self::_pinternal::field_type::RepeatedNumericalField::<
+                    <self::_pinternal::RepeatedNumericalField::<
                         i64,
                         self::_pinternal::tags::SFixed64,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.sfixed64_repeated,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 191i32 => {
-                    <self::_pinternal::field_type::SingularNumericalField::<
+                    <self::_pinternal::SingularNumericalField::<
                         f64,
                         self::_pinternal::tags::Double,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.f64_unlabeled,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 192i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         f64,
                         self::_pinternal::tags::Double,
                         14usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.f64_optional,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 193i32 => {
-                    <self::_pinternal::field_type::RepeatedNumericalField::<
+                    <self::_pinternal::RepeatedNumericalField::<
                         f64,
                         self::_pinternal::tags::Double,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.f64_repeated,
                         &mut self._bitfield,
                         field_data,
@@ -2722,446 +2722,446 @@ impl self::_puroro::Message for Msg {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::OneofUnion as _;
+        <self::_pinternal::SingularNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.i32_unlabeled,
             &self._bitfield,
             1i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             0usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.i32_optional,
             &self._bitfield,
             2i32,
             out,
         )?;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        <self::_pinternal::RepeatedNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.i32_repeated,
             &self._bitfield,
             3i32,
             out,
         )?;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        <self::_pinternal::SingularNumericalField::<
             f32,
             self::_pinternal::tags::Float,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.float_unlabeled,
             &self._bitfield,
             11i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        <self::_pinternal::OptionalNumericalField::<
             f32,
             self::_pinternal::tags::Float,
             1usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.float_optional,
             &self._bitfield,
             12i32,
             out,
         )?;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        <self::_pinternal::RepeatedNumericalField::<
             f32,
             self::_pinternal::tags::Float,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.float_repeated,
             &self._bitfield,
             13i32,
             out,
         )?;
-        <self::_pinternal::field_type::SingularUnsizedField::<
+        <self::_pinternal::SingularUnsizedField::<
             ::std::vec::Vec<u8>,
             self::_pinternal::tags::Bytes,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.bytes_unlabeled,
             &self._bitfield,
             21i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::vec::Vec<u8>,
             self::_pinternal::tags::Bytes,
             2usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.bytes_optional,
             &self._bitfield,
             22i32,
             out,
         )?;
-        <self::_pinternal::field_type::RepeatedUnsizedField::<
+        <self::_pinternal::RepeatedUnsizedField::<
             ::std::vec::Vec<u8>,
             self::_pinternal::tags::Bytes,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.bytes_repeated,
             &self._bitfield,
             23i32,
             out,
         )?;
-        <self::_pinternal::field_type::SingularUnsizedField::<
+        <self::_pinternal::SingularUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.string_unlabeled,
             &self._bitfield,
             31i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalUnsizedField::<
+        <self::_pinternal::OptionalUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
             3usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.string_optional,
             &self._bitfield,
             32i32,
             out,
         )?;
-        <self::_pinternal::field_type::RepeatedUnsizedField::<
+        <self::_pinternal::RepeatedUnsizedField::<
             ::std::string::String,
             self::_pinternal::tags::String,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.string_repeated,
             &self._bitfield,
             33i32,
             out,
         )?;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        <self::_pinternal::SingularNumericalField::<
             self::_root::full_coverage3::Enum,
             self::_pinternal::tags::Enum3::<self::_root::full_coverage3::Enum>,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.enum_unlabeled,
             &self._bitfield,
             41i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        <self::_pinternal::OptionalNumericalField::<
             self::_root::full_coverage3::Enum,
             self::_pinternal::tags::Enum3::<self::_root::full_coverage3::Enum>,
             4usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.enum_optional,
             &self._bitfield,
             42i32,
             out,
         )?;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        <self::_pinternal::RepeatedNumericalField::<
             self::_root::full_coverage3::Enum,
             self::_pinternal::tags::Enum3::<self::_root::full_coverage3::Enum>,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.enum_repeated,
             &self._bitfield,
             43i32,
             out,
         )?;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::full_coverage3::msg::Submsg,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.submsg_unlabeled,
             &self._bitfield,
             51i32,
             out,
         )?;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::full_coverage3::msg::Submsg,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.submsg_optional,
             &self._bitfield,
             52i32,
             out,
         )?;
-        <self::_pinternal::field_type::RepeatedMessageField::<
+        <self::_pinternal::RepeatedMessageField::<
             self::_root::full_coverage3::msg::Submsg,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.submsg_repeated,
             &self._bitfield,
             53i32,
             out,
         )?;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        <self::_pinternal::SingularNumericalField::<
             i64,
             self::_pinternal::tags::Int64,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.i64_unlabeled,
             &self._bitfield,
             101i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        <self::_pinternal::OptionalNumericalField::<
             i64,
             self::_pinternal::tags::Int64,
             5usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.i64_optional,
             &self._bitfield,
             102i32,
             out,
         )?;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        <self::_pinternal::RepeatedNumericalField::<
             i64,
             self::_pinternal::tags::Int64,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.i64_repeated,
             &self._bitfield,
             103i32,
             out,
         )?;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        <self::_pinternal::SingularNumericalField::<
             u32,
             self::_pinternal::tags::UInt32,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.u32_unlabeled,
             &self._bitfield,
             111i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        <self::_pinternal::OptionalNumericalField::<
             u32,
             self::_pinternal::tags::UInt32,
             6usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.u32_optional,
             &self._bitfield,
             112i32,
             out,
         )?;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        <self::_pinternal::RepeatedNumericalField::<
             u32,
             self::_pinternal::tags::UInt32,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.u32_repeated,
             &self._bitfield,
             113i32,
             out,
         )?;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        <self::_pinternal::SingularNumericalField::<
             u64,
             self::_pinternal::tags::UInt64,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.u64_unlabeled,
             &self._bitfield,
             121i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        <self::_pinternal::OptionalNumericalField::<
             u64,
             self::_pinternal::tags::UInt64,
             7usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.u64_optional,
             &self._bitfield,
             122i32,
             out,
         )?;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        <self::_pinternal::RepeatedNumericalField::<
             u64,
             self::_pinternal::tags::UInt64,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.u64_repeated,
             &self._bitfield,
             123i32,
             out,
         )?;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        <self::_pinternal::SingularNumericalField::<
             i32,
             self::_pinternal::tags::SInt32,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.s32_unlabeled,
             &self._bitfield,
             131i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::SInt32,
             8usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.s32_optional,
             &self._bitfield,
             132i32,
             out,
         )?;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        <self::_pinternal::RepeatedNumericalField::<
             i32,
             self::_pinternal::tags::SInt32,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.s32_repeated,
             &self._bitfield,
             133i32,
             out,
         )?;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        <self::_pinternal::SingularNumericalField::<
             i64,
             self::_pinternal::tags::SInt64,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.s64_unlabeled,
             &self._bitfield,
             141i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        <self::_pinternal::OptionalNumericalField::<
             i64,
             self::_pinternal::tags::SInt64,
             9usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.s64_optional,
             &self._bitfield,
             142i32,
             out,
         )?;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        <self::_pinternal::RepeatedNumericalField::<
             i64,
             self::_pinternal::tags::SInt64,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.s64_repeated,
             &self._bitfield,
             143i32,
             out,
         )?;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        <self::_pinternal::SingularNumericalField::<
             u32,
             self::_pinternal::tags::Fixed32,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.fixed32_unlabeled,
             &self._bitfield,
             151i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        <self::_pinternal::OptionalNumericalField::<
             u32,
             self::_pinternal::tags::Fixed32,
             10usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.fixed32_optional,
             &self._bitfield,
             152i32,
             out,
         )?;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        <self::_pinternal::RepeatedNumericalField::<
             u32,
             self::_pinternal::tags::Fixed32,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.fixed32_repeated,
             &self._bitfield,
             153i32,
             out,
         )?;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        <self::_pinternal::SingularNumericalField::<
             u64,
             self::_pinternal::tags::Fixed64,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.fixed64_unlabeled,
             &self._bitfield,
             161i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        <self::_pinternal::OptionalNumericalField::<
             u64,
             self::_pinternal::tags::Fixed64,
             11usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.fixed64_optional,
             &self._bitfield,
             162i32,
             out,
         )?;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        <self::_pinternal::RepeatedNumericalField::<
             u64,
             self::_pinternal::tags::Fixed64,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.fixed64_repeated,
             &self._bitfield,
             163i32,
             out,
         )?;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        <self::_pinternal::SingularNumericalField::<
             i32,
             self::_pinternal::tags::SFixed32,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.sfixed32_unlabeled,
             &self._bitfield,
             171i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::SFixed32,
             12usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.sfixed32_optional,
             &self._bitfield,
             172i32,
             out,
         )?;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        <self::_pinternal::RepeatedNumericalField::<
             i32,
             self::_pinternal::tags::SFixed32,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.sfixed32_repeated,
             &self._bitfield,
             173i32,
             out,
         )?;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        <self::_pinternal::SingularNumericalField::<
             i64,
             self::_pinternal::tags::SFixed64,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.sfixed64_unlabeled,
             &self._bitfield,
             181i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        <self::_pinternal::OptionalNumericalField::<
             i64,
             self::_pinternal::tags::SFixed64,
             13usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.sfixed64_optional,
             &self._bitfield,
             182i32,
             out,
         )?;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        <self::_pinternal::RepeatedNumericalField::<
             i64,
             self::_pinternal::tags::SFixed64,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.sfixed64_repeated,
             &self._bitfield,
             183i32,
             out,
         )?;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        <self::_pinternal::SingularNumericalField::<
             f64,
             self::_pinternal::tags::Double,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.f64_unlabeled,
             &self._bitfield,
             191i32,
             out,
         )?;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        <self::_pinternal::OptionalNumericalField::<
             f64,
             self::_pinternal::tags::Double,
             14usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.f64_optional,
             &self._bitfield,
             192i32,
             out,
         )?;
-        <self::_pinternal::field_type::RepeatedNumericalField::<
+        <self::_pinternal::RepeatedNumericalField::<
             f64,
             self::_pinternal::tags::Double,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.f64_repeated,
             &self._bitfield,
             193i32,
@@ -3173,207 +3173,207 @@ impl self::_puroro::Message for Msg {
 impl ::std::clone::Clone for Msg {
     fn clone(&self) -> Self {
         Self {
-            i32_unlabeled: <self::_pinternal::field_type::SingularNumericalField::<
+            i32_unlabeled: <self::_pinternal::SingularNumericalField::<
                 i32,
                 self::_pinternal::tags::Int32,
             > as ::std::clone::Clone>::clone(&self.i32_unlabeled),
-            i32_optional: <self::_pinternal::field_type::OptionalNumericalField::<
+            i32_optional: <self::_pinternal::OptionalNumericalField::<
                 i32,
                 self::_pinternal::tags::Int32,
                 0usize,
             > as ::std::clone::Clone>::clone(&self.i32_optional),
-            i32_repeated: <self::_pinternal::field_type::RepeatedNumericalField::<
+            i32_repeated: <self::_pinternal::RepeatedNumericalField::<
                 i32,
                 self::_pinternal::tags::Int32,
             > as ::std::clone::Clone>::clone(&self.i32_repeated),
-            float_unlabeled: <self::_pinternal::field_type::SingularNumericalField::<
+            float_unlabeled: <self::_pinternal::SingularNumericalField::<
                 f32,
                 self::_pinternal::tags::Float,
             > as ::std::clone::Clone>::clone(&self.float_unlabeled),
-            float_optional: <self::_pinternal::field_type::OptionalNumericalField::<
+            float_optional: <self::_pinternal::OptionalNumericalField::<
                 f32,
                 self::_pinternal::tags::Float,
                 1usize,
             > as ::std::clone::Clone>::clone(&self.float_optional),
-            float_repeated: <self::_pinternal::field_type::RepeatedNumericalField::<
+            float_repeated: <self::_pinternal::RepeatedNumericalField::<
                 f32,
                 self::_pinternal::tags::Float,
             > as ::std::clone::Clone>::clone(&self.float_repeated),
-            bytes_unlabeled: <self::_pinternal::field_type::SingularUnsizedField::<
+            bytes_unlabeled: <self::_pinternal::SingularUnsizedField::<
                 ::std::vec::Vec<u8>,
                 self::_pinternal::tags::Bytes,
             > as ::std::clone::Clone>::clone(&self.bytes_unlabeled),
-            bytes_optional: <self::_pinternal::field_type::OptionalUnsizedField::<
+            bytes_optional: <self::_pinternal::OptionalUnsizedField::<
                 ::std::vec::Vec<u8>,
                 self::_pinternal::tags::Bytes,
                 2usize,
             > as ::std::clone::Clone>::clone(&self.bytes_optional),
-            bytes_repeated: <self::_pinternal::field_type::RepeatedUnsizedField::<
+            bytes_repeated: <self::_pinternal::RepeatedUnsizedField::<
                 ::std::vec::Vec<u8>,
                 self::_pinternal::tags::Bytes,
             > as ::std::clone::Clone>::clone(&self.bytes_repeated),
-            string_unlabeled: <self::_pinternal::field_type::SingularUnsizedField::<
+            string_unlabeled: <self::_pinternal::SingularUnsizedField::<
                 ::std::string::String,
                 self::_pinternal::tags::String,
             > as ::std::clone::Clone>::clone(&self.string_unlabeled),
-            string_optional: <self::_pinternal::field_type::OptionalUnsizedField::<
+            string_optional: <self::_pinternal::OptionalUnsizedField::<
                 ::std::string::String,
                 self::_pinternal::tags::String,
                 3usize,
             > as ::std::clone::Clone>::clone(&self.string_optional),
-            string_repeated: <self::_pinternal::field_type::RepeatedUnsizedField::<
+            string_repeated: <self::_pinternal::RepeatedUnsizedField::<
                 ::std::string::String,
                 self::_pinternal::tags::String,
             > as ::std::clone::Clone>::clone(&self.string_repeated),
-            enum_unlabeled: <self::_pinternal::field_type::SingularNumericalField::<
+            enum_unlabeled: <self::_pinternal::SingularNumericalField::<
                 self::_root::full_coverage3::Enum,
                 self::_pinternal::tags::Enum3::<self::_root::full_coverage3::Enum>,
             > as ::std::clone::Clone>::clone(&self.enum_unlabeled),
-            enum_optional: <self::_pinternal::field_type::OptionalNumericalField::<
+            enum_optional: <self::_pinternal::OptionalNumericalField::<
                 self::_root::full_coverage3::Enum,
                 self::_pinternal::tags::Enum3::<self::_root::full_coverage3::Enum>,
                 4usize,
             > as ::std::clone::Clone>::clone(&self.enum_optional),
-            enum_repeated: <self::_pinternal::field_type::RepeatedNumericalField::<
+            enum_repeated: <self::_pinternal::RepeatedNumericalField::<
                 self::_root::full_coverage3::Enum,
                 self::_pinternal::tags::Enum3::<self::_root::full_coverage3::Enum>,
             > as ::std::clone::Clone>::clone(&self.enum_repeated),
-            submsg_unlabeled: <self::_pinternal::field_type::SingularHeapMessageField::<
+            submsg_unlabeled: <self::_pinternal::SingularHeapMessageField::<
                 self::_root::full_coverage3::msg::Submsg,
             > as ::std::clone::Clone>::clone(&self.submsg_unlabeled),
-            submsg_optional: <self::_pinternal::field_type::SingularHeapMessageField::<
+            submsg_optional: <self::_pinternal::SingularHeapMessageField::<
                 self::_root::full_coverage3::msg::Submsg,
             > as ::std::clone::Clone>::clone(&self.submsg_optional),
-            submsg_repeated: <self::_pinternal::field_type::RepeatedMessageField::<
+            submsg_repeated: <self::_pinternal::RepeatedMessageField::<
                 self::_root::full_coverage3::msg::Submsg,
             > as ::std::clone::Clone>::clone(&self.submsg_repeated),
-            i64_unlabeled: <self::_pinternal::field_type::SingularNumericalField::<
+            i64_unlabeled: <self::_pinternal::SingularNumericalField::<
                 i64,
                 self::_pinternal::tags::Int64,
             > as ::std::clone::Clone>::clone(&self.i64_unlabeled),
-            i64_optional: <self::_pinternal::field_type::OptionalNumericalField::<
+            i64_optional: <self::_pinternal::OptionalNumericalField::<
                 i64,
                 self::_pinternal::tags::Int64,
                 5usize,
             > as ::std::clone::Clone>::clone(&self.i64_optional),
-            i64_repeated: <self::_pinternal::field_type::RepeatedNumericalField::<
+            i64_repeated: <self::_pinternal::RepeatedNumericalField::<
                 i64,
                 self::_pinternal::tags::Int64,
             > as ::std::clone::Clone>::clone(&self.i64_repeated),
-            u32_unlabeled: <self::_pinternal::field_type::SingularNumericalField::<
+            u32_unlabeled: <self::_pinternal::SingularNumericalField::<
                 u32,
                 self::_pinternal::tags::UInt32,
             > as ::std::clone::Clone>::clone(&self.u32_unlabeled),
-            u32_optional: <self::_pinternal::field_type::OptionalNumericalField::<
+            u32_optional: <self::_pinternal::OptionalNumericalField::<
                 u32,
                 self::_pinternal::tags::UInt32,
                 6usize,
             > as ::std::clone::Clone>::clone(&self.u32_optional),
-            u32_repeated: <self::_pinternal::field_type::RepeatedNumericalField::<
+            u32_repeated: <self::_pinternal::RepeatedNumericalField::<
                 u32,
                 self::_pinternal::tags::UInt32,
             > as ::std::clone::Clone>::clone(&self.u32_repeated),
-            u64_unlabeled: <self::_pinternal::field_type::SingularNumericalField::<
+            u64_unlabeled: <self::_pinternal::SingularNumericalField::<
                 u64,
                 self::_pinternal::tags::UInt64,
             > as ::std::clone::Clone>::clone(&self.u64_unlabeled),
-            u64_optional: <self::_pinternal::field_type::OptionalNumericalField::<
+            u64_optional: <self::_pinternal::OptionalNumericalField::<
                 u64,
                 self::_pinternal::tags::UInt64,
                 7usize,
             > as ::std::clone::Clone>::clone(&self.u64_optional),
-            u64_repeated: <self::_pinternal::field_type::RepeatedNumericalField::<
+            u64_repeated: <self::_pinternal::RepeatedNumericalField::<
                 u64,
                 self::_pinternal::tags::UInt64,
             > as ::std::clone::Clone>::clone(&self.u64_repeated),
-            s32_unlabeled: <self::_pinternal::field_type::SingularNumericalField::<
+            s32_unlabeled: <self::_pinternal::SingularNumericalField::<
                 i32,
                 self::_pinternal::tags::SInt32,
             > as ::std::clone::Clone>::clone(&self.s32_unlabeled),
-            s32_optional: <self::_pinternal::field_type::OptionalNumericalField::<
+            s32_optional: <self::_pinternal::OptionalNumericalField::<
                 i32,
                 self::_pinternal::tags::SInt32,
                 8usize,
             > as ::std::clone::Clone>::clone(&self.s32_optional),
-            s32_repeated: <self::_pinternal::field_type::RepeatedNumericalField::<
+            s32_repeated: <self::_pinternal::RepeatedNumericalField::<
                 i32,
                 self::_pinternal::tags::SInt32,
             > as ::std::clone::Clone>::clone(&self.s32_repeated),
-            s64_unlabeled: <self::_pinternal::field_type::SingularNumericalField::<
+            s64_unlabeled: <self::_pinternal::SingularNumericalField::<
                 i64,
                 self::_pinternal::tags::SInt64,
             > as ::std::clone::Clone>::clone(&self.s64_unlabeled),
-            s64_optional: <self::_pinternal::field_type::OptionalNumericalField::<
+            s64_optional: <self::_pinternal::OptionalNumericalField::<
                 i64,
                 self::_pinternal::tags::SInt64,
                 9usize,
             > as ::std::clone::Clone>::clone(&self.s64_optional),
-            s64_repeated: <self::_pinternal::field_type::RepeatedNumericalField::<
+            s64_repeated: <self::_pinternal::RepeatedNumericalField::<
                 i64,
                 self::_pinternal::tags::SInt64,
             > as ::std::clone::Clone>::clone(&self.s64_repeated),
-            fixed32_unlabeled: <self::_pinternal::field_type::SingularNumericalField::<
+            fixed32_unlabeled: <self::_pinternal::SingularNumericalField::<
                 u32,
                 self::_pinternal::tags::Fixed32,
             > as ::std::clone::Clone>::clone(&self.fixed32_unlabeled),
-            fixed32_optional: <self::_pinternal::field_type::OptionalNumericalField::<
+            fixed32_optional: <self::_pinternal::OptionalNumericalField::<
                 u32,
                 self::_pinternal::tags::Fixed32,
                 10usize,
             > as ::std::clone::Clone>::clone(&self.fixed32_optional),
-            fixed32_repeated: <self::_pinternal::field_type::RepeatedNumericalField::<
+            fixed32_repeated: <self::_pinternal::RepeatedNumericalField::<
                 u32,
                 self::_pinternal::tags::Fixed32,
             > as ::std::clone::Clone>::clone(&self.fixed32_repeated),
-            fixed64_unlabeled: <self::_pinternal::field_type::SingularNumericalField::<
+            fixed64_unlabeled: <self::_pinternal::SingularNumericalField::<
                 u64,
                 self::_pinternal::tags::Fixed64,
             > as ::std::clone::Clone>::clone(&self.fixed64_unlabeled),
-            fixed64_optional: <self::_pinternal::field_type::OptionalNumericalField::<
+            fixed64_optional: <self::_pinternal::OptionalNumericalField::<
                 u64,
                 self::_pinternal::tags::Fixed64,
                 11usize,
             > as ::std::clone::Clone>::clone(&self.fixed64_optional),
-            fixed64_repeated: <self::_pinternal::field_type::RepeatedNumericalField::<
+            fixed64_repeated: <self::_pinternal::RepeatedNumericalField::<
                 u64,
                 self::_pinternal::tags::Fixed64,
             > as ::std::clone::Clone>::clone(&self.fixed64_repeated),
-            sfixed32_unlabeled: <self::_pinternal::field_type::SingularNumericalField::<
+            sfixed32_unlabeled: <self::_pinternal::SingularNumericalField::<
                 i32,
                 self::_pinternal::tags::SFixed32,
             > as ::std::clone::Clone>::clone(&self.sfixed32_unlabeled),
-            sfixed32_optional: <self::_pinternal::field_type::OptionalNumericalField::<
+            sfixed32_optional: <self::_pinternal::OptionalNumericalField::<
                 i32,
                 self::_pinternal::tags::SFixed32,
                 12usize,
             > as ::std::clone::Clone>::clone(&self.sfixed32_optional),
-            sfixed32_repeated: <self::_pinternal::field_type::RepeatedNumericalField::<
+            sfixed32_repeated: <self::_pinternal::RepeatedNumericalField::<
                 i32,
                 self::_pinternal::tags::SFixed32,
             > as ::std::clone::Clone>::clone(&self.sfixed32_repeated),
-            sfixed64_unlabeled: <self::_pinternal::field_type::SingularNumericalField::<
+            sfixed64_unlabeled: <self::_pinternal::SingularNumericalField::<
                 i64,
                 self::_pinternal::tags::SFixed64,
             > as ::std::clone::Clone>::clone(&self.sfixed64_unlabeled),
-            sfixed64_optional: <self::_pinternal::field_type::OptionalNumericalField::<
+            sfixed64_optional: <self::_pinternal::OptionalNumericalField::<
                 i64,
                 self::_pinternal::tags::SFixed64,
                 13usize,
             > as ::std::clone::Clone>::clone(&self.sfixed64_optional),
-            sfixed64_repeated: <self::_pinternal::field_type::RepeatedNumericalField::<
+            sfixed64_repeated: <self::_pinternal::RepeatedNumericalField::<
                 i64,
                 self::_pinternal::tags::SFixed64,
             > as ::std::clone::Clone>::clone(&self.sfixed64_repeated),
-            f64_unlabeled: <self::_pinternal::field_type::SingularNumericalField::<
+            f64_unlabeled: <self::_pinternal::SingularNumericalField::<
                 f64,
                 self::_pinternal::tags::Double,
             > as ::std::clone::Clone>::clone(&self.f64_unlabeled),
-            f64_optional: <self::_pinternal::field_type::OptionalNumericalField::<
+            f64_optional: <self::_pinternal::OptionalNumericalField::<
                 f64,
                 self::_pinternal::tags::Double,
                 14usize,
             > as ::std::clone::Clone>::clone(&self.f64_optional),
-            f64_repeated: <self::_pinternal::field_type::RepeatedNumericalField::<
+            f64_repeated: <self::_pinternal::RepeatedNumericalField::<
                 f64,
                 self::_pinternal::tags::Double,
             > as ::std::clone::Clone>::clone(&self.f64_repeated),
@@ -3384,7 +3384,7 @@ impl ::std::clone::Clone for Msg {
 impl ::std::ops::Drop for Msg {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for Msg {
@@ -3447,7 +3447,7 @@ impl ::std::fmt::Debug for Msg {
 impl ::std::cmp::PartialEq for Msg {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         true && self.i32_unlabeled_opt() == rhs.i32_unlabeled_opt()
             && self.i32_optional_opt() == rhs.i32_optional_opt()
             && self.i32_repeated() == rhs.i32_repeated()

--- a/tests-pb/src/full_coverage3/msg.rs
+++ b/tests-pb/src/full_coverage3/msg.rs
@@ -1,33 +1,37 @@
-mod _puroro_root {
+mod _root {
     #[allow(unused)]
-    pub(crate) use super::super::_puroro_root::*;
+    pub(crate) use super::super::_root::*;
 }
 mod _puroro {
     #[allow(unused)]
     pub(crate) use ::puroro::*;
 }
+mod _pinternal {
+    #[allow(unused)]
+    pub(crate) use ::puroro::internal::*;
+}
 #[derive(::std::default::Default)]
 pub struct Submsg {
-    i32_unlabeled: self::_puroro::internal::field_type::SingularNumericalField::<
+    i32_unlabeled: self::_pinternal::field_type::SingularNumericalField::<
         i32,
-        self::_puroro::internal::tags::Int32,
+        self::_pinternal::tags::Int32,
     >,
-    i32_optional: self::_puroro::internal::field_type::SingularNumericalField::<
+    i32_optional: self::_pinternal::field_type::SingularNumericalField::<
         i32,
-        self::_puroro::internal::tags::Int32,
+        self::_pinternal::tags::Int32,
     >,
-    i64_unlabeled: self::_puroro::internal::field_type::SingularNumericalField::<
+    i64_unlabeled: self::_pinternal::field_type::SingularNumericalField::<
         i64,
-        self::_puroro::internal::tags::Int64,
+        self::_pinternal::tags::Int64,
     >,
-    _bitfield: self::_puroro::internal::bitvec::BitArray<0usize>,
+    _bitfield: self::_pinternal::bitvec::BitArray<0usize>,
 }
 impl Submsg {
     pub fn i32_unlabeled(&self) -> i32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.i32_unlabeled,
             &self._bitfield,
@@ -35,17 +39,17 @@ impl Submsg {
         )
     }
     pub fn i32_unlabeled_opt(&self) -> ::std::option::Option::<i32> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
         > as NonRepeatedFieldType>::get_field_opt(&self.i32_unlabeled, &self._bitfield)
     }
     pub fn i32_unlabeled_mut(&mut self) -> &mut i32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.i32_unlabeled,
             &mut self._bitfield,
@@ -53,25 +57,25 @@ impl Submsg {
         )
     }
     pub fn has_i32_unlabeled(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
         > as NonRepeatedFieldType>::get_field_opt(&self.i32_unlabeled, &self._bitfield)
             .is_some()
     }
     pub fn clear_i32_unlabeled(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
         > as NonRepeatedFieldType>::clear(&mut self.i32_unlabeled, &mut self._bitfield)
     }
     pub fn i32_optional(&self) -> i32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.i32_optional,
             &self._bitfield,
@@ -79,17 +83,17 @@ impl Submsg {
         )
     }
     pub fn i32_optional_opt(&self) -> ::std::option::Option::<i32> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
         > as NonRepeatedFieldType>::get_field_opt(&self.i32_optional, &self._bitfield)
     }
     pub fn i32_optional_mut(&mut self) -> &mut i32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.i32_optional,
             &mut self._bitfield,
@@ -97,25 +101,25 @@ impl Submsg {
         )
     }
     pub fn has_i32_optional(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
         > as NonRepeatedFieldType>::get_field_opt(&self.i32_optional, &self._bitfield)
             .is_some()
     }
     pub fn clear_i32_optional(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
         > as NonRepeatedFieldType>::clear(&mut self.i32_optional, &mut self._bitfield)
     }
     pub fn i64_unlabeled(&self) -> i64 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             i64,
-            self::_puroro::internal::tags::Int64,
+            self::_pinternal::tags::Int64,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.i64_unlabeled,
             &self._bitfield,
@@ -123,17 +127,17 @@ impl Submsg {
         )
     }
     pub fn i64_unlabeled_opt(&self) -> ::std::option::Option::<i64> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             i64,
-            self::_puroro::internal::tags::Int64,
+            self::_pinternal::tags::Int64,
         > as NonRepeatedFieldType>::get_field_opt(&self.i64_unlabeled, &self._bitfield)
     }
     pub fn i64_unlabeled_mut(&mut self) -> &mut i64 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             i64,
-            self::_puroro::internal::tags::Int64,
+            self::_pinternal::tags::Int64,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.i64_unlabeled,
             &mut self._bitfield,
@@ -141,18 +145,18 @@ impl Submsg {
         )
     }
     pub fn has_i64_unlabeled(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             i64,
-            self::_puroro::internal::tags::Int64,
+            self::_pinternal::tags::Int64,
         > as NonRepeatedFieldType>::get_field_opt(&self.i64_unlabeled, &self._bitfield)
             .is_some()
     }
     pub fn clear_i64_unlabeled(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             i64,
-            self::_puroro::internal::tags::Int64,
+            self::_pinternal::tags::Int64,
         > as NonRepeatedFieldType>::clear(&mut self.i64_unlabeled, &mut self._bitfield)
     }
 }
@@ -168,37 +172,37 @@ impl self::_puroro::Message for Submsg {
         &mut self,
         mut iter: I,
     ) -> self::_puroro::Result<()> {
-        use self::_puroro::internal::ser::FieldData;
+        use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 1i32 => {
-                    <self::_puroro::internal::field_type::SingularNumericalField::<
+                    <self::_pinternal::field_type::SingularNumericalField::<
                         i32,
-                        self::_puroro::internal::tags::Int32,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                        self::_pinternal::tags::Int32,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.i32_unlabeled,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 2i32 => {
-                    <self::_puroro::internal::field_type::SingularNumericalField::<
+                    <self::_pinternal::field_type::SingularNumericalField::<
                         i32,
-                        self::_puroro::internal::tags::Int32,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                        self::_pinternal::tags::Int32,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.i32_optional,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 101i32 => {
-                    <self::_puroro::internal::field_type::SingularNumericalField::<
+                    <self::_pinternal::field_type::SingularNumericalField::<
                         i64,
-                        self::_puroro::internal::tags::Int64,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                        self::_pinternal::tags::Int64,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.i64_unlabeled,
                         &mut self._bitfield,
                         field_data,
@@ -215,29 +219,29 @@ impl self::_puroro::Message for Submsg {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::oneof_type::OneofUnion as _;
+        <self::_pinternal::field_type::SingularNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+            self::_pinternal::tags::Int32,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.i32_unlabeled,
             &self._bitfield,
             1i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        <self::_pinternal::field_type::SingularNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+            self::_pinternal::tags::Int32,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.i32_optional,
             &self._bitfield,
             2i32,
             out,
         )?;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        <self::_pinternal::field_type::SingularNumericalField::<
             i64,
-            self::_puroro::internal::tags::Int64,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+            self::_pinternal::tags::Int64,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.i64_unlabeled,
             &self._bitfield,
             101i32,
@@ -249,17 +253,17 @@ impl self::_puroro::Message for Submsg {
 impl ::std::clone::Clone for Submsg {
     fn clone(&self) -> Self {
         Self {
-            i32_unlabeled: <self::_puroro::internal::field_type::SingularNumericalField::<
+            i32_unlabeled: <self::_pinternal::field_type::SingularNumericalField::<
                 i32,
-                self::_puroro::internal::tags::Int32,
+                self::_pinternal::tags::Int32,
             > as ::std::clone::Clone>::clone(&self.i32_unlabeled),
-            i32_optional: <self::_puroro::internal::field_type::SingularNumericalField::<
+            i32_optional: <self::_pinternal::field_type::SingularNumericalField::<
                 i32,
-                self::_puroro::internal::tags::Int32,
+                self::_pinternal::tags::Int32,
             > as ::std::clone::Clone>::clone(&self.i32_optional),
-            i64_unlabeled: <self::_puroro::internal::field_type::SingularNumericalField::<
+            i64_unlabeled: <self::_pinternal::field_type::SingularNumericalField::<
                 i64,
-                self::_puroro::internal::tags::Int64,
+                self::_pinternal::tags::Int64,
             > as ::std::clone::Clone>::clone(&self.i64_unlabeled),
             _bitfield: ::std::clone::Clone::clone(&self._bitfield),
         }
@@ -268,7 +272,7 @@ impl ::std::clone::Clone for Submsg {
 impl ::std::ops::Drop for Submsg {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for Submsg {
@@ -286,7 +290,7 @@ impl ::std::fmt::Debug for Submsg {
 impl ::std::cmp::PartialEq for Submsg {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         true && self.i32_unlabeled_opt() == rhs.i32_unlabeled_opt()
             && self.i32_optional_opt() == rhs.i32_optional_opt()
             && self.i64_unlabeled_opt() == rhs.i64_unlabeled_opt()

--- a/tests-pb/src/full_coverage3/msg.rs
+++ b/tests-pb/src/full_coverage3/msg.rs
@@ -12,24 +12,24 @@ mod _pinternal {
 }
 #[derive(::std::default::Default)]
 pub struct Submsg {
-    i32_unlabeled: self::_pinternal::field_type::SingularNumericalField::<
+    i32_unlabeled: self::_pinternal::SingularNumericalField::<
         i32,
         self::_pinternal::tags::Int32,
     >,
-    i32_optional: self::_pinternal::field_type::SingularNumericalField::<
+    i32_optional: self::_pinternal::SingularNumericalField::<
         i32,
         self::_pinternal::tags::Int32,
     >,
-    i64_unlabeled: self::_pinternal::field_type::SingularNumericalField::<
+    i64_unlabeled: self::_pinternal::SingularNumericalField::<
         i64,
         self::_pinternal::tags::Int64,
     >,
-    _bitfield: self::_pinternal::bitvec::BitArray<0usize>,
+    _bitfield: self::_pinternal::BitArray<0usize>,
 }
 impl Submsg {
     pub fn i32_unlabeled(&self) -> i32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
         > as NonRepeatedFieldType>::get_field_or_else(
@@ -39,15 +39,15 @@ impl Submsg {
         )
     }
     pub fn i32_unlabeled_opt(&self) -> ::std::option::Option::<i32> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
         > as NonRepeatedFieldType>::get_field_opt(&self.i32_unlabeled, &self._bitfield)
     }
     pub fn i32_unlabeled_mut(&mut self) -> &mut i32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
         > as NonRepeatedFieldType>::get_field_mut(
@@ -57,23 +57,23 @@ impl Submsg {
         )
     }
     pub fn has_i32_unlabeled(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
         > as NonRepeatedFieldType>::get_field_opt(&self.i32_unlabeled, &self._bitfield)
             .is_some()
     }
     pub fn clear_i32_unlabeled(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
         > as NonRepeatedFieldType>::clear(&mut self.i32_unlabeled, &mut self._bitfield)
     }
     pub fn i32_optional(&self) -> i32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
         > as NonRepeatedFieldType>::get_field_or_else(
@@ -83,15 +83,15 @@ impl Submsg {
         )
     }
     pub fn i32_optional_opt(&self) -> ::std::option::Option::<i32> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
         > as NonRepeatedFieldType>::get_field_opt(&self.i32_optional, &self._bitfield)
     }
     pub fn i32_optional_mut(&mut self) -> &mut i32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
         > as NonRepeatedFieldType>::get_field_mut(
@@ -101,23 +101,23 @@ impl Submsg {
         )
     }
     pub fn has_i32_optional(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
         > as NonRepeatedFieldType>::get_field_opt(&self.i32_optional, &self._bitfield)
             .is_some()
     }
     pub fn clear_i32_optional(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
         > as NonRepeatedFieldType>::clear(&mut self.i32_optional, &mut self._bitfield)
     }
     pub fn i64_unlabeled(&self) -> i64 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             i64,
             self::_pinternal::tags::Int64,
         > as NonRepeatedFieldType>::get_field_or_else(
@@ -127,15 +127,15 @@ impl Submsg {
         )
     }
     pub fn i64_unlabeled_opt(&self) -> ::std::option::Option::<i64> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             i64,
             self::_pinternal::tags::Int64,
         > as NonRepeatedFieldType>::get_field_opt(&self.i64_unlabeled, &self._bitfield)
     }
     pub fn i64_unlabeled_mut(&mut self) -> &mut i64 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             i64,
             self::_pinternal::tags::Int64,
         > as NonRepeatedFieldType>::get_field_mut(
@@ -145,16 +145,16 @@ impl Submsg {
         )
     }
     pub fn has_i64_unlabeled(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             i64,
             self::_pinternal::tags::Int64,
         > as NonRepeatedFieldType>::get_field_opt(&self.i64_unlabeled, &self._bitfield)
             .is_some()
     }
     pub fn clear_i64_unlabeled(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             i64,
             self::_pinternal::tags::Int64,
         > as NonRepeatedFieldType>::clear(&mut self.i64_unlabeled, &mut self._bitfield)
@@ -174,35 +174,35 @@ impl self::_puroro::Message for Submsg {
     ) -> self::_puroro::Result<()> {
         use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 1i32 => {
-                    <self::_pinternal::field_type::SingularNumericalField::<
+                    <self::_pinternal::SingularNumericalField::<
                         i32,
                         self::_pinternal::tags::Int32,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.i32_unlabeled,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 2i32 => {
-                    <self::_pinternal::field_type::SingularNumericalField::<
+                    <self::_pinternal::SingularNumericalField::<
                         i32,
                         self::_pinternal::tags::Int32,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.i32_optional,
                         &mut self._bitfield,
                         field_data,
                     )?
                 }
                 101i32 => {
-                    <self::_pinternal::field_type::SingularNumericalField::<
+                    <self::_pinternal::SingularNumericalField::<
                         i64,
                         self::_pinternal::tags::Int64,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.i64_unlabeled,
                         &mut self._bitfield,
                         field_data,
@@ -219,29 +219,29 @@ impl self::_puroro::Message for Submsg {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::OneofUnion as _;
+        <self::_pinternal::SingularNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.i32_unlabeled,
             &self._bitfield,
             1i32,
             out,
         )?;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        <self::_pinternal::SingularNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.i32_optional,
             &self._bitfield,
             2i32,
             out,
         )?;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        <self::_pinternal::SingularNumericalField::<
             i64,
             self::_pinternal::tags::Int64,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.i64_unlabeled,
             &self._bitfield,
             101i32,
@@ -253,15 +253,15 @@ impl self::_puroro::Message for Submsg {
 impl ::std::clone::Clone for Submsg {
     fn clone(&self) -> Self {
         Self {
-            i32_unlabeled: <self::_pinternal::field_type::SingularNumericalField::<
+            i32_unlabeled: <self::_pinternal::SingularNumericalField::<
                 i32,
                 self::_pinternal::tags::Int32,
             > as ::std::clone::Clone>::clone(&self.i32_unlabeled),
-            i32_optional: <self::_pinternal::field_type::SingularNumericalField::<
+            i32_optional: <self::_pinternal::SingularNumericalField::<
                 i32,
                 self::_pinternal::tags::Int32,
             > as ::std::clone::Clone>::clone(&self.i32_optional),
-            i64_unlabeled: <self::_pinternal::field_type::SingularNumericalField::<
+            i64_unlabeled: <self::_pinternal::SingularNumericalField::<
                 i64,
                 self::_pinternal::tags::Int64,
             > as ::std::clone::Clone>::clone(&self.i64_unlabeled),
@@ -272,7 +272,7 @@ impl ::std::clone::Clone for Submsg {
 impl ::std::ops::Drop for Submsg {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for Submsg {
@@ -290,7 +290,7 @@ impl ::std::fmt::Debug for Submsg {
 impl ::std::cmp::PartialEq for Submsg {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         true && self.i32_unlabeled_opt() == rhs.i32_unlabeled_opt()
             && self.i32_optional_opt() == rhs.i32_optional_opt()
             && self.i64_unlabeled_opt() == rhs.i64_unlabeled_opt()

--- a/tests-pb/src/keywords.rs
+++ b/tests-pb/src/keywords.rs
@@ -1,26 +1,30 @@
-mod _puroro_root {
+mod _root {
     #[allow(unused)]
-    pub(crate) use super::super::_puroro_root::*;
+    pub(crate) use super::super::_root::*;
 }
 mod _puroro {
     #[allow(unused)]
     pub(crate) use ::puroro::*;
 }
+mod _pinternal {
+    #[allow(unused)]
+    pub(crate) use ::puroro::internal::*;
+}
 #[derive(::std::default::Default)]
 pub struct Msg {
-    r#type: self::_puroro::internal::field_type::OptionalNumericalField::<
+    r#type: self::_pinternal::field_type::OptionalNumericalField::<
         i32,
-        self::_puroro::internal::tags::Int32,
+        self::_pinternal::tags::Int32,
         0usize,
     >,
-    _bitfield: self::_puroro::internal::bitvec::BitArray<1usize>,
+    _bitfield: self::_pinternal::bitvec::BitArray<1usize>,
 }
 impl Msg {
     pub fn r#type(&self) -> i32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             0usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.r#type,
@@ -29,18 +33,18 @@ impl Msg {
         )
     }
     pub fn type_opt(&self) -> ::std::option::Option::<i32> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.r#type, &self._bitfield)
     }
     pub fn type_mut(&mut self) -> &mut i32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             0usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.r#type,
@@ -49,19 +53,19 @@ impl Msg {
         )
     }
     pub fn has_type(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.r#type, &self._bitfield)
             .is_some()
     }
     pub fn clear_type(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             0usize,
         > as NonRepeatedFieldType>::clear(&mut self.r#type, &mut self._bitfield)
     }
@@ -78,18 +82,18 @@ impl self::_puroro::Message for Msg {
         &mut self,
         mut iter: I,
     ) -> self::_puroro::Result<()> {
-        use self::_puroro::internal::ser::FieldData;
+        use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 1i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         i32,
-                        self::_puroro::internal::tags::Int32,
+                        self::_pinternal::tags::Int32,
                         0usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.r#type,
                         &mut self._bitfield,
                         field_data,
@@ -106,12 +110,12 @@ impl self::_puroro::Message for Msg {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::oneof_type::OneofUnion as _;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             0usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.r#type,
             &self._bitfield,
             1i32,
@@ -123,9 +127,9 @@ impl self::_puroro::Message for Msg {
 impl ::std::clone::Clone for Msg {
     fn clone(&self) -> Self {
         Self {
-            r#type: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            r#type: <self::_pinternal::field_type::OptionalNumericalField::<
                 i32,
-                self::_puroro::internal::tags::Int32,
+                self::_pinternal::tags::Int32,
                 0usize,
             > as ::std::clone::Clone>::clone(&self.r#type),
             _bitfield: ::std::clone::Clone::clone(&self._bitfield),
@@ -135,7 +139,7 @@ impl ::std::clone::Clone for Msg {
 impl ::std::ops::Drop for Msg {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for Msg {
@@ -151,25 +155,25 @@ impl ::std::fmt::Debug for Msg {
 impl ::std::cmp::PartialEq for Msg {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         true && self.type_opt() == rhs.type_opt()
     }
 }
 #[derive(::std::default::Default)]
 pub struct _Self {
-    r#type: self::_puroro::internal::field_type::OptionalNumericalField::<
+    r#type: self::_pinternal::field_type::OptionalNumericalField::<
         i32,
-        self::_puroro::internal::tags::Int32,
+        self::_pinternal::tags::Int32,
         0usize,
     >,
-    _bitfield: self::_puroro::internal::bitvec::BitArray<1usize>,
+    _bitfield: self::_pinternal::bitvec::BitArray<1usize>,
 }
 impl _Self {
     pub fn r#type(&self) -> i32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             0usize,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.r#type,
@@ -178,18 +182,18 @@ impl _Self {
         )
     }
     pub fn type_opt(&self) -> ::std::option::Option::<i32> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.r#type, &self._bitfield)
     }
     pub fn type_mut(&mut self) -> &mut i32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             0usize,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.r#type,
@@ -198,19 +202,19 @@ impl _Self {
         )
     }
     pub fn has_type(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.r#type, &self._bitfield)
             .is_some()
     }
     pub fn clear_type(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             0usize,
         > as NonRepeatedFieldType>::clear(&mut self.r#type, &mut self._bitfield)
     }
@@ -227,18 +231,18 @@ impl self::_puroro::Message for _Self {
         &mut self,
         mut iter: I,
     ) -> self::_puroro::Result<()> {
-        use self::_puroro::internal::ser::FieldData;
+        use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 1i32 => {
-                    <self::_puroro::internal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::field_type::OptionalNumericalField::<
                         i32,
-                        self::_puroro::internal::tags::Int32,
+                        self::_pinternal::tags::Int32,
                         0usize,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.r#type,
                         &mut self._bitfield,
                         field_data,
@@ -255,12 +259,12 @@ impl self::_puroro::Message for _Self {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
-        <self::_puroro::internal::field_type::OptionalNumericalField::<
+        use self::_pinternal::oneof_type::OneofUnion as _;
+        <self::_pinternal::field_type::OptionalNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
             0usize,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.r#type,
             &self._bitfield,
             1i32,
@@ -272,9 +276,9 @@ impl self::_puroro::Message for _Self {
 impl ::std::clone::Clone for _Self {
     fn clone(&self) -> Self {
         Self {
-            r#type: <self::_puroro::internal::field_type::OptionalNumericalField::<
+            r#type: <self::_pinternal::field_type::OptionalNumericalField::<
                 i32,
-                self::_puroro::internal::tags::Int32,
+                self::_pinternal::tags::Int32,
                 0usize,
             > as ::std::clone::Clone>::clone(&self.r#type),
             _bitfield: ::std::clone::Clone::clone(&self._bitfield),
@@ -284,7 +288,7 @@ impl ::std::clone::Clone for _Self {
 impl ::std::ops::Drop for _Self {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for _Self {
@@ -300,7 +304,7 @@ impl ::std::fmt::Debug for _Self {
 impl ::std::cmp::PartialEq for _Self {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         true && self.type_opt() == rhs.type_opt()
     }
 }

--- a/tests-pb/src/keywords.rs
+++ b/tests-pb/src/keywords.rs
@@ -12,17 +12,17 @@ mod _pinternal {
 }
 #[derive(::std::default::Default)]
 pub struct Msg {
-    r#type: self::_pinternal::field_type::OptionalNumericalField::<
+    r#type: self::_pinternal::OptionalNumericalField::<
         i32,
         self::_pinternal::tags::Int32,
         0usize,
     >,
-    _bitfield: self::_pinternal::bitvec::BitArray<1usize>,
+    _bitfield: self::_pinternal::BitArray<1usize>,
 }
 impl Msg {
     pub fn r#type(&self) -> i32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             0usize,
@@ -33,16 +33,16 @@ impl Msg {
         )
     }
     pub fn type_opt(&self) -> ::std::option::Option::<i32> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.r#type, &self._bitfield)
     }
     pub fn type_mut(&mut self) -> &mut i32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             0usize,
@@ -53,8 +53,8 @@ impl Msg {
         )
     }
     pub fn has_type(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             0usize,
@@ -62,8 +62,8 @@ impl Msg {
             .is_some()
     }
     pub fn clear_type(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             0usize,
@@ -84,16 +84,16 @@ impl self::_puroro::Message for Msg {
     ) -> self::_puroro::Result<()> {
         use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 1i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         i32,
                         self::_pinternal::tags::Int32,
                         0usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.r#type,
                         &mut self._bitfield,
                         field_data,
@@ -110,12 +110,12 @@ impl self::_puroro::Message for Msg {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::OneofUnion as _;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             0usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.r#type,
             &self._bitfield,
             1i32,
@@ -127,7 +127,7 @@ impl self::_puroro::Message for Msg {
 impl ::std::clone::Clone for Msg {
     fn clone(&self) -> Self {
         Self {
-            r#type: <self::_pinternal::field_type::OptionalNumericalField::<
+            r#type: <self::_pinternal::OptionalNumericalField::<
                 i32,
                 self::_pinternal::tags::Int32,
                 0usize,
@@ -139,7 +139,7 @@ impl ::std::clone::Clone for Msg {
 impl ::std::ops::Drop for Msg {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for Msg {
@@ -155,23 +155,23 @@ impl ::std::fmt::Debug for Msg {
 impl ::std::cmp::PartialEq for Msg {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         true && self.type_opt() == rhs.type_opt()
     }
 }
 #[derive(::std::default::Default)]
 pub struct _Self {
-    r#type: self::_pinternal::field_type::OptionalNumericalField::<
+    r#type: self::_pinternal::OptionalNumericalField::<
         i32,
         self::_pinternal::tags::Int32,
         0usize,
     >,
-    _bitfield: self::_pinternal::bitvec::BitArray<1usize>,
+    _bitfield: self::_pinternal::BitArray<1usize>,
 }
 impl _Self {
     pub fn r#type(&self) -> i32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             0usize,
@@ -182,16 +182,16 @@ impl _Self {
         )
     }
     pub fn type_opt(&self) -> ::std::option::Option::<i32> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             0usize,
         > as NonRepeatedFieldType>::get_field_opt(&self.r#type, &self._bitfield)
     }
     pub fn type_mut(&mut self) -> &mut i32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             0usize,
@@ -202,8 +202,8 @@ impl _Self {
         )
     }
     pub fn has_type(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             0usize,
@@ -211,8 +211,8 @@ impl _Self {
             .is_some()
     }
     pub fn clear_type(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             0usize,
@@ -233,16 +233,16 @@ impl self::_puroro::Message for _Self {
     ) -> self::_puroro::Result<()> {
         use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 1i32 => {
-                    <self::_pinternal::field_type::OptionalNumericalField::<
+                    <self::_pinternal::OptionalNumericalField::<
                         i32,
                         self::_pinternal::tags::Int32,
                         0usize,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.r#type,
                         &mut self._bitfield,
                         field_data,
@@ -259,12 +259,12 @@ impl self::_puroro::Message for _Self {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
-        <self::_pinternal::field_type::OptionalNumericalField::<
+        use self::_pinternal::OneofUnion as _;
+        <self::_pinternal::OptionalNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
             0usize,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.r#type,
             &self._bitfield,
             1i32,
@@ -276,7 +276,7 @@ impl self::_puroro::Message for _Self {
 impl ::std::clone::Clone for _Self {
     fn clone(&self) -> Self {
         Self {
-            r#type: <self::_pinternal::field_type::OptionalNumericalField::<
+            r#type: <self::_pinternal::OptionalNumericalField::<
                 i32,
                 self::_pinternal::tags::Int32,
                 0usize,
@@ -288,7 +288,7 @@ impl ::std::clone::Clone for _Self {
 impl ::std::ops::Drop for _Self {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for _Self {
@@ -304,7 +304,7 @@ impl ::std::fmt::Debug for _Self {
 impl ::std::cmp::PartialEq for _Self {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         true && self.type_opt() == rhs.type_opt()
     }
 }

--- a/tests-pb/src/lib.rs
+++ b/tests-pb/src/lib.rs
@@ -3,13 +3,17 @@ pub use ::puroro;
 /// re-export the primitive types in puroro namespace.
 /// by using the "*", it can be hidden by the same typename explicitly defined in this file.
 pub use ::puroro::*;
-mod _puroro_root {
+mod _root {
     #[allow(unused)]
     pub(crate) use super::*;
 }
 mod _puroro {
     #[allow(unused)]
     pub(crate) use ::puroro::*;
+}
+mod _pinternal {
+    #[allow(unused)]
+    pub(crate) use ::puroro::internal::*;
 }
 pub mod full_coverage2;
 pub mod full_coverage3;

--- a/tests-pb/src/nested.rs
+++ b/tests-pb/src/nested.rs
@@ -1,26 +1,30 @@
-mod _puroro_root {
+mod _root {
     #[allow(unused)]
-    pub(crate) use super::super::_puroro_root::*;
+    pub(crate) use super::super::_root::*;
 }
 mod _puroro {
     #[allow(unused)]
     pub(crate) use ::puroro::*;
 }
+mod _pinternal {
+    #[allow(unused)]
+    pub(crate) use ::puroro::internal::*;
+}
 pub mod msg;
 #[derive(::std::default::Default)]
 pub struct Msg {
-    item_outer: self::_puroro::internal::field_type::SingularNumericalField::<
+    item_outer: self::_pinternal::field_type::SingularNumericalField::<
         i32,
-        self::_puroro::internal::tags::Int32,
+        self::_pinternal::tags::Int32,
     >,
-    _bitfield: self::_puroro::internal::bitvec::BitArray<0usize>,
+    _bitfield: self::_pinternal::bitvec::BitArray<0usize>,
 }
 impl Msg {
     pub fn item_outer(&self) -> i32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.item_outer,
             &self._bitfield,
@@ -28,17 +32,17 @@ impl Msg {
         )
     }
     pub fn item_outer_opt(&self) -> ::std::option::Option::<i32> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
         > as NonRepeatedFieldType>::get_field_opt(&self.item_outer, &self._bitfield)
     }
     pub fn item_outer_mut(&mut self) -> &mut i32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.item_outer,
             &mut self._bitfield,
@@ -46,18 +50,18 @@ impl Msg {
         )
     }
     pub fn has_item_outer(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
         > as NonRepeatedFieldType>::get_field_opt(&self.item_outer, &self._bitfield)
             .is_some()
     }
     pub fn clear_item_outer(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
         > as NonRepeatedFieldType>::clear(&mut self.item_outer, &mut self._bitfield)
     }
 }
@@ -73,17 +77,17 @@ impl self::_puroro::Message for Msg {
         &mut self,
         mut iter: I,
     ) -> self::_puroro::Result<()> {
-        use self::_puroro::internal::ser::FieldData;
+        use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 1i32 => {
-                    <self::_puroro::internal::field_type::SingularNumericalField::<
+                    <self::_pinternal::field_type::SingularNumericalField::<
                         i32,
-                        self::_puroro::internal::tags::Int32,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                        self::_pinternal::tags::Int32,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.item_outer,
                         &mut self._bitfield,
                         field_data,
@@ -100,11 +104,11 @@ impl self::_puroro::Message for Msg {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::oneof_type::OneofUnion as _;
+        <self::_pinternal::field_type::SingularNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+            self::_pinternal::tags::Int32,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.item_outer,
             &self._bitfield,
             1i32,
@@ -116,9 +120,9 @@ impl self::_puroro::Message for Msg {
 impl ::std::clone::Clone for Msg {
     fn clone(&self) -> Self {
         Self {
-            item_outer: <self::_puroro::internal::field_type::SingularNumericalField::<
+            item_outer: <self::_pinternal::field_type::SingularNumericalField::<
                 i32,
-                self::_puroro::internal::tags::Int32,
+                self::_pinternal::tags::Int32,
             > as ::std::clone::Clone>::clone(&self.item_outer),
             _bitfield: ::std::clone::Clone::clone(&self._bitfield),
         }
@@ -127,7 +131,7 @@ impl ::std::clone::Clone for Msg {
 impl ::std::ops::Drop for Msg {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for Msg {
@@ -143,7 +147,7 @@ impl ::std::fmt::Debug for Msg {
 impl ::std::cmp::PartialEq for Msg {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         true && self.item_outer_opt() == rhs.item_outer_opt()
     }
 }

--- a/tests-pb/src/nested.rs
+++ b/tests-pb/src/nested.rs
@@ -13,16 +13,16 @@ mod _pinternal {
 pub mod msg;
 #[derive(::std::default::Default)]
 pub struct Msg {
-    item_outer: self::_pinternal::field_type::SingularNumericalField::<
+    item_outer: self::_pinternal::SingularNumericalField::<
         i32,
         self::_pinternal::tags::Int32,
     >,
-    _bitfield: self::_pinternal::bitvec::BitArray<0usize>,
+    _bitfield: self::_pinternal::BitArray<0usize>,
 }
 impl Msg {
     pub fn item_outer(&self) -> i32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
         > as NonRepeatedFieldType>::get_field_or_else(
@@ -32,15 +32,15 @@ impl Msg {
         )
     }
     pub fn item_outer_opt(&self) -> ::std::option::Option::<i32> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
         > as NonRepeatedFieldType>::get_field_opt(&self.item_outer, &self._bitfield)
     }
     pub fn item_outer_mut(&mut self) -> &mut i32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
         > as NonRepeatedFieldType>::get_field_mut(
@@ -50,16 +50,16 @@ impl Msg {
         )
     }
     pub fn has_item_outer(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
         > as NonRepeatedFieldType>::get_field_opt(&self.item_outer, &self._bitfield)
             .is_some()
     }
     pub fn clear_item_outer(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
         > as NonRepeatedFieldType>::clear(&mut self.item_outer, &mut self._bitfield)
@@ -79,15 +79,15 @@ impl self::_puroro::Message for Msg {
     ) -> self::_puroro::Result<()> {
         use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 1i32 => {
-                    <self::_pinternal::field_type::SingularNumericalField::<
+                    <self::_pinternal::SingularNumericalField::<
                         i32,
                         self::_pinternal::tags::Int32,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.item_outer,
                         &mut self._bitfield,
                         field_data,
@@ -104,11 +104,11 @@ impl self::_puroro::Message for Msg {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::OneofUnion as _;
+        <self::_pinternal::SingularNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.item_outer,
             &self._bitfield,
             1i32,
@@ -120,7 +120,7 @@ impl self::_puroro::Message for Msg {
 impl ::std::clone::Clone for Msg {
     fn clone(&self) -> Self {
         Self {
-            item_outer: <self::_pinternal::field_type::SingularNumericalField::<
+            item_outer: <self::_pinternal::SingularNumericalField::<
                 i32,
                 self::_pinternal::tags::Int32,
             > as ::std::clone::Clone>::clone(&self.item_outer),
@@ -131,7 +131,7 @@ impl ::std::clone::Clone for Msg {
 impl ::std::ops::Drop for Msg {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for Msg {
@@ -147,7 +147,7 @@ impl ::std::fmt::Debug for Msg {
 impl ::std::cmp::PartialEq for Msg {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         true && self.item_outer_opt() == rhs.item_outer_opt()
     }
 }

--- a/tests-pb/src/nested/msg.rs
+++ b/tests-pb/src/nested/msg.rs
@@ -12,16 +12,16 @@ mod _pinternal {
 }
 #[derive(::std::default::Default)]
 pub struct Submsg {
-    item_inner: self::_pinternal::field_type::SingularNumericalField::<
+    item_inner: self::_pinternal::SingularNumericalField::<
         i32,
         self::_pinternal::tags::Int32,
     >,
-    _bitfield: self::_pinternal::bitvec::BitArray<0usize>,
+    _bitfield: self::_pinternal::BitArray<0usize>,
 }
 impl Submsg {
     pub fn item_inner(&self) -> i32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
         > as NonRepeatedFieldType>::get_field_or_else(
@@ -31,15 +31,15 @@ impl Submsg {
         )
     }
     pub fn item_inner_opt(&self) -> ::std::option::Option::<i32> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
         > as NonRepeatedFieldType>::get_field_opt(&self.item_inner, &self._bitfield)
     }
     pub fn item_inner_mut(&mut self) -> &mut i32 {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
         > as NonRepeatedFieldType>::get_field_mut(
@@ -49,16 +49,16 @@ impl Submsg {
         )
     }
     pub fn has_item_inner(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
         > as NonRepeatedFieldType>::get_field_opt(&self.item_inner, &self._bitfield)
             .is_some()
     }
     pub fn clear_item_inner(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
         > as NonRepeatedFieldType>::clear(&mut self.item_inner, &mut self._bitfield)
@@ -78,15 +78,15 @@ impl self::_puroro::Message for Submsg {
     ) -> self::_puroro::Result<()> {
         use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 1i32 => {
-                    <self::_pinternal::field_type::SingularNumericalField::<
+                    <self::_pinternal::SingularNumericalField::<
                         i32,
                         self::_pinternal::tags::Int32,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.item_inner,
                         &mut self._bitfield,
                         field_data,
@@ -103,11 +103,11 @@ impl self::_puroro::Message for Submsg {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
-        <self::_pinternal::field_type::SingularNumericalField::<
+        use self::_pinternal::OneofUnion as _;
+        <self::_pinternal::SingularNumericalField::<
             i32,
             self::_pinternal::tags::Int32,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.item_inner,
             &self._bitfield,
             1i32,
@@ -119,7 +119,7 @@ impl self::_puroro::Message for Submsg {
 impl ::std::clone::Clone for Submsg {
     fn clone(&self) -> Self {
         Self {
-            item_inner: <self::_pinternal::field_type::SingularNumericalField::<
+            item_inner: <self::_pinternal::SingularNumericalField::<
                 i32,
                 self::_pinternal::tags::Int32,
             > as ::std::clone::Clone>::clone(&self.item_inner),
@@ -130,7 +130,7 @@ impl ::std::clone::Clone for Submsg {
 impl ::std::ops::Drop for Submsg {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for Submsg {
@@ -146,7 +146,7 @@ impl ::std::fmt::Debug for Submsg {
 impl ::std::cmp::PartialEq for Submsg {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         true && self.item_inner_opt() == rhs.item_inner_opt()
     }
 }

--- a/tests-pb/src/nested/msg.rs
+++ b/tests-pb/src/nested/msg.rs
@@ -1,25 +1,29 @@
-mod _puroro_root {
+mod _root {
     #[allow(unused)]
-    pub(crate) use super::super::_puroro_root::*;
+    pub(crate) use super::super::_root::*;
 }
 mod _puroro {
     #[allow(unused)]
     pub(crate) use ::puroro::*;
 }
+mod _pinternal {
+    #[allow(unused)]
+    pub(crate) use ::puroro::internal::*;
+}
 #[derive(::std::default::Default)]
 pub struct Submsg {
-    item_inner: self::_puroro::internal::field_type::SingularNumericalField::<
+    item_inner: self::_pinternal::field_type::SingularNumericalField::<
         i32,
-        self::_puroro::internal::tags::Int32,
+        self::_pinternal::tags::Int32,
     >,
-    _bitfield: self::_puroro::internal::bitvec::BitArray<0usize>,
+    _bitfield: self::_pinternal::bitvec::BitArray<0usize>,
 }
 impl Submsg {
     pub fn item_inner(&self) -> i32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.item_inner,
             &self._bitfield,
@@ -27,17 +31,17 @@ impl Submsg {
         )
     }
     pub fn item_inner_opt(&self) -> ::std::option::Option::<i32> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
         > as NonRepeatedFieldType>::get_field_opt(&self.item_inner, &self._bitfield)
     }
     pub fn item_inner_mut(&mut self) -> &mut i32 {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.item_inner,
             &mut self._bitfield,
@@ -45,18 +49,18 @@ impl Submsg {
         )
     }
     pub fn has_item_inner(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
         > as NonRepeatedFieldType>::get_field_opt(&self.item_inner, &self._bitfield)
             .is_some()
     }
     pub fn clear_item_inner(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
+            self::_pinternal::tags::Int32,
         > as NonRepeatedFieldType>::clear(&mut self.item_inner, &mut self._bitfield)
     }
 }
@@ -72,17 +76,17 @@ impl self::_puroro::Message for Submsg {
         &mut self,
         mut iter: I,
     ) -> self::_puroro::Result<()> {
-        use self::_puroro::internal::ser::FieldData;
+        use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 1i32 => {
-                    <self::_puroro::internal::field_type::SingularNumericalField::<
+                    <self::_pinternal::field_type::SingularNumericalField::<
                         i32,
-                        self::_puroro::internal::tags::Int32,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                        self::_pinternal::tags::Int32,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.item_inner,
                         &mut self._bitfield,
                         field_data,
@@ -99,11 +103,11 @@ impl self::_puroro::Message for Submsg {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
-        <self::_puroro::internal::field_type::SingularNumericalField::<
+        use self::_pinternal::oneof_type::OneofUnion as _;
+        <self::_pinternal::field_type::SingularNumericalField::<
             i32,
-            self::_puroro::internal::tags::Int32,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+            self::_pinternal::tags::Int32,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.item_inner,
             &self._bitfield,
             1i32,
@@ -115,9 +119,9 @@ impl self::_puroro::Message for Submsg {
 impl ::std::clone::Clone for Submsg {
     fn clone(&self) -> Self {
         Self {
-            item_inner: <self::_puroro::internal::field_type::SingularNumericalField::<
+            item_inner: <self::_pinternal::field_type::SingularNumericalField::<
                 i32,
-                self::_puroro::internal::tags::Int32,
+                self::_pinternal::tags::Int32,
             > as ::std::clone::Clone>::clone(&self.item_inner),
             _bitfield: ::std::clone::Clone::clone(&self._bitfield),
         }
@@ -126,7 +130,7 @@ impl ::std::clone::Clone for Submsg {
 impl ::std::ops::Drop for Submsg {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for Submsg {
@@ -142,7 +146,7 @@ impl ::std::fmt::Debug for Submsg {
 impl ::std::cmp::PartialEq for Submsg {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         true && self.item_inner_opt() == rhs.item_inner_opt()
     }
 }

--- a/tests-pb/src/self_recursive.rs
+++ b/tests-pb/src/self_recursive.rs
@@ -1,25 +1,29 @@
-mod _puroro_root {
+mod _root {
     #[allow(unused)]
-    pub(crate) use super::super::_puroro_root::*;
+    pub(crate) use super::super::_root::*;
 }
 mod _puroro {
     #[allow(unused)]
     pub(crate) use ::puroro::*;
 }
+mod _pinternal {
+    #[allow(unused)]
+    pub(crate) use ::puroro::internal::*;
+}
 #[derive(::std::default::Default)]
 pub struct Msg {
-    recursive_unlabeled: self::_puroro::internal::field_type::SingularHeapMessageField::<
-        self::_puroro_root::self_recursive::Msg,
+    recursive_unlabeled: self::_pinternal::field_type::SingularHeapMessageField::<
+        self::_root::self_recursive::Msg,
     >,
-    _bitfield: self::_puroro::internal::bitvec::BitArray<0usize>,
+    _bitfield: self::_pinternal::bitvec::BitArray<0usize>,
 }
 impl Msg {
     pub fn recursive_unlabeled(
         &self,
-    ) -> ::std::option::Option::<&self::_puroro_root::self_recursive::Msg> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::self_recursive::Msg,
+    ) -> ::std::option::Option::<&self::_root::self_recursive::Msg> {
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::self_recursive::Msg,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.recursive_unlabeled,
             &self._bitfield,
@@ -28,21 +32,19 @@ impl Msg {
     }
     pub fn recursive_unlabeled_opt(
         &self,
-    ) -> ::std::option::Option::<&self::_puroro_root::self_recursive::Msg> {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::self_recursive::Msg,
+    ) -> ::std::option::Option::<&self::_root::self_recursive::Msg> {
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::self_recursive::Msg,
         > as NonRepeatedFieldType>::get_field_opt(
             &self.recursive_unlabeled,
             &self._bitfield,
         )
     }
-    pub fn recursive_unlabeled_mut(
-        &mut self,
-    ) -> &mut self::_puroro_root::self_recursive::Msg {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::self_recursive::Msg,
+    pub fn recursive_unlabeled_mut(&mut self) -> &mut self::_root::self_recursive::Msg {
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::self_recursive::Msg,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.recursive_unlabeled,
             &mut self._bitfield,
@@ -50,9 +52,9 @@ impl Msg {
         )
     }
     pub fn has_recursive_unlabeled(&self) -> bool {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::self_recursive::Msg,
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::self_recursive::Msg,
         > as NonRepeatedFieldType>::get_field_opt(
                 &self.recursive_unlabeled,
                 &self._bitfield,
@@ -60,9 +62,9 @@ impl Msg {
             .is_some()
     }
     pub fn clear_recursive_unlabeled(&mut self) {
-        use self::_puroro::internal::field_type::NonRepeatedFieldType;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::self_recursive::Msg,
+        use self::_pinternal::field_type::NonRepeatedFieldType;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::self_recursive::Msg,
         > as NonRepeatedFieldType>::clear(
             &mut self.recursive_unlabeled,
             &mut self._bitfield,
@@ -81,16 +83,16 @@ impl self::_puroro::Message for Msg {
         &mut self,
         mut iter: I,
     ) -> self::_puroro::Result<()> {
-        use self::_puroro::internal::ser::FieldData;
+        use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 1i32 => {
-                    <self::_puroro::internal::field_type::SingularHeapMessageField::<
-                        self::_puroro_root::self_recursive::Msg,
-                    > as self::_puroro::internal::field_type::FieldType>::deser_from_iter(
+                    <self::_pinternal::field_type::SingularHeapMessageField::<
+                        self::_root::self_recursive::Msg,
+                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
                         &mut self.recursive_unlabeled,
                         &mut self._bitfield,
                         field_data,
@@ -107,10 +109,10 @@ impl self::_puroro::Message for Msg {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
-        <self::_puroro::internal::field_type::SingularHeapMessageField::<
-            self::_puroro_root::self_recursive::Msg,
-        > as self::_puroro::internal::field_type::FieldType>::ser_to_write(
+        use self::_pinternal::oneof_type::OneofUnion as _;
+        <self::_pinternal::field_type::SingularHeapMessageField::<
+            self::_root::self_recursive::Msg,
+        > as self::_pinternal::field_type::FieldType>::ser_to_write(
             &self.recursive_unlabeled,
             &self._bitfield,
             1i32,
@@ -122,8 +124,8 @@ impl self::_puroro::Message for Msg {
 impl ::std::clone::Clone for Msg {
     fn clone(&self) -> Self {
         Self {
-            recursive_unlabeled: <self::_puroro::internal::field_type::SingularHeapMessageField::<
-                self::_puroro_root::self_recursive::Msg,
+            recursive_unlabeled: <self::_pinternal::field_type::SingularHeapMessageField::<
+                self::_root::self_recursive::Msg,
             > as ::std::clone::Clone>::clone(&self.recursive_unlabeled),
             _bitfield: ::std::clone::Clone::clone(&self._bitfield),
         }
@@ -132,7 +134,7 @@ impl ::std::clone::Clone for Msg {
 impl ::std::ops::Drop for Msg {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for Msg {
@@ -148,7 +150,7 @@ impl ::std::fmt::Debug for Msg {
 impl ::std::cmp::PartialEq for Msg {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_puroro::internal::oneof_type::OneofUnion as _;
+        use self::_pinternal::oneof_type::OneofUnion as _;
         true && self.recursive_unlabeled_opt() == rhs.recursive_unlabeled_opt()
     }
 }

--- a/tests-pb/src/self_recursive.rs
+++ b/tests-pb/src/self_recursive.rs
@@ -12,17 +12,17 @@ mod _pinternal {
 }
 #[derive(::std::default::Default)]
 pub struct Msg {
-    recursive_unlabeled: self::_pinternal::field_type::SingularHeapMessageField::<
+    recursive_unlabeled: self::_pinternal::SingularHeapMessageField::<
         self::_root::self_recursive::Msg,
     >,
-    _bitfield: self::_pinternal::bitvec::BitArray<0usize>,
+    _bitfield: self::_pinternal::BitArray<0usize>,
 }
 impl Msg {
     pub fn recursive_unlabeled(
         &self,
     ) -> ::std::option::Option::<&self::_root::self_recursive::Msg> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::self_recursive::Msg,
         > as NonRepeatedFieldType>::get_field_or_else(
             &self.recursive_unlabeled,
@@ -33,8 +33,8 @@ impl Msg {
     pub fn recursive_unlabeled_opt(
         &self,
     ) -> ::std::option::Option::<&self::_root::self_recursive::Msg> {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::self_recursive::Msg,
         > as NonRepeatedFieldType>::get_field_opt(
             &self.recursive_unlabeled,
@@ -42,8 +42,8 @@ impl Msg {
         )
     }
     pub fn recursive_unlabeled_mut(&mut self) -> &mut self::_root::self_recursive::Msg {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::self_recursive::Msg,
         > as NonRepeatedFieldType>::get_field_mut(
             &mut self.recursive_unlabeled,
@@ -52,8 +52,8 @@ impl Msg {
         )
     }
     pub fn has_recursive_unlabeled(&self) -> bool {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::self_recursive::Msg,
         > as NonRepeatedFieldType>::get_field_opt(
                 &self.recursive_unlabeled,
@@ -62,8 +62,8 @@ impl Msg {
             .is_some()
     }
     pub fn clear_recursive_unlabeled(&mut self) {
-        use self::_pinternal::field_type::NonRepeatedFieldType;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::NonRepeatedFieldType;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::self_recursive::Msg,
         > as NonRepeatedFieldType>::clear(
             &mut self.recursive_unlabeled,
@@ -85,14 +85,14 @@ impl self::_puroro::Message for Msg {
     ) -> self::_puroro::Result<()> {
         use self::_pinternal::ser::FieldData;
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         while let Some((number, field_data))
             = FieldData::from_bytes_iter(iter.by_ref())? {
             match number {
                 1i32 => {
-                    <self::_pinternal::field_type::SingularHeapMessageField::<
+                    <self::_pinternal::SingularHeapMessageField::<
                         self::_root::self_recursive::Msg,
-                    > as self::_pinternal::field_type::FieldType>::deser_from_iter(
+                    > as self::_pinternal::FieldType>::deser_from_iter(
                         &mut self.recursive_unlabeled,
                         &mut self._bitfield,
                         field_data,
@@ -109,10 +109,10 @@ impl self::_puroro::Message for Msg {
         out: &mut W,
     ) -> self::_puroro::Result<()> {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
-        <self::_pinternal::field_type::SingularHeapMessageField::<
+        use self::_pinternal::OneofUnion as _;
+        <self::_pinternal::SingularHeapMessageField::<
             self::_root::self_recursive::Msg,
-        > as self::_pinternal::field_type::FieldType>::ser_to_write(
+        > as self::_pinternal::FieldType>::ser_to_write(
             &self.recursive_unlabeled,
             &self._bitfield,
             1i32,
@@ -124,7 +124,7 @@ impl self::_puroro::Message for Msg {
 impl ::std::clone::Clone for Msg {
     fn clone(&self) -> Self {
         Self {
-            recursive_unlabeled: <self::_pinternal::field_type::SingularHeapMessageField::<
+            recursive_unlabeled: <self::_pinternal::SingularHeapMessageField::<
                 self::_root::self_recursive::Msg,
             > as ::std::clone::Clone>::clone(&self.recursive_unlabeled),
             _bitfield: ::std::clone::Clone::clone(&self._bitfield),
@@ -134,7 +134,7 @@ impl ::std::clone::Clone for Msg {
 impl ::std::ops::Drop for Msg {
     fn drop(&mut self) {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
     }
 }
 impl ::std::fmt::Debug for Msg {
@@ -150,7 +150,7 @@ impl ::std::fmt::Debug for Msg {
 impl ::std::cmp::PartialEq for Msg {
     fn eq(&self, rhs: &Self) -> bool {
         #[allow(unused)]
-        use self::_pinternal::oneof_type::OneofUnion as _;
+        use self::_pinternal::OneofUnion as _;
         true && self.recursive_unlabeled_opt() == rhs.recursive_unlabeled_opt()
     }
 }


### PR DESCRIPTION
renamed _puroro_root to just _root,
and added pinternal mod under each mod. pinternal mod redirects to puroro::internal directory.
Also moved some puroro::internal submodules items into the internal root directory.