### PR TITLE
Add AGENTS.md with Cursor Cloud development environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,71 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Overview
+
+This is the `scratch-ai` development branch of **puroro** — a performance-oriented Protocol Buffers runtime for Rust, targeting edition 2024 with nightly Rust.
+
+### Rust toolchain
+
+- `rust-toolchain.toml` pins the workspace to `channel = "nightly"` (rolling latest). Cargo respects this automatically; no manual `rustup default` is needed.
+- Ensure the nightly toolchain is installed: `rustup toolchain install nightly`
+- Components needed: `rustfmt`, `clippy`. They are installed alongside nightly when the update script runs.
+
+### Git submodules — REQUIRED before building
+
+Two workspace members are private git submodules and **must be initialised** before anything compiles:
+
+| Submodule       | GitHub URL                                   |
+|-----------------|----------------------------------------------|
+| `protobuf-core` | `git@github.com:wada314/protobuf-core.git`   |
+| `unmanaged`     | `git@github.com:wada314/unmanaged.git`       |
+
+Run after SSH access is configured:
+```sh
+git submodule update --init
+```
+
+Without this step, every `cargo` command fails with a missing `Cargo.toml` error.
+
+### Build
+
+```sh
+cargo build           # workspace (excludes update-* crates by default)
+cargo build -p puroro # specific crate
+```
+
+`.cargo/config.toml` enables unstable `bindeps` (required for `puroro-codegen-tests` build script which uses the `protoc-gen-puroro` binary as an artifact dependency).
+
+### Test
+
+```sh
+cargo test                             # all default workspace members
+cargo test -p puroro-sample-generated  # sample hand-written generated code tests
+cargo test -p puroro-codegen-tests     # end-to-end codegen + behavioural tests (needs protoc in PATH or via protoc-bin-vendored)
+```
+
+### Lint (run before handing off changes)
+
+Per `.cursor/rules/rust-fmt-clippy.mdc`:
+
+```sh
+cargo fmt --all
+cargo clippy --all-targets
+```
+
+Fix any new warnings introduced; do not silence lints unless the project already does so.
+
+### Code style
+
+See `.cursor/rules/rust-name-resolution.mdc` for import path conventions (`::` prefix for external crates, `crate::` / `self::` for internal).
+
+### SSH key setup
+
+The environment needs an SSH private key with read access to the `wada314` private repos. Set it up before initialising submodules:
+
+```sh
+eval "$(ssh-agent -s)"
+ssh-add ~/.ssh/id_rsa   # or wherever the key is stored
+git submodule update --init
+```


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` documenting Cloud Agent development environment setup for the `scratch-ai` branch.

### Contents

- Rust nightly toolchain requirement and setup
- Git submodule initialization steps (`protobuf-core`, `unmanaged`)
- Build, test, and lint commands
- SSH key setup note for private submodule access
- Code style conventions reference

### Blocker

The two workspace-member submodules (`protobuf-core` and `unmanaged`) point to private GitHub repos (`git@github.com:wada314/protobuf-core.git`, `git@github.com:wada314/unmanaged.git`) that are not yet accessible in the Cloud Agent environment. An SSH private key with read access to those repos is required before `cargo build` can succeed.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5c48a585-1ab7-43af-82c0-a39781170366?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5c48a585-1ab7-43af-82c0-a39781170366&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

